### PR TITLE
fix #1423: show full error log in a popup

### DIFF
--- a/services/dashboard/styles/bootstrap-override.css
+++ b/services/dashboard/styles/bootstrap-override.css
@@ -173,3 +173,13 @@ html, body {
   border-bottom: thin dotted;
   cursor: help;
 }
+
+/* Make alert padding narrower (2 rules) */
+.alert {
+  padding: 7px 10px 7px 10px;
+}
+
+.alert-dismissable,
+.alert-dismissible {
+  padding-right: 30px;
+}

--- a/services/dashboard/styles/dashboard.css
+++ b/services/dashboard/styles/dashboard.css
@@ -74,9 +74,9 @@ td.td-no-padding  {
 /**
  * Animated loading arrows (3 rules)
  */
-.glyphicon-refresh-animate {
-  -animation: spin .7s infinite linear;
-  -webkit-animation: spin2 .7s infinite linear;
+.rotate-animation {
+  -animation: spin 1s infinite linear;
+  -webkit-animation: spin2 1s infinite linear;
 }
 
 @-webkit-keyframes spin2 {

--- a/services/dashboard/views/apps/submit/submit.html
+++ b/services/dashboard/views/apps/submit/submit.html
@@ -6,21 +6,25 @@
           <span>&times;</span></button>
         <h4>Submit Application</h4>
 
+        <p style="padding-top: 4px; padding-bottom: 14px;">Upload self contained JAR file and launch it immediately.</p>
+
         <div ng-show="shouldNoticeSubmitFailed">
           <div class="alert alert-danger alert-dismissible" role="alert">
             <button type="button" class="close" data-dismiss="alert"
                     ng-click="shouldNoticeSubmitFailed=false">
-              <span aria-hidden="true">&times;</span></button>
+              <span aria-hidden="true">&times;</span>
+            </button>
             Failed to submit the application.
             <span ng-if="error">
               Check out the
-              <span class="help-text" bs-tooltip="error"
-                    html="true" placement="auto bottom">reason</span>.
+              <span class="help-text"
+                 bs-tooltip="error" html="true" placement="bottom"
+                 ng-click="showErrorInNewWin()">reason
+                <i ng-if="hasStackTrace"
+                   class="fa fa-external-link"></i></span>.
             </span>
           </div>
         </div>
-
-        <p style="padding-top: 4px; padding-bottom: 14px;">Upload self contained JAR file and launch it immediately.</p>
 
         <form>
           <div class="row">
@@ -32,10 +36,9 @@
               <div class="form-group has-feedback form-row">
                 <input id="jarFileInput" readonly
                        type="text" class="form-control input-sm"
-                       placeholder="No file selected"
-                       ng-value="filenames['jar']"/>
-                  <span class="glyphicon glyphicon-folder-open form-control-feedback form-control-feedback-sm clickable"
-                        ngf-select ng-model="jar" ngf-accept="'.jar'"></span>
+                       ng-value="names['jar']"/>
+                <span class="glyphicon glyphicon-folder-open form-control-feedback form-control-feedback-sm clickable"
+                      ngf-select ng-model="jar" accept=".jar"></span>
               </div>
             </div>
             <!-- input 2 -->
@@ -47,13 +50,14 @@
               <div class="form-group has-feedback form-row">
                 <input id="configFileInput" readonly
                        type="text" class="form-control input-sm"
-                       ng-value="filenames['conf']"/>
-                  <span ng-hide="filenames['conf']"
-                        class="glyphicon glyphicon-folder-open form-control-feedback form-control-feedback-sm clickable"
-                        ngf-select ng-model="conf" ngf-accept="'.conf'"></span>
-                  <span ng-show="filenames['conf']"
-                        class="glyphicon glyphicon-trash form-control-feedback form-control-feedback-sm clickable"
-                        ng-click="clear('conf')"></span>
+                       ng-value="names['conf']"/>
+                <!-- Toggle buttons -->
+                <span ng-hide="names['conf']"
+                      class="glyphicon glyphicon-folder-open form-control-feedback form-control-feedback-sm clickable"
+                      ngf-select ng-model="conf" accept=".conf"></span>
+                <span ng-show="names['conf']"
+                      class="glyphicon glyphicon-trash form-control-feedback form-control-feedback-sm clickable"
+                      ng-click="clear('conf')"></span>
               </div>
             </div>
             <!-- input 3 -->
@@ -77,7 +81,7 @@
         <button type="button" class="btn btn-primary btn-sm"
                 ng-disabled="!canSubmit()" ng-click="submit()">
           <span ng-show="uploading"
-                class="glyphicon glyphicon-refresh glyphicon-refresh-animate"></span>&nbsp;
+                class="glyphicon glyphicon-repeat rotate-animation"></span>
           Submit
         </button>
       </div>

--- a/services/dashboard/views/apps/submit/submit.js
+++ b/services/dashboard/views/apps/submit/submit.js
@@ -2,21 +2,22 @@
  * Licensed under the Apache License, Version 2.0
  * See accompanying LICENSE file.
  */
-'use strict';
 angular.module('dashboard')
 
   .controller('AppSubmitCtrl', ['$scope', 'restapi',
     function($scope, restapi) {
+      'use strict';
+
       $scope.files = {};
-      $scope.filenames = {};
+      $scope.names = {};
 
       ['jar', 'conf'].forEach(function(name) {
         $scope.files[name] = null;
-        $scope.filenames[name] = null;
+        $scope.names[name] = null;
         $scope.$watch(name, function(val) {
           if (val != null && val.length) {
             $scope.files[name] = val[0];
-            $scope.filenames[name] = val[0].name;
+            $scope.names[name] = val[0].name;
           }
         });
       });
@@ -27,7 +28,7 @@ angular.module('dashboard')
 
       $scope.clear = function(name) {
         $scope.files[name] = null;
-        $scope.filenames[name] = null;
+        $scope.names[name] = null;
       };
 
       $scope.submit = function() {
@@ -44,11 +45,17 @@ angular.module('dashboard')
           if (response.success) {
             $scope.$hide();
           } else {
-            var reason = response.error;
-            if (response.stackTrace.length) {
-              reason = [reason, 'Stack Trace:'].concat(response.stackTrace).join('<br/>');
+            $scope.error = response.error;
+            $scope.hasStackTrace = response.stackTrace.length > 0;
+            $scope.showErrorInNewWin = function() {
+              if ($scope.hasStackTrace) {
+                var popup = window.open('', 'Error Log');
+                var html = [$scope.error].concat(response.stackTrace).join('\n');
+                popup.document.open();
+                popup.document.write('<pre>' + html + '</pre>');
+                popup.document.close();
+              }
             }
-            $scope.error = '<p align="left">' + reason + '</p>';
           }
         });
       };


### PR DESCRIPTION
The PR contains 3 fixes:
1. The filter text in file upload dialog was "All files", now it is "JAR (*.jar)".
2. If the error has a long stack trace, tooltip is not suitable. Now we popup a window with full log.
3. The submit button has a couple of pixel more at left side. And the loading animation was too fast.