### PR TITLE
fix #1691: dashboard layout and textual changes and update dashing

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -280,14 +280,12 @@ object Build extends sbt.Build {
       "org.webjars.bower" % "bootstrap-additions" % "0.3.1",
       "org.webjars.bower" % "angular-strap" % "2.3.2",
       "org.webjars.bower" % "angular-ui-select" % "0.12.0",
-      "org.webjars" % "select2" % "3.5.2",
-      "org.webjars" % "select2-bootstrap-css" % "1.4.6",
       "org.webjars.bower" % "ng-file-upload" % "5.0.9",
       "org.webjars.bower" % "vis" % "4.7.0",
       "org.webjars" % "font-awesome" % "4.4.0",
       "org.webjars.bower" % "clipboard.js" % "0.1.1",
       "org.webjars.npm" % "dashing-deps" % "0.0.8",
-      "org.webjars.npm" % "dashing" % "0.3.3"
+      "org.webjars.npm" % "dashing" % "0.3.5"
   ).map(_.exclude("org.scalamacros", "quasiquotes_2.10")).map(_.exclude("org.scalamacros", "quasiquotes_2.10.3")))
 
   lazy val serviceJSSettings = Seq(

--- a/services/dashboard/index.html
+++ b/services/dashboard/index.html
@@ -17,7 +17,7 @@
   <link rel="stylesheet" href="webjars/angular-ui-select/0.12.0/dist/select.min.css"/>
   <link rel="stylesheet" href="webjars/angular-loading-bar/0.8.0/build/loading-bar.min.css"/>
   <link rel="stylesheet" href="webjars/vis/4.7.0/dist/vis.min.css"/>
-  <link rel="stylesheet" href="webjars/dashing/0.3.3/dist/dashing.min.css"/>
+  <link rel="stylesheet" href="webjars/dashing/0.3.5/dist/dashing.min.css"/>
 
   <!-- Site styles -->
   <link rel="stylesheet" href="webjars/dashing-deps/0.0.8/roboto/roboto.min.css"/>
@@ -60,7 +60,7 @@
 <script src="webjars/ng-file-upload/5.0.9/ng-file-upload.min.js"></script>
 <script src="webjars/clipboard.js/0.1.1/clipboard.js"></script>
 <script src="webjars/dashing-deps/0.0.8/echarts/2.2.7-compact/echarts-all.min.js"></script>
-<script src="webjars/dashing/0.3.3/dist/dashing.min.js"></script>
+<script src="webjars/dashing/0.3.5/dist/dashing.min.js"></script>
 
 <!-- Application -->
 <script src="dashboard.js"></script>

--- a/services/dashboard/services/models/models.js
+++ b/services/dashboard/services/models/models.js
@@ -79,7 +79,7 @@ angular.module('dashboard')
           });
           return result;
         },
