### PR TITLE
allows cluster to setup port forwarding for testing e.g. kafka 

### DIFF
--- a/integrationtest/src/main/scala/io/gearpump/minicluster/Docker.scala
+++ b/integrationtest/src/main/scala/io/gearpump/minicluster/Docker.scala
@@ -53,7 +53,9 @@ object Docker {
    */
   def execAndCaptureOutput(name: String, command: String): String = {
     LOG.info(s"$name -> exec: `$command`")
-    s"docker exec $name $command".!!.trim
+    val output = s"docker exec $name $command".!!.trim
+    LOG.info(s"$name <- exec: `$output`")
+    output
   }
 
   def killAndRemove(name: String): Boolean = {

--- a/integrationtest/src/test/scala/io/gearpump/integrationtest/checklist/CoreSpec.scala
+++ b/integrationtest/src/test/scala/io/gearpump/integrationtest/checklist/CoreSpec.scala
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gearpump.functionaltests
+package io.gearpump.integrationtest.checklist
 
 import io.gearpump.minicluster.MiniCluster
 import org.scalatest.{FlatSpec, Matchers, BeforeAndAfterAll}


### PR DESCRIPTION
(2) print exec result in log (3) renamed packages