### PR TITLE
add readme and fixed a potential docker command issue

### DIFF
--- a/integrationtest/README.md
+++ b/integrationtest/README.md
@@ -1,0 +1,47 @@
+## Getting Started
+
+To run the integration test, you need a Linux with Kernel version >= 3.10 and Docker 1.7 (or higher). The test framework will use two Docker images. They will be downloaded at the first time, when you launching the tests. You can also prepare them manually:
+
+ * [The Gearpump Cluster Launcher and Storm Client](https://hub.docker.com/r/stanleyxu2005/gpct-jdk8)
+   `docker pull stanleyxu2005/gpct-jdk8`
+ * [The standalone single node Kafka cluster with Zookeeper](https://hub.docker.com/r/spotify/kafka/)
+   `docker pull spotify/kafka`
+
+### Install Docker
+
+The integration test framework is majorly developed on CentOS 7.0. We assume the command `docker` has added to `sudo` group without asking password. `sudo usermod -aG docker $(whoami)` Here is the [installation guide of Docker for CentOS](http://docs.docker.com/engine/installation/centos/). You can find more installation guide for other Linux/Mac OS distributions. If your machine is behind a firewall, here are [some leads](https://github.com/gearpump/gearpump-docker) to make it right.
+
+### Step to Run Tests
+
+1. Checkout Gearpump project
+   `git clone https://github.com/gearpump/gearpump.git`
+2. Build Gearpump project
+   `sbt assembly pack`
+3. Run Integration test
+   `sbt it:test`
+
+The test will launch a Gearpump cluster with 1 master and 2 worker nodes as 3 Docker containers. It might take 10-20 minutes to go through all the test cases. It depends on, how powerful your machine is. The Docker container itself does not have a Gearpump distribution. It will link your local build to the Docker container. When tests are finished, you can see the test result on the screen, or you can save them to a file with this command `sbt it:test > test_report.out`. To investigate Gearpump log, please check the directory `output/target/pack/logs`.
+
+## Manual Test
+
+To launch a Gearpump cluster manually, you can run the commands as follows. You can launch so many worker containers, as you wish. But only one master for the time being.
+```
+export GEARPUMP_HOME=/path/to/gearpump/dist
+
+docker run -d \
+ -h master0 --name master0 \
+ -v $GEARPUMP_HOME:/opt/gearpump \
+ -e JAVA_OPTS=-Dgearpump.cluster.masters.0=master0:3000 \
+ -p 8090:8090 \
+ stanleyxu2005/gpct-jdk8 \
+ master -ip master0 -port 3000
+
+docker run -d \
+ --link master0 \
+ -v $GEARPUMP_HOME:/opt/gearpump \
+ -e JAVA_OPTS=-Dgearpump.cluster.masters.0=master0:3000 \
+ stanleyxu2005/gpct-jdk8 \
+ worker
+```
+
+Have a nice test drive!

--- a/integrationtest/src/it/scala/io/gearpump/integrationtest/TestSpecBase.scala
+++ b/integrationtest/src/it/scala/io/gearpump/integrationtest/TestSpecBase.scala
@@ -61,7 +61,7 @@ trait TestSpecBase extends WordSpec with Matchers with BeforeAndAfterEach with B
   }
 
   override def afterEach() = {
-    if (restartClusterRequired) {
+    if (restartClusterRequired || !cluster.isAlive) {
       restartClusterRequired = false
       LOG.info("Will restart the cluster for next test case")
       cluster.restart()

--- a/integrationtest/src/it/scala/io/gearpump/integrationtest/checklist/RestServiceSpec.scala
+++ b/integrationtest/src/it/scala/io/gearpump/integrationtest/checklist/RestServiceSpec.scala
@@ -326,7 +326,7 @@ class RestServiceSpec extends TestSpecBase {
   }
 
   private def expectMetricsAvailable(condition: => Boolean): Unit = {
-    Util.retryUntil(condition, attempts = 30, interval = 15.seconds)
+    Util.retryUntil(condition, interval = 15.seconds)
   }
 
 }

--- a/integrationtest/src/main/scala/io/gearpump/integrationtest/Docker.scala
+++ b/integrationtest/src/main/scala/io/gearpump/integrationtest/Docker.scala
@@ -28,7 +28,7 @@ object Docker {
   }
 
   def containerIsRunning(name: String): Boolean = {
-    ShellExec.execAndCaptureOutput(s"docker ps -q --filter 'name=$name'", s"FIND $name").nonEmpty
+    ShellExec.execAndCaptureOutput(s"docker ps -q --filter name=$name", s"FIND $name").nonEmpty
   }
 
   def getContainerIPAddr(name: String): String = {
@@ -36,7 +36,7 @@ object Docker {
   }
 
   def containerExists(name: String): Boolean = {
-    ShellExec.execAndCaptureOutput(s"docker ps -q -a --filter 'name=$name'", s"FIND $name").nonEmpty
+    ShellExec.execAndCaptureOutput(s"docker ps -q -a --filter name=$name", s"FIND $name").nonEmpty
   }
 
   /**

--- a/integrationtest/src/main/scala/io/gearpump/integrationtest/ShellExec.scala
+++ b/integrationtest/src/main/scala/io/gearpump/integrationtest/ShellExec.scala
@@ -46,7 +46,7 @@ object ShellExec {
           p.exitValue()
       }
 
-    LOG.debug(s"$sender <- `$retval`")
+    LOG.debug(s"$sender <- exit $retval")
     retval == 0
   }
 
@@ -70,10 +70,10 @@ object ShellExec {
     val preview = if (output.length > PREVIEW_MAX_LENGTH)
       output.substring(0, PREVIEW_MAX_LENGTH) + "\n..." else output
 
-    LOG.debug(s"$sender <= `$preview` with exit code $retval")
+    LOG.debug(s"$sender <= `$preview` exit $retval")
     if (retval != 0) {
       throw new RuntimeException(
-        s"failed to execute command. exit code=$retval, command=`$command`")
+        s"exited ($retval) by executing `$command`")
     }
     output
   }

--- a/integrationtest/src/main/scala/io/gearpump/integrationtest/Util.scala
+++ b/integrationtest/src/main/scala/io/gearpump/integrationtest/Util.scala
@@ -39,25 +39,24 @@ object Util {
     }
   }
 
-  def retryUntil(condition: => Boolean, attempts: Int = 30,
-                 interval: Duration = 2.seconds): Unit = {
-    var success = false
+  def retryUntil(condition: => Boolean, attempts: Int = 20,
+                 interval: Duration = 3.seconds): Unit = {
+    var met = false
     var attemptsLeft = attempts
 
-    while (!success && attemptsLeft > 0) {
+    while (!met) {
       try {
         attemptsLeft -= 1
-        success = condition
-        assert(success)
+        met = condition
+        if (!met) {
+          throw new RuntimeException(
+            s"condition is not met after ${attempts - attemptsLeft} retries")
+        }
       } catch {
         case ex if attemptsLeft > 0 =>
-          LOG.info(s"condition is not met. will test again in ${interval.toSeconds}s ($attemptsLeft attempts left)")
+          LOG.debug(s"condition is not met, retry in ${interval.toSeconds}s ($attemptsLeft attempts left)")
           Thread.sleep(interval.toMillis)
       }
-    }
-    if (!success) {
-      throw new RuntimeException(
-        s"condition is not met after (${interval.toSeconds}s attempting")
     }
   }
 

--- a/integrationtest/src/main/scala/io/gearpump/integrationtest/minicluster/MiniCluster.scala
+++ b/integrationtest/src/main/scala/io/gearpump/integrationtest/minicluster/MiniCluster.scala
@@ -84,7 +84,7 @@ class MiniCluster {
   private def expectClusterAvailable(): Unit = {
     Util.retryUntil({
       val response = restClient.queryMaster()
-      LOG.debug(s"Finish waiting for cluster available with response: $response.")
+      LOG.info(s"cluster is now available with response: $response.")
       response.aliveFor > 0
     })
   }


### PR DESCRIPTION
Accidentally I saw wired things in log. `docker ps -q -a --filter 'name=master0'` could return three container ids. But if I manually execute the same command in console, it returns only one container id. After removing the single quote marks, it also returns one container id.