### PR TITLE
fix worker resource update bug

### DIFF
--- a/core/src/main/scala/org/apache/gearpump/cluster/ClusterMessage.scala
+++ b/core/src/main/scala/org/apache/gearpump/cluster/ClusterMessage.scala
@@ -29,7 +29,7 @@ import scala.util.Try
 object WorkerToMaster {
   case object RegisterNewWorker
   case class RegisterWorker(workerId: Int)
-  case class ResourceUpdate(workerId: Int, resource: Resource)
+  case class ResourceUpdate(worker: ActorRef, workerId: Int, resource: Resource)
 }
 
 object MasterToWorker {

--- a/core/src/main/scala/org/apache/gearpump/cluster/scheduler/Scheduler.scala
+++ b/core/src/main/scala/org/apache/gearpump/cluster/scheduler/Scheduler.scala
@@ -38,11 +38,11 @@ abstract class Scheduler extends Actor{
         LOG.info(s"Worker $id added to the scheduler")
         resources.put(id, (sender, Resource.empty))
       }
-    case ResourceUpdate(workerId, resource) =>
+    case ResourceUpdate(worker, workerId, resource) =>
       LOG.info(s"Resource update id: $workerId, slots: ${resource.slots}....")
       if(resources.contains(workerId)) {
         val resourceReturned = resource.greaterThan(resources.get(workerId).get._2)
-        resources.update(workerId, (sender, resource))
+        resources.update(workerId, (worker, resource))
         if(resourceReturned){
           allocateResource()
         }

--- a/core/src/test/scala/org/apache/gearpump/cluster/WorkerSpec.scala
+++ b/core/src/test/scala/org/apache/gearpump/cluster/WorkerSpec.scala
@@ -65,7 +65,7 @@ class WorkerSpec(_system: ActorSystem) extends TestKit(_system) with ImplicitSen
       mockMaster.expectMsg(RegisterNewWorker)
 
       worker.tell(WorkerRegistered(workerId), mockMaster.ref)
-      mockMaster.expectMsg(ResourceUpdate(workerId, Resource(workerSlots)))
+      mockMaster.expectMsg(ResourceUpdate(worker, workerId, Resource(workerSlots)))
 
       worker.tell(UpdateResourceFailed("Test resource update failed", new Exception()), mockMaster.ref)
       mockMaster.expectTerminated(worker, 5 seconds)
@@ -80,7 +80,7 @@ class WorkerSpec(_system: ActorSystem) extends TestKit(_system) with ImplicitSen
       masterProxy.expectMsg(RegisterNewWorker)
 
       worker.tell(WorkerRegistered(workerId), mockMaster.ref)
-      mockMaster.expectMsg(ResourceUpdate(workerId, Resource(100)))
+      mockMaster.expectMsg(ResourceUpdate(worker, workerId, Resource(100)))
 
       val executorName = ActorUtil.actorNameForExecutor(appId, executorId)
       val reportBack = "dummy"   //This is an actor path which the ActorSystemBooter will report back to, not needed in this test.
@@ -91,11 +91,11 @@ class WorkerSpec(_system: ActorSystem) extends TestKit(_system) with ImplicitSen
       mockMaster.expectMsg(ExecutorLaunchRejected("There is no free resource on this machine", Resource(101)))
 
       worker.tell(LaunchExecutor(appId, executorId, Resource(5), executionContext), mockMaster.ref)
-      mockMaster.expectMsg(ResourceUpdate(workerId, Resource(95)))
+      mockMaster.expectMsg(ResourceUpdate(worker, workerId, Resource(95)))
 
       //Test terminationWatch
       worker ! ShutdownExecutor(appId, executorId, "Test shut down executor")
-      mockMaster.expectMsg(ResourceUpdate(workerId, Resource(100)))
+      mockMaster.expectMsg(ResourceUpdate(worker, workerId, Resource(100)))
 
       mockMaster.ref ! PoisonPill
       masterProxy.expectMsg(RegisterWorker(workerId))

--- a/core/src/test/scala/org/apache/gearpump/cluster/scheduler/PrioritySchedulerSpec.scala
+++ b/core/src/test/scala/org/apache/gearpump/cluster/scheduler/PrioritySchedulerSpec.scala
@@ -46,7 +46,7 @@ class PrioritySchedulerSpec(_system: ActorSystem) extends TestKit(_system) with 
   "The scheduler" should {
     "update resource only when the worker is registered" in {
       val scheduler = system.actorOf(Props(classOf[PriorityScheduler]))
-      scheduler ! ResourceUpdate(workerId1, Resource(100))
+      scheduler ! ResourceUpdate(mockWorker1.ref, workerId1, Resource(100))
       expectMsg(UpdateResourceFailed(s"ResourceUpdate failed! The worker $workerId1 has not been registered into master"))
     }
 
@@ -58,7 +58,7 @@ class PrioritySchedulerSpec(_system: ActorSystem) extends TestKit(_system) with 
       scheduler.tell(RequestResource(appId, request2), mockAppMaster.ref)
       scheduler.tell(ApplicationFinished(appId), mockAppMaster.ref)
       scheduler.tell(WorkerRegistered(workerId1), mockWorker1.ref)
-      scheduler.tell(ResourceUpdate(workerId1, Resource(100)), mockWorker1.ref)
+      scheduler.tell(ResourceUpdate(mockWorker1.ref, workerId1, Resource(100)), mockWorker1.ref)
       mockAppMaster.expectNoMsg(5 seconds)
     }
   }
@@ -75,7 +75,7 @@ class PrioritySchedulerSpec(_system: ActorSystem) extends TestKit(_system) with 
       scheduler.tell(RequestResource(appId, request2), mockAppMaster.ref)
       scheduler.tell(RequestResource(appId, request3), mockAppMaster.ref)
       scheduler.tell(WorkerRegistered(workerId1), mockWorker1.ref)
-      scheduler.tell(ResourceUpdate(workerId1, Resource(100)), mockWorker1.ref)
+      scheduler.tell(ResourceUpdate(mockWorker1.ref, workerId1, Resource(100)), mockWorker1.ref)
 
       mockAppMaster.expectMsg(5 seconds, ResourceAllocated(Array(ResourceAllocation(Resource(30), mockWorker1.ref, workerId1))))
       mockAppMaster.expectMsg(5 seconds, ResourceAllocated(Array(ResourceAllocation(Resource(20), mockWorker1.ref, workerId1))))
@@ -83,8 +83,8 @@ class PrioritySchedulerSpec(_system: ActorSystem) extends TestKit(_system) with 
       mockAppMaster.expectMsg(5 seconds, ResourceAllocated(Array(ResourceAllocation(Resource(10), mockWorker1.ref, workerId1))))
 
       scheduler.tell(WorkerRegistered(workerId2), mockWorker2.ref)
-      scheduler.tell(ResourceUpdate(workerId1, Resource.empty), mockWorker1.ref)
-      scheduler.tell(ResourceUpdate(workerId2, Resource(100)), mockWorker2.ref)
+      scheduler.tell(ResourceUpdate(mockWorker1.ref, workerId1, Resource.empty), mockWorker1.ref)
+      scheduler.tell(ResourceUpdate(mockWorker2.ref, workerId2, Resource(100)), mockWorker2.ref)
       mockAppMaster.expectMsg(5 seconds, ResourceAllocated(Array(ResourceAllocation(Resource(30), mockWorker2.ref, workerId2))))
     }
   }