-        _location: function(actorPath) {
+        _akkaAddr: function(actorPath) {
           return actorPath
             .split('@')[1]
             .split('/')[0];
@@ -118,7 +118,7 @@ angular.module('dashboard')
           return angular.merge(obj, {
             // extra properties
             jvm: decoder._jvm(obj.jvmName),
-            location: decoder._location(obj.actorPath),
+            akkaAddr: decoder._akkaAddr(obj.actorPath),
             isRunning: obj.state === 'active',
             slots: {
               usage: util.usage(slotsUsed, obj.totalSlots),
@@ -143,9 +143,10 @@ angular.module('dashboard')
           return angular.merge(obj, {
             // extra properties
             isRunning: obj.status === 'active',
-            location: decoder._location(obj.appMasterPath),
+            akkaAddr: decoder._akkaAddr(obj.appMasterPath),
             // extra methods
             pageUrl: locator.app(obj.appId, obj.type),
+            configLink: restapi.appConfigLink(obj.appId),
             terminate: function() {
               return restapi.killApp(obj.appId);
             },

--- a/services/dashboard/styles/dashboard.css
+++ b/services/dashboard/styles/dashboard.css
@@ -48,10 +48,17 @@ body {
 th.td-no-padding {
   padding-left: 0 !important;
   padding-right: 0 !important;
+  width: 8px;
 }
 
 td.td-no-padding {
   padding: 0 !important;
+}
+
+/* Reset table and heading top margin/padding value */
+h4, table > caption {
+  padding-top: 0;
+  margin-top: 0;
 }
 
 /* todo: experimental style for tooltip panel */

--- a/services/dashboard/views/apps/app/app.html
+++ b/services/dashboard/views/apps/app/app.html
@@ -7,4 +7,12 @@
   <h5 ng-bind="app.description"></h5>
 </div>
 
+<div class="col-md-12">
+  <ul class="nav nav-tabs nav-tabs-underlined" bs-navbar>
+    <li data-match-route="/apps/app/\d+(/overview)?$">
+      <a href="#/apps/app/{{app.appId}}">Overview</a>
+    </li>
+  </ul>
+</div>
+
 <div ui-view></div>

--- a/services/dashboard/views/apps/app/overview.js
+++ b/services/dashboard/views/apps/app/overview.js
@@ -23,17 +23,19 @@ angular.module('dashboard')
 
       $scope.appSummary = [
         $ptb.text('ID').done(),
-        $ptb.datetime('Start Time').done(),
         $ptb.text('Actor Path').done(),
+        $ptb.datetime('Start Time').done(),
+        $ptb.text('User').done(),
         $ptb.button('Quick Links').done()
       ];
 
       $scope.$watch('app', function(app) {
         $ptb.$update($scope.appSummary, [
           app.appId,
-          app.startTime,
           app.actorPath,
-          {href: app.configLink, text: 'Config', class: 'btn-xs'}
+          app.startTime,
+          app.user,
+          {href: app.configLink, target: '_blank', text: 'Config', class: 'btn-xs'}
         ]);
       });
     }])

--- a/services/dashboard/views/apps/apps.js
+++ b/services/dashboard/views/apps/apps.js
@@ -48,17 +48,18 @@ angular.module('dashboard')
 
       $scope.appsTable = {
         cols: [
+          // group 1/3 (4-col)
           $stb.indicator().key('state').canSort('state.condition+"_"+submissionTime').styleClass('td-no-padding').done(),
           $stb.link('ID').key('id').canSort().done(),
-          $stb.link('Name').key('name').canSort('name.text').styleClass('col-md-2').done(),
+          $stb.link('Name').key('name').canSort('name.text').styleClass('col-md-1').done(),
+          $stb.text('Address').key('akkaAddr').canSort().styleClass('col-md-3 hidden-sm hidden-xs').done(),
+          // group 2/3 (5-col)
           $stb.datetime('Submission Time').key('submissionTime').canSort().sortDefaultDescent().styleClass('col-md-1').done(),
           $stb.datetime('Start Time').key('startTime').canSort().styleClass('col-md-1').done(),
           $stb.datetime('Stop Time').key('stopTime').canSort().styleClass('col-md-1').done(),
           $stb.text('User').key('user').canSort().styleClass('col-md-2').done(),
-          $stb.text('Location').key('location').canSort()
-            .help('The location where application master is running at')
-            .styleClass('col-md-2 hidden-sm hidden-xs').done(),
-          $stb.button('Actions').key(['view', 'kill', 'restart']).styleClass('col-md-3').done()
+          // group 3/3 (3-col)
+          $stb.button('Actions').key(['view', 'config', 'kill', 'restart']).styleClass('col-md-3').done()
         ],
         rows: null
       };
@@ -69,20 +70,21 @@ angular.module('dashboard')
             id: {href: app.pageUrl, text: app.appId},
             name: {href: app.pageUrl, text: app.appName},
             state: {tooltip: app.status, condition: app.isRunning ? 'good' : '', shape: 'stripe'},
-            location: app.location,
+            akkaAddr: app.akkaAddr,
             user: app.user,
             submissionTime: app.submissionTime,
             startTime: app.startTime,
             stopTime: app.finishTime || '-',
-            view: {href: app.pageUrl, text: 'Details', class: 'btn-xs btn-primary', hide: !app.isRunning},
+            view: {href: app.pageUrl, text: 'Details', class: 'btn-xs btn-primary', disabled: !app.isRunning},
+            config: {href: app.configLink, target: '_blank', text: 'Config', class: 'btn-xs'},
             kill: {
-              text: 'Kill', class: 'btn-xs', hide: !app.isRunning,
+              text: 'Kill', class: 'btn-xs', disabled: !app.isRunning,
               click: function() {
                 app.terminate();
               }
             },
             restart: {
-              text: 'Restart', class: 'btn-xs', hide: !app.isRunning,
+              text: 'Restart', class: 'btn-xs', disabled: !app.isRunning,
               click: function() {
                 app.restart();
               }

--- a/services/dashboard/views/apps/streamingapp/executor.html
+++ b/services/dashboard/views/apps/streamingapp/executor.html
@@ -1,15 +1,6 @@
 <div class="col-md-6">
-  <h4 ng-if="executor.id === -1">AppMaster</h4>
-  <h4 ng-if="executor.id !== -1">
-    Executor # <span ng-bind="executor.id"></span>
-  </h4>
-  <h5>
-    <span ng-bind="executor.jvmName"></span>
-    <remark tooltip="PID: {{executor.jvm.pid}} Hostname: {{executor.jvm.hostname}}"></remark>
-  </h5>
-
   <property-table
-    caption="Overview"
+    caption="{{executorName}}"
     props-bind="overviewTable"
     prop-name-class="col-sm-4 bold"
     prop-value-class="col-sm-8 actor-path">

--- a/services/dashboard/views/apps/streamingapp/executor.js
+++ b/services/dashboard/views/apps/streamingapp/executor.js
@@ -27,13 +27,15 @@ angular.module('dashboard')
     function($scope, $stateParams, $ptb, helper, restapi, conf, models, executor0) {
       'use strict';
 
+      $scope.executorName = executor0.id === -1 ?
+        'AppMaster' : ('Executor ' + executor0.id);
       $scope.overviewTable = [
-        $ptb.text('ID').done(),
+        $ptb.text('JVM Info').help('Format: PID@hostname').done(),
         $ptb.text('Actor Path').done(),
         $ptb.link('Worker').done(),
         $ptb.number('Task Count').done(),
         $ptb.button('Quick Links').values([
-            {href: restapi.appExecutorConfigLink($scope.app.appId, executor0.id), text: 'Config', class: 'btn-xs'},
+            {href: restapi.appExecutorConfigLink($scope.app.appId, executor0.id), target: '_blank', text: 'Config', class: 'btn-xs'},
             helper.withClickToCopy({text: 'Log Dir.', class: 'btn-xs'}, executor0.logFile)
           ]
         ).done()
@@ -41,7 +43,7 @@ angular.module('dashboard')
 
       function updateOverviewTable(executor) {
         $ptb.$update($scope.overviewTable, [
-          executor.id,
+          executor.jvmName,
           executor.actorPath,
           {href: executor.workerPageUrl, text: 'Worker ' + executor.workerId},
           executor.taskCount

--- a/services/dashboard/views/apps/streamingapp/overview.js
+++ b/services/dashboard/views/apps/streamingapp/overview.js
@@ -23,20 +23,20 @@ angular.module('dashboard')
 
       $scope.appSummary = [
         $ptb.text('ID').done(),
+        $ptb.text('Actor Path').done(),
         $ptb.datetime('Start Time').done(),
         $ptb.text('User').done(),
-        $ptb.text('Actor Path').done(),
         $ptb.button('Quick Links').done()
       ];
 
       function updateSummaryTable(app) {
         $ptb.$update($scope.appSummary, [
           app.appId,
+          app.actorPath,
           app.startTime,
           app.user,
-          app.actorPath,
           [
-            {href: app.configLink, text: 'Config', class: 'btn-xs'},
+            {href: app.configLink, target: '_blank', text: 'Config', class: 'btn-xs'},
             helper.withClickToCopy({text: 'Home Dir.', class: 'btn-xs'}, app.homeDirectory),
             helper.withClickToCopy({text: 'Log Dir.', class: 'btn-xs'}, app.logFile)
           ]

--- a/services/dashboard/views/apps/streamingapp/processor.html
+++ b/services/dashboard/views/apps/streamingapp/processor.html
@@ -1,22 +1,13 @@
 <!-- left half -->
 <div class="col-md-6">
   <div class="row">
-    <div class="col-md-6">
-      <h4>Processor #<span ng-bind="processor.id"></span></h4>
-      <h5>{{processor.description}}</h5>
+    <div class="col-md-12">
       <property-table
+        caption="Processor {{processor.id}}"
         props-bind="processorInfoTable"
         prop-name-class="col-sm-4 bold"
         prop-value-class="col-sm-8 actor-path">
       </property-table>
-    </div>
-
-    <div ng-if="processor.parallelism > 1" class="col-md-6">
-      <h4>Receive Throughput Skew</h4>
-      <bar-chart
-        options-bind="::receiveSkewChart.options"
-        datasource-bind="receiveSkewChart.data">
-      </bar-chart>
     </div>
 
     <div class="col-md-12">
@@ -30,19 +21,30 @@
 
 <!-- right half -->
 <div class="col-md-6">
-  <h5>Task Selector</h5>
-  <ui-select theme="select2" multiple ng-model="tasks.selected">
-    <ui-select-match placeholder="Select tasks...">{{$item}}</ui-select-match>
-    <ui-select-choices repeat="task in tasks.available|filter:$select.search">
-      <span ng-bind="task"></span>
-    </ui-select-choices>
-  </ui-select>
+  <div class="row">
+    <div class="col-md-12">
+      <h5>Task Receive Throughput</h5>
+      <bar-chart
+        options-bind="::receiveSkewChart.options"
+        datasource-bind="receiveSkewChart.data">
+      </bar-chart>
+    </div>
+    <div class="col-md-12">
+      <h5>Pick one task to see metrics details</h5>
+      <ui-select theme="select2" multiple ng-model="tasks.selected">
+        <ui-select-match placeholder="Select tasks...">{{$item}}</ui-select-match>
+        <ui-select-choices repeat="task in tasks.available|filter:$select.search">
+          <span ng-bind="task"></span>
+        </ui-select-choices>
+      </ui-select>
 
-  <div ng-if="tasks.selected.length>0">
-    <br/>
+      <div ng-if="tasks.selected.length>0">
+        <br/>
 
-    <div ng-include src="'views/apps/streamingapp/processor_task_charts.html?'+tasks.selected.length"
-         ng-controller="StreamingAppProcessorTaskChartsCtrl"></div>
+        <div ng-include src="'views/apps/streamingapp/processor_task_charts.html?'+tasks.selected.length"
+             ng-controller="StreamingAppProcessorTaskChartsCtrl"></div>
+      </div>
+    </div>
   </div>
 </div>
 <!-- end of right half -->

--- a/services/dashboard/views/apps/streamingapp/processor.js
+++ b/services/dashboard/views/apps/streamingapp/processor.js
@@ -30,23 +30,30 @@ angular.module('dashboard')
       $scope.processorInfoTable = [
         $ptb.text('Task Class').done(),
         $ptb.number('Parallelism').done(),
-        $ptb.text('Inputs').done(),
-        $ptb.text('Outputs').done(),
+        $ptb.text('Processing Type').done(),
         $ptb.datetime('Birth Time').done(),
         $ptb.datetime('Death Time').done()
       ];
+
+      function describeProcessorType(inputs, outputs) {
+        if (inputs === 0) {
+          return outputs > 0 ? 'Source Processor (%s out)'.replace('%s', outputs) : 'Orphan';
+        } else if (outputs === 0) {
+          return inputs > 0 ? 'Sink Processor (%s in)'.replace('%s', inputs): 'Orphan';
+        }
+        return 'Transit Processor (%s in, %s out)'.replace('%s', inputs).replace('%s', outputs);
+      }
 
       function updateProcessorInfoTable(processor) {
         var connections = $scope.dag.calculateProcessorConnections(processor.id);
         $ptb.$update($scope.processorInfoTable, [
           processor.taskClass,
           processor.parallelism,
-          connections.inputs + ' processor(s)',
-          connections.outputs + ' processor(s)',
+          describeProcessorType(connections.inputs, connections.outputs),
           processor.life.birth <= 0 ?
             'Start with the application' : processor.life.birth,
           processor.life.death === '9223372036854775807' /* Long.max */ ?
-            'Not scheduled' : processor.life.death
+            'Not specified' : processor.life.death
         ]);
 
         $scope.tasks = {

--- a/services/dashboard/views/apps/streamingapp/streamingapp.html
+++ b/services/dashboard/views/apps/streamingapp/streamingapp.html
@@ -23,12 +23,12 @@
     <div class="col-md-2 col-sm-3 hidden-xs">
       <metrics
         caption="Up Time"
-        help="Running for {{app.uptime|duration}}"
+        help="Running for {{app.uptime|duration}}" remark-type="info"
         value="{{uptimeCompact.value}}" unit="{{uptimeCompact.unit}}"></metrics>
     </div>
     <div class="col-md-2 col-sm-3 hidden-xs">
-      <metrics value="{{dag.getNumOfProcessors()}}" unit="processor"></metrics>
-      <metrics value="{{size(app.executors)}}" unit="executor"></metrics>
+      <metrics value="{{dag.getNumOfProcessors()}}" unit="processor" unit-plural="processors"></metrics>
+      <metrics value="{{size(app.executors)}}" unit="executor" unit-plural="executors"></metrics>
     </div>
   </div>
 </div>

--- a/services/dashboard/views/apps/streamingapp/streamingapp.js
+++ b/services/dashboard/views/apps/streamingapp/streamingapp.js
@@ -48,7 +48,6 @@ angular.module('dashboard')
           executor.isRunning = false;
         });
         updateAppDetails(app);
-        return true; // cancel subscription
       });
 
       function updateAppDetails(app) {

--- a/services/dashboard/views/cluster/master/master.js
+++ b/services/dashboard/views/cluster/master/master.js
@@ -35,12 +35,13 @@ angular.module('dashboard')
       'use strict';
 
       $scope.masterInfoTable = [
-        $ptb.text('Leader').help('The central coordinator').done(),
+        $ptb.text('JVM Info').help('Format: PID@hostname').done(),
+        $ptb.text('Leader').done(),
         $ptb.text('Master Members').done(),
         $ptb.tag('Status').done(),
         $ptb.duration('Up Time').done(),
         $ptb.button('Quick Links').values([
-          {href: master0.configLink, text: 'Config', class: 'btn-xs'},
+          {href: master0.configLink, target: '_blank', text: 'Config', class: 'btn-xs'},
           helper.withClickToCopy({text: 'Home Dir.', class: 'btn-xs'}, master0.homeDirectory),
           helper.withClickToCopy({text: 'Log Dir.', class: 'btn-xs'}, master0.logFile),
           helper.withClickToCopy({text: 'Jar Store', class: 'btn-xs'}, master0.jarStore)
@@ -49,6 +50,7 @@ angular.module('dashboard')
 
       function updateSummaryTable(master) {
         $ptb.$update($scope.masterInfoTable, [
+          master.jvmName,
           master.leader,
           master.cluster,
           {text: master.masterStatus, condition: master.isHealthy ? 'good' : 'concern'},

--- a/services/dashboard/views/cluster/workers/worker/worker.html
+++ b/services/dashboard/views/cluster/workers/worker/worker.html
@@ -7,15 +7,11 @@
         <indicator condition="{{worker.isRunning ? 'good' : ''}}"
                    tooltip="{{worker.state}}"></indicator>
       </h4>
-      <h5>
-        <span ng-bind="worker.jvmName"></span>
-        <remark tooltip="PID: {{worker.jvm.pid}} Hostname: {{worker.jvm.hostname}}"></remark>
-      </h5>
     </div>
     <div class="col-md-2 col-sm-3 col-xs-6">
       <metrics
         caption="Up Time"
-        help="Running for {{worker.aliveFor|duration}}"
+        help="Running for {{worker.aliveFor|duration}}" remark-type="info"
         value="{{(worker.aliveFor / 1000 / 3600).toFixed(0)}}" unit="hr"></metrics>
     </div>
     <div class="col-md-2 col-sm-3 hidden-xs">
@@ -25,8 +21,8 @@
         value="{{worker.slots.usage|number:1}}" unit="%"></metrics>
     </div>
     <div class="col-md-2 col-sm-3 hidden-xs">
-      <metrics value="{{worker.executors.length}}" unit="executor"></metrics>
-      <metrics value="{{appsCount}}" unit="application"></metrics>
+      <metrics value="{{worker.executors.length}}" unit="executor" unit-plural="executors"></metrics>
+      <metrics value="{{appsCount}}" unit="application" unit-plural="applications"></metrics>
     </div>
   </div>
   <hr/>

--- a/services/dashboard/views/cluster/workers/worker/worker.js
+++ b/services/dashboard/views/cluster/workers/worker/worker.js
@@ -42,12 +42,11 @@ angular.module('dashboard')
       'use strict';
 
       $scope.overviewTable = [
-        $ptb.text('ID').done(),
-        $ptb.text('Location').done(),
+        $ptb.text('JVM Info').help('Format: PID@hostname').done(),
         $ptb.text('Actor Path').done(),
         $ptb.number('Slots Capacity').done(),
         $ptb.button('Quick Links').values([
-          {href: worker0.configLink, text: 'Config', class: 'btn-xs'},
+          {href: worker0.configLink, target: '_blank', text: 'Config', class: 'btn-xs'},
           helper.withClickToCopy({text: 'Home Dir.', class: 'btn-xs'}, worker0.homeDirectory),
           helper.withClickToCopy({text: 'Log Dir.', class: 'btn-xs'}, worker0.logFile)
         ]).done()
@@ -65,8 +64,7 @@ angular.module('dashboard')
 
       function updateOverviewTable(worker) {
         $ptb.$update($scope.overviewTable, [
-          worker.workerId,
-          worker.location,
+          worker.jvmName,
           worker.actorPath,
           worker.slots.total
           /* placeholder for quick links, but they do not need to be updated */
@@ -112,7 +110,6 @@ angular.module('dashboard')
           executor.isRunning = false;
         });
         updateWorkerDetails(worker);
-        return true; // cancel subscription
       });
 
       function updateWorkerDetails(worker) {
@@ -124,19 +121,16 @@ angular.module('dashboard')
       apps0.$subscribe($scope, function(apps) {
         $scope.apps = apps;
         updateExecutorsTable();
-        return !$scope.worker.isRunning;
       });
 
       // JvmMetricsChartsCtrl will watch `$scope.metrics` and `$scope.historicalMetrics`.
       $scope.metrics = metrics0.$data();
       metrics0.$subscribe($scope, function(metrics) {
         $scope.metrics = metrics;
-        return !$scope.worker.isRunning;
       });
       $scope.historicalMetrics = historicalMetrics0.$data();
       historicalMetrics0.$subscribe($scope, function(metrics) {
         $scope.historicalMetrics = metrics;
-        return !$scope.worker.isRunning;
       });
     }])
 ;

--- a/services/dashboard/views/cluster/workers/workers_listview.js
+++ b/services/dashboard/views/cluster/workers/workers_listview.js
@@ -29,14 +29,20 @@ angular.module('dashboard')
 
       $scope.workersTable = {
         cols: [
+          // group 1/3 (4-col)
           $stb.indicator().key('state').canSort('state.condition+"_"+aliveFor').styleClass('td-no-padding').done(),
           $stb.link('ID').key('id').canSort().styleClass('col-md-1').done(),
-          $stb.text('Location').key('location').canSort().sortDefault().styleClass('col-md-3').done(),
+          $stb.text('Address').key('akkaAddr').canSort().sortDefault().styleClass('col-md-1').done(),
+          $stb.text('JVM Info').key('jvm').canSort()
+            .help('Format: PID@hostname')
+            .styleClass('col-md-2 hidden-xs').done(),
+          // group 2/3 (5-col)
           $stb.number('Executors').key('executors').canSort().styleClass('col-md-1').done(),
           $stb.progressbar('Slots Usage').key('slots').sortBy('slots.usage')
             .help('Slot is a minimal compute unit. The usage indicates the computation capacity.')
             .styleClass('col-md-1').done(),
-          $stb.duration('Up Time').key('aliveFor').canSort().styleClass('col-md-3').done(),
+          $stb.duration('Up Time').key('aliveFor').canSort().styleClass('col-md-3 hidden-xs').done(),
+          // group 3/3 (3-col)
           $stb.button('Quick Links').key(['detail', 'conf']).styleClass('col-md-3').done()
         ],
         rows: null
@@ -47,12 +53,13 @@ angular.module('dashboard')
           return {
             id: {href: worker.pageUrl, text: worker.workerId},
             state: {tooltip: worker.state, condition: worker.isRunning ? 'good' : 'concern', shape: 'stripe'},
-            location: worker.location,
+            akkaAddr: worker.akkaAddr,
+            jvm: worker.jvmName,
             aliveFor: worker.aliveFor,
             slots: {current: worker.slots.used, max: worker.slots.total, usage: worker.slots.usage},
             executors: worker.executors.length || 0,
             detail: {href: worker.pageUrl, text: 'Details', class: 'btn-xs btn-primary'},
-            conf: {href: worker.configLink, text: 'Config', class: 'btn-xs'}
+            conf: {href: worker.configLink, target: '_blank', text: 'Config', class: 'btn-xs'}
           };
         });
       }

--- a/services/dashboard/views/landing/header.html
+++ b/services/dashboard/views/landing/header.html
@@ -24,6 +24,11 @@
     </ul>
     <ul class="nav navbar-nav pull-right">
       <li>
+        <a href="//gearpump.io" target="_blank">
+          <i class="fa fa-book"></i>&nbsp;Docs
+        </a>
+      </li>
+      <li>
         <a href="//github.com/gearpump/gearpump" target="_blank">
           <i class="fa fa-github"></i>&nbsp;GitHub
         </a>


### PR DESCRIPTION
Also changed a REST call policy. Previously when querying worker status is timed out, we assume the worker is dead. No more query requests will be sent to backend. But if the backend is temporary stuck,  it might come back again shortly, so we should keep querying the backend.