### PR TITLE
Add grouper interface and locality aware grouper

### DIFF
--- a/conf/kafka.conf
+++ b/conf/kafka.conf
@@ -33,6 +33,8 @@ kafka {
     checkpoint.interval.ms = 1000
   }
 
+  grouper.factory.class = "org.apache.gearpump.streaming.transaction.lib.kafka.grouper.KafkaDefaultGrouperFactory"
+
   gearpump {
     streaming {
       executor {

--- a/streaming/src/main/scala/org/apache/gearpump/streaming/transaction/lib/kafka/KafkaConfig.scala
+++ b/streaming/src/main/scala/org/apache/gearpump/streaming/transaction/lib/kafka/KafkaConfig.scala
@@ -28,6 +28,7 @@ import kafka.utils.ZKStringSerializer
 import org.I0Itec.zkclient.ZkClient
 import org.I0Itec.zkclient.serialize.ZkSerializer
 import org.apache.gearpump.streaming.transaction.checkpoint.TimeExtractor
+import org.apache.gearpump.streaming.transaction.lib.kafka.grouper.KafkaGrouperFactory
 import org.apache.gearpump.streaming.transaction.storage.api.KeyValueStoreFactory
 import org.slf4j.{Logger, LoggerFactory}
 
@@ -67,6 +68,9 @@ object KafkaConfig {
   // storage config
   val KV_STORE_FACTORY = "kafka.storage.kv.store.factory"
   val STORAGE_CHECKPOINT_INTERVAL_MS = "kafka.storage.checkpoint.interval.ms"
+
+  // grouper config
+  val GROUPER_FACTORY_CLASS = "kafka.grouper.factory.class"
 
   def apply(): Map[String, _] = new KafkaConfig().toMap
 
@@ -211,6 +215,10 @@ object KafkaConfig {
 
     def getStorageCheckpointIntervalMS = {
       getInt(STORAGE_CHECKPOINT_INTERVAL_MS)
+    }
+
+    def getGrouperFactory = {
+      getInstance[KafkaGrouperFactory](GROUPER_FACTORY_CLASS)
     }
   }
 

--- a/streaming/src/main/scala/org/apache/gearpump/streaming/transaction/lib/kafka/KafkaUtil.scala
+++ b/streaming/src/main/scala/org/apache/gearpump/streaming/transaction/lib/kafka/KafkaUtil.scala
@@ -18,6 +18,9 @@
 
 package org.apache.gearpump.streaming.transaction.lib.kafka
 
+import java.net.InetAddress
+
+import akka.actor.{ExtendedActorSystem, ActorContext}
 import kafka.utils.ZkUtils
 import org.apache.gearpump.streaming.transaction.lib.kafka.KafkaConsumer.Broker
 import org.I0Itec.zkclient.ZkClient
@@ -48,5 +51,10 @@ object KafkaUtil {
     val broker = ZkUtils.getBrokerInfo(zkClient, leader)
       .getOrElse(throw new Exception(s"broker info not found for leader $leader"))
     Broker(broker.host, broker.port)
+  }
+
+  def getHost(context: ActorContext): String = {
+    val address = context.system.asInstanceOf[ExtendedActorSystem].provider.getDefaultAddress
+    InetAddress.getByName(address.host.get).getHostName
   }
 }

--- a/streaming/src/main/scala/org/apache/gearpump/streaming/transaction/lib/kafka/grouper/KafkaGrouper.scala
+++ b/streaming/src/main/scala/org/apache/gearpump/streaming/transaction/lib/kafka/grouper/KafkaGrouper.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.streaming.transaction.lib.kafka.grouper
+
+import akka.actor.ActorContext
+import kafka.common.TopicAndPartition
+import org.apache.gearpump.streaming.task.TaskId
+import org.apache.gearpump.util.Configs
+
+trait KafkaGrouperFactory {
+  def getKafkaGrouper(conf: Configs, context: ActorContext): KafkaGrouper
+}
+
+trait KafkaGrouper {
+  def group(topicAndPartitions: Array[TopicAndPartition]): Array[TopicAndPartition]
+}
+
+

--- a/streaming/src/main/scala/org/apache/gearpump/streaming/transaction/lib/kafka/grouper/KafkaLocalityAwareGrouper.scala
+++ b/streaming/src/main/scala/org/apache/gearpump/streaming/transaction/lib/kafka/grouper/KafkaLocalityAwareGrouper.scala
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.streaming.transaction.lib.kafka.grouper
+
+import akka.actor.ActorContext
+import kafka.common.TopicAndPartition
+import org.I0Itec.zkclient.ZkClient
+import org.apache.gearpump.streaming.transaction.lib.kafka.KafkaUtil
+import org.apache.gearpump.util.Configs
+import org.apache.gearpump.streaming.transaction.lib.kafka.KafkaConfig._
+
+class KafkaLocalityAwareGrouperFactory extends KafkaGrouperFactory {
+  override def getKafkaGrouper(conf: Configs, context: ActorContext): KafkaGrouper = {
+    val zkClient = conf.config.getZkClient()
+    val host = KafkaUtil.getHost(context)
+    new KafkaLocalityAwareGrouper(zkClient, host)
+  }
+}
+
+/**
+ *  get TopicAndPartitions whose Kafka brokers are collocated with task
+ *  TODO: we need to provide a TopicAndPartition for task
+ *        which is not collocated with any Kafka brokers
+ */
+class KafkaLocalityAwareGrouper(zkClient: ZkClient, host: String) extends KafkaGrouper {
+  def group(topicAndPartitions: Array[TopicAndPartition]): Array[TopicAndPartition] = {
+    topicAndPartitions.filter(tp =>
+      KafkaUtil.getBroker(zkClient, tp.topic, tp.partition).host.equals(host))
+  }
+}

--- a/streaming/src/test/scala/org/apache/gearpump/streaming/transaction/lib/kafka/grouper/KafkaDefaultGrouperSpec.scala
+++ b/streaming/src/test/scala/org/apache/gearpump/streaming/transaction/lib/kafka/grouper/KafkaDefaultGrouperSpec.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.streaming.transaction.lib.kafka.grouper
+
+import kafka.common.TopicAndPartition
+import org.scalacheck.Gen
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.{Matchers, PropSpec}
+
+class KafkaDefaultGrouperSpec extends PropSpec with PropertyChecks with Matchers {
+  property("KafkaDefaultGrouper should group TopicAndPartitions in a round-robin way") {
+    forAll(Gen.posNum[Int], Gen.posNum[Int], Gen.posNum[Int]) {
+      (topicNum: Int, partitionNum: Int, taskNum: Int) => {
+        val topicAndPartitions = for {
+          t <- 0.until(topicNum)
+          p <- 0.until(partitionNum)
+        } yield TopicAndPartition("topic" + t, p)
+        0.until(taskNum).foreach { taskIndex =>
+          val grouper = new KafkaDefaultGrouper(taskNum, taskIndex)
+          grouper.group(topicAndPartitions.toArray).forall(
+            tp => topicAndPartitions.indexOf(tp) % taskNum == taskIndex)
+        }
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
this pull request
1. adds grouper and grouper factory trait such that grouper is configurable via kafka.conf;
2. adds a locality aware implementation such that tasks could read from local kafka partitions.
