### PR TITLE
fix #1412: add 'no-cache' header in ajax responses

### DIFF
--- a/services/dashboard/dashboard.js
+++ b/services/dashboard/dashboard.js
@@ -44,6 +44,15 @@ angular.module('dashboard', [
     cfpLoadingBarProvider.latencyThreshold = 200;
   }])
 
+  // disable caching for ajax calls to make MSIE happy
+  .config(['$httpProvider', function($httpProvider) {
+    $httpProvider.defaults.headers.get = angular.merge({
+      'If-Modified-Since': new Date(0),
+      'Cache-Control': 'no-cache',
+      'Pragma': 'no-cache'
+    }, $httpProvider.defaults.headers.get);
+  }])
+
   // constants
   .constant('conf', {
     restapiProtocol: 'v1.0',


### PR DESCRIPTION
Without the patch MSIE 8/9/10/11 will not receive page changes, because the response of ajax calls are cached...