### PR TITLE
fix #809: static resources are now sent to client gzipped

### DIFF
--- a/services/jvm/src/main/scala/io/gearpump/services/StaticService.scala
+++ b/services/jvm/src/main/scala/io/gearpump/services/StaticService.scala
@@ -39,7 +39,9 @@ trait StaticService  {
     new Manifest(input)
   }
 
-  val staticRoute = {
+  // Optionally compresses the response with Gzip or Deflate, if the client accepts
+  // compressed responses.
+  val staticRoute = encodeResponse {
     pathEndOrSingleSlash {
       getFromResource("index.html")
     } ~


### PR DESCRIPTION
This patch will reduce dashboard js files from 1MB to 300kb