@@ -97,7 +97,7 @@ class PrioritySchedulerSpec(_system: ActorSystem) extends TestKit(_system) with 
       scheduler.tell(RequestResource(appId, request1), mockAppMaster.ref)
       scheduler.tell(RequestResource(appId, request2), mockAppMaster.ref)
       scheduler.tell(WorkerRegistered(workerId1), mockWorker1.ref)
-      scheduler.tell(ResourceUpdate(workerId1, Resource(100)), mockWorker1.ref)
+      scheduler.tell(ResourceUpdate(mockWorker1.ref, workerId1, Resource(100)), mockWorker1.ref)
 
       mockAppMaster.expectMsg(5 seconds, ResourceAllocated(Array(ResourceAllocation(Resource(40), mockWorker1.ref, workerId1))))
       mockAppMaster.expectMsg(5 seconds, ResourceAllocated(Array(ResourceAllocation(Resource(20), mockWorker1.ref, workerId1))))
@@ -113,11 +113,11 @@ class PrioritySchedulerSpec(_system: ActorSystem) extends TestKit(_system) with 
       scheduler.tell(RequestResource(appId, request1), mockAppMaster.ref)
       scheduler.tell(RequestResource(appId, request2), mockAppMaster.ref)
       scheduler.tell(WorkerRegistered(workerId1), mockWorker1.ref)
-      scheduler.tell(ResourceUpdate(workerId1, Resource(100)), mockWorker1.ref)
+      scheduler.tell(ResourceUpdate(mockWorker1.ref, workerId1, Resource(100)), mockWorker1.ref)
       mockAppMaster.expectMsg(5 seconds, ResourceAllocated(Array(ResourceAllocation(Resource(20), mockWorker1.ref, workerId1))))
 
       scheduler.tell(WorkerRegistered(workerId2), mockWorker2.ref)
-      scheduler.tell(ResourceUpdate(workerId2, Resource(100)), mockWorker2.ref)
+      scheduler.tell(ResourceUpdate(mockWorker2.ref, workerId2, Resource(100)), mockWorker2.ref)
       mockAppMaster.expectMsg(5 seconds, ResourceAllocated(Array(ResourceAllocation(Resource(40), mockWorker2.ref, workerId2))))
 
       val request3 = ResourceRequest(Resource(30), 0, Priority.NORMAL, Relaxation.ANY)
@@ -125,8 +125,8 @@ class PrioritySchedulerSpec(_system: ActorSystem) extends TestKit(_system) with 
       mockAppMaster.expectMsg(5 seconds, ResourceAllocated(Array(ResourceAllocation(Resource(15), mockWorker1.ref, workerId1), ResourceAllocation(Resource(15), mockWorker2.ref, workerId2))))
 
       //we have to manually update the resource on each worker
-      scheduler.tell(ResourceUpdate(workerId1, Resource(65)), mockWorker1.ref)
-      scheduler.tell(ResourceUpdate(workerId2, Resource(45)), mockWorker2.ref)
+      scheduler.tell(ResourceUpdate(mockWorker1.ref, workerId1, Resource(65)), mockWorker1.ref)
+      scheduler.tell(ResourceUpdate(mockWorker2.ref, workerId2, Resource(45)), mockWorker2.ref)
       val request4 = ResourceRequest(Resource(60), 0, Priority.NORMAL, Relaxation.ONEWORKER)
       scheduler.tell(RequestResource(appId, request4), mockAppMaster.ref)
       mockAppMaster.expectMsg(5 seconds, ResourceAllocated(Array(ResourceAllocation(Resource(60), mockWorker1.ref, workerId1))))


### PR DESCRIPTION
I use ask pattern to update worker resource and when scheduler receive the message, it will save the sender along with the resource, which is wrong because the sender actually is a temporarily actor.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/intel-hadoop/gearpump/249)

<!-- Reviewable:end -->
