### PR TITLE
added some notes related to building on mac os x.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,12 @@ all needed software via:
     gem install kramdown
     sudo easy_install Pygments
 
+For Mac OSX you may need to do `sudo gem install -n /usr/local/bin jekyll` if you see the following error:
+```
+ERROR:  While executing gem ... (Errno::EPERM)
+    Operation not permitted - /usr/bin/listen
+```
+
 Kramdown is needed for Markdown processing and the Python based Pygments is used for syntax
 highlighting.
 


### PR DESCRIPTION
A few questions on the docs branch:

1. There are a bunch of *.md files under docs but they don't seem to be included in the default page when you run `jekyll serve --watch`. What I see is the following:

![screen shot 2015-10-29 at 9 57 20 am]
(https://cloud.githubusercontent.com/assets/146453/10825860/1abd83d4-7e24-11e5-9afc-792f8bc06bb1.png)

Should the default page provide a list of contents of something that includes these .md files?
