### PR TITLE
fix #1479: add uptime field in service interface

### DIFF
--- a/core/src/main/scala/io/gearpump/cluster/ClusterMessage.scala
+++ b/core/src/main/scala/io/gearpump/cluster/ClusterMessage.scala
@@ -94,28 +94,26 @@ object AppMasterToMaster {
   case class GetAppData(appId: Int, key: String)
   case class GetAppDataResult(key: String, value: Any)
 
-  //TODO:
-  // clock field may not make sense for applications other than streaming
   trait AppMasterSummary {
-
     def appType: String
     def appId: Int
     def appName: String
     def actorPath: String
-
     def status: AppMasterStatus
     def startTime: TimeStamp
+    def uptime: TimeStamp
     def user: String
   }
 
   case class GeneralAppMasterSummary(
-      appId: Int,
-      appType: String = "general",
-      appName: String = null,
-      actorPath: String = null,
-      status: AppMasterStatus = MasterToAppMaster.AppMasterActive,
-      startTime: TimeStamp = 0L,
-      user: String = null)
+    appId: Int,
+    appType: String = "general",
+    appName: String = null,
+    actorPath: String = null,
+    status: AppMasterStatus = MasterToAppMaster.AppMasterActive,
+    startTime: TimeStamp = 0L,
+    uptime: TimeStamp = 0L,
+    user: String = null)
     extends AppMasterSummary
 
   case object GetAllWorkers

--- a/services/dashboard/services/models/models.js
+++ b/services/dashboard/services/models/models.js
@@ -193,7 +193,6 @@ angular.module('dashboard')
 
           angular.merge(obj, {
             // extra properties
-            aliveFor: moment() - obj.startTime,
             isRunning: true, // todo: handle empty response, which is the case application is stopped
             // extra methods
             pageUrl: locator.app(obj.appId, obj.type),

--- a/services/dashboard/views/apps/streamingapp/streamingapp.html
+++ b/services/dashboard/views/apps/streamingapp/streamingapp.html
@@ -17,8 +17,8 @@
     <div class="col-md-2 col-sm-3 hidden-xs">
       <metrics
         caption="Up Time"
-        help="Running for {{app.aliveFor|duration}}"
-        value="{{aliveForCompact.value}}" unit="{{aliveForCompact.unit}}"></metrics>
+        help="Running for {{app.uptime|duration}}"
+        value="{{uptimeCompact.value}}" unit="{{uptimeCompact.unit}}"></metrics>
     </div>
     <div class="col-md-2 col-sm-3 hidden-xs">
       <metrics value="{{dag.getNumOfProcessors()}}" unit="processor"></metrics>

--- a/services/dashboard/views/apps/streamingapp/streamingapp.js
+++ b/services/dashboard/views/apps/streamingapp/streamingapp.js
@@ -35,13 +35,13 @@ angular.module('dashboard')
 
       $scope.$state = $state; // required by streamingapp.html
       $scope.app = app0;
-      $scope.aliveForCompact = buildCompactDuration(app0.aliveFor);
+      $scope.uptimeCompact = buildCompactDuration(app0.uptime);
       $scope.dag = models.createDag(app0.clock, app0.processors,
         app0.processorLevels, app0.dag.edgeList);
 
       app0.$subscribe($scope, function(app) {
         $scope.app = app;
-        $scope.aliveForCompact = buildCompactDuration(app.aliveFor);
+        $scope.uptimeCompact = buildCompactDuration(app.uptime);
         $scope.dag.setData(app.clock, app.processors,
           app.processorLevels, app.dag.edgeList);
       });

--- a/services/jvm/src/main/scala/io/gearpump/services/AppMasterService.scala
+++ b/services/jvm/src/main/scala/io/gearpump/services/AppMasterService.scala
@@ -146,9 +146,9 @@ trait AppMasterService  {
       pathEnd {
         get {
           parameter("detail" ? "false") { detail =>
-            val detailValue = Try(detail.toBoolean).getOrElse(false)
+            val queryDetails = Try(detail.toBoolean).getOrElse(false)
             val request = AppMasterDataDetailRequest(appId)
-            detailValue match {
+            queryDetails match {
               case true =>
                 onComplete(askAppMaster[AppMasterSummary](master, appId, request)) {
                   case Success(value) =>

--- a/streaming/src/main/scala/io/gearpump/streaming/appmaster/AppMaster.scala
+++ b/streaming/src/main/scala/io/gearpump/streaming/appmaster/AppMaster.scala
@@ -194,6 +194,7 @@ class AppMaster(appContext : AppMasterContext, app : AppDescription)  extends Ap
           executors,
           status = MasterToAppMaster.AppMasterActive,
           startTime = startTime,
+          uptime = System.currentTimeMillis() - startTime,
           user = username,
           homeDirectory = userDir,
           logFile = logFile.getAbsolutePath

--- a/streaming/src/main/scala/io/gearpump/streaming/appmaster/StreamAppMasterSummary.scala
+++ b/streaming/src/main/scala/io/gearpump/streaming/appmaster/StreamAppMasterSummary.scala
@@ -38,6 +38,7 @@ case class StreamAppMasterSummary(
     executors: List[ExecutorBrief] = null,
     status: AppMasterStatus = MasterToAppMaster.AppMasterActive,
     startTime: TimeStamp = 0L,
+    uptime: TimeStamp = 0L,
     user: String = null,
     appType: String = "streaming",
     homeDirectory: String = "",


### PR DESCRIPTION
The `uptime` is no longer calculated from the browser. If the application is terminated, the appdetail will not return any meaningful data.