### PR TITLE
#1660 remove Try block in io.gearpump.experiments.yarn.ContainerLaunchConte…

### DIFF
--- a/experiments/yarn/src/main/scala/io/gearpump/experiments/yarn/ContainerLaunchContext.scala
+++ b/experiments/yarn/src/main/scala/io/gearpump/experiments/yarn/ContainerLaunchContext.scala
@@ -34,7 +34,6 @@ import org.apache.hadoop.yarn.util.{ConverterUtils, Records}
 import org.slf4j.Logger
 
 import scala.collection.JavaConversions._
-import scala.util.{Failure, Success, Try}
 
 object ContainerLaunchContext {
   private val LOG: Logger = LogUtil.getLogger(getClass)
@@ -55,21 +54,14 @@ object ContainerLaunchContext {
   }
 
   private def getAMLocalResourcesMap: Map[String, LocalResource] = {
-    Try({
-      val fs = getFs(yarnConf)
-      val version = appConfig.getEnv("version")
-      val hdfsRoot = appConfig.getEnv(HDFS_ROOT)
-      Map(
-        "pack" -> newYarnAppResource(fs, new Path(s"$hdfsRoot/$version.tar.gz"),
-          LocalResourceType.ARCHIVE, LocalResourceVisibility.APPLICATION),
-        "yarnConf" -> newYarnAppResource(fs, new Path(s"$hdfsRoot/conf"),
-          LocalResourceType.FILE, LocalResourceVisibility.APPLICATION))
-    }) match {
-      case Success(map) =>
-        map
-      case Failure(throwable) =>
-        Map.empty[String, LocalResource]
-    }
+    val fs = getFs(yarnConf)
+    val version = appConfig.getEnv("version")
+    val hdfsRoot = appConfig.getEnv(HDFS_ROOT)
+    Map(
+      "pack" -> newYarnAppResource(fs, new Path(s"$hdfsRoot/$version.tar.gz"),
+        LocalResourceType.ARCHIVE, LocalResourceVisibility.APPLICATION),
+      "yarnConf" -> newYarnAppResource(fs, new Path(s"$hdfsRoot/conf"),
+        LocalResourceType.FILE, LocalResourceVisibility.APPLICATION))
   }
 
   private def newYarnAppResource(fs: FileSystem, path: Path,

--- a/experiments/yarn/src/main/scala/io/gearpump/experiments/yarn/client/Client.scala
+++ b/experiments/yarn/src/main/scala/io/gearpump/experiments/yarn/client/Client.scala
@@ -17,7 +17,7 @@
  */
 package io.gearpump.experiments.yarn.client
 
-import java.io._
+import java.io.{File,FileNotFoundException}
 
 import com.typesafe.config.ConfigFactory
 import io.gearpump.experiments.yarn
@@ -248,7 +248,7 @@ class Client(configuration: AppConfig, yarnConf: YarnConfiguration, yarnClient: 
 }
 
 object Client extends App with ArgumentsParser {
-  
+
   case class ClusterResources(totalFreeMemory: Long, totalContainers: Int, nodeManagersFreeMemory: Map[String, Long])
 
   override val options: Array[(String, CLIOption[Any])] = Array(
@@ -277,5 +277,11 @@ object Client extends App with ArgumentsParser {
     new Client(appConfig, conf, client, containerLaunchContext, fileSystem).deploy()
   }
 
-  Try(apply()).recover{case ex => help; throw ex}
+  Try(apply()).recover{
+    case ex:FileNotFoundException =>
+      Console.err.println(s"${ex.getMessage}\n" +
+        s"try to check if your gearpump version is right " +
+        s"or HDFS was correctly configured.")
+    case ex => help; throw ex
+  }
 }

--- a/experiments/yarn/src/main/scala/io/gearpump/experiments/yarn/master/YarnApplicationMaster.scala
+++ b/experiments/yarn/src/main/scala/io/gearpump/experiments/yarn/master/YarnApplicationMaster.scala
@@ -18,6 +18,7 @@
 
 package io.gearpump.experiments.yarn.master
 
+import java.io.FileNotFoundException
 import java.net.InetAddress
 import java.util.concurrent.TimeUnit
 
@@ -39,6 +40,8 @@ import org.apache.hadoop.yarn.client.api.async.NMClientAsync
 import org.apache.hadoop.yarn.client.api.async.impl.NMClientAsyncImpl
 import org.apache.hadoop.yarn.conf.YarnConfiguration
 import org.slf4j.Logger
+
+import scala.util.Try
 
 object AmActorProtocol {
 
@@ -367,6 +370,12 @@ object YarnApplicationMaster extends App with ArgumentsParser {
     }
   }
 
-  apply(args)
+  Try(apply(args)).recover{
+    case ex:FileNotFoundException =>
+      Console.err.println(s"${ex.getMessage}\n" +
+        s"try to check if your gearpump version is right " +
+        s"or HDFS was correctly configured.")
+    case ex => help; throw ex
+  }
 }
 


### PR DESCRIPTION
Since cluster on YARN will not run successfully anyway if getAMLocalResourcesMap does not perform well.I think the Try{}match{} block should be removed so that we can get some useful error info.