### PR TITLE
fix kafka key NPE and consumer close exception

### DIFF
--- a/streaming/src/main/scala/org/apache/gearpump/streaming/transaction/checkpoint/kafka/KafkaCheckpointManager.scala
+++ b/streaming/src/main/scala/org/apache/gearpump/streaming/transaction/checkpoint/kafka/KafkaCheckpointManager.scala
@@ -85,6 +85,9 @@ class KafkaCheckpointManager[K, V](checkpointId: Int,
       def fetch(records: List[(K, V)]): List[(K, V)] = {
         if (msgIter.hasNext) {
           val (_, key, payload) = msgIter.next
+          if (null == key) {
+            throw new RuntimeException("checkpoint key should not be null")
+          }
           val r: (K, V) = (checkpointSerDe.fromKeyBytes(key), checkpointSerDe.fromValueBytes(payload))
           fetch(records :+ r)
         } else {

--- a/streaming/src/main/scala/org/apache/gearpump/streaming/transaction/lib/kafka/MessageIterator.scala
+++ b/streaming/src/main/scala/org/apache/gearpump/streaming/transaction/lib/kafka/MessageIterator.scala
@@ -49,13 +49,18 @@ class MessageIterator(host: String,
   def next: (Long, Array[Byte], Array[Byte]) = {
     val mo = iter.next()
     val message = mo.message
-    val offset = mo.offset
-    val key = Utils.readBytes(message.key)
-    val payload = Utils.readBytes(message.payload)
 
     readMessages += 1
     nextOffset = mo.nextOffset
-    (offset, key, payload)
+
+    val offset = mo.offset
+    val payload = Utils.readBytes(message.payload)
+    if (message.key == null) {
+      (offset, null, payload)
+    } else {
+      val key = Utils.readBytes(message.key)
+      (offset, key, payload)
+    }
   }
 
 


### PR DESCRIPTION
this pull request fixes:
1. null pointer exception when reading a kafka message whose key is null;
2. consumer exception when fetch thread has been interrupted

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/intel-hadoop/gearpump/180)

<!-- Reviewable:end -->
