### PR TITLE
Add README to quick-start a KafkaWordCount example

### DIFF
--- a/conf/kafka.conf
+++ b/conf/kafka.conf
@@ -1,7 +1,7 @@
 kafka {
   consumer {
-    zookeeper.connect = "127.0.0.1:2181/kafka/kafka-cluster-0"
-    topics = ["topic1", "topic2", "topic3"]
+    zookeeper.connect = "127.0.0.1:2181"
+    topics = ["topic1"]
     client.id = "gearpump-app"
     socket.timeout.ms = 30000
     socket.receive.buffer.bytes = 65536
@@ -11,7 +11,7 @@ kafka {
   }
 
   producer {
-    topic = "topic"
+    topic = "topic2"
     metadata.broker.list = "127.0.0.1:9092"
     producer.type = "sync"
     serializer.class = "kafka.serializer.StringEncoder"

--- a/examples/kafka/README.md
+++ b/examples/kafka/README.md
@@ -99,7 +99,7 @@ Finally, let's run the KafkaWordCount example.
    ./target/pack/bin/gear app -jar ./examples/kafka/target/pack/lib/gearpump-examples-kafka-0.2-SNAPSHOT.jar org.apache.gearpump.streaming.examples.kafka.wordcount.KafkaWordCount -master 127.0.0.1:3000
    ```
 
-One more step is to verify that we've suceeded in producing data to Kafka.
+One more step is to verify that we've succeeded in producing data to Kafka.
 
 ```bash
    $KAFKA_PATH/bin/kafka-console-consumer.sh --zookeeper localhost:2181 --from-beginning --topic topic2


### PR DESCRIPTION
this pull request add README to quick-start a KafkaWordCount example

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/intel-hadoop/gearpump/187)

<!-- Reviewable:end -->
