### PR TITLE
fix #1711: layout is more responsive on small devices

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -276,7 +276,7 @@ object Build extends sbt.Build {
       "org.webjars" % "lodash" % "3.10.1",
       "org.webjars" % "font-awesome" % "4.5.0",
       "org.webjars.bower" % "angular-loading-bar" % "0.8.0",
-      "org.webjars.bower" % "angular-smart-table" % "2.1.5",
+      "org.webjars.bower" % "angular-smart-table" % "2.1.6",
       "org.webjars.bower" % "angular-motion" % "0.4.3",
       "org.webjars.bower" % "bootstrap-additions" % "0.3.1",
       "org.webjars.bower" % "angular-strap" % "2.3.5",
@@ -285,7 +285,7 @@ object Build extends sbt.Build {
       "org.webjars.bower" % "vis" % "4.7.0",
       "org.webjars.bower" % "clipboard.js" % "0.1.1",
       "org.webjars.npm" % "dashing-deps" % "0.0.8",
-      "org.webjars.npm" % "dashing" % "0.3.7"
+      "org.webjars.npm" % "dashing" % "0.3.8"
   ).map(_.exclude("org.scalamacros", "quasiquotes_2.10")).map(_.exclude("org.scalamacros", "quasiquotes_2.10.3")))
 
   lazy val serviceJSSettings = Seq(

--- a/services/dashboard/dashboard.js
+++ b/services/dashboard/dashboard.js
@@ -43,7 +43,7 @@ angular.module('dashboard', [
     'use strict';
 
     cfpLoadingBarProvider.includeSpinner = false;
-    cfpLoadingBarProvider.latencyThreshold = 200;
+    cfpLoadingBarProvider.latencyThreshold = 1000;
   }])
 
   // configure angular-strap

--- a/services/dashboard/index.html
+++ b/services/dashboard/index.html
@@ -17,7 +17,7 @@
   <link rel="stylesheet" href="webjars/angular-ui-select/0.13.2/dist/select.min.css"/>
   <link rel="stylesheet" href="webjars/angular-loading-bar/0.8.0/build/loading-bar.min.css"/>
   <link rel="stylesheet" href="webjars/vis/4.7.0/dist/vis.min.css"/>
-  <link rel="stylesheet" href="webjars/dashing/0.3.7/dist/dashing.min.css"/>
+  <link rel="stylesheet" href="webjars/dashing/0.3.8/dist/dashing.min.css"/>
 
   <!-- Site styles -->
   <link rel="stylesheet" href="webjars/dashing-deps/0.0.8/roboto/roboto.min.css"/>
@@ -51,7 +51,7 @@
 <script src="webjars/angular-strap/2.3.5/dist/angular-strap.min.js"></script>
 <script src="webjars/angular-strap/2.3.5/dist/angular-strap.tpl.min.js"></script>
 <script src="webjars/angular-ui-select/0.13.2/dist/select.min.js"></script>
-<script src="webjars/angular-smart-table/2.1.5/dist/smart-table.min.js"></script>
+<script src="webjars/angular-smart-table/2.1.6/dist/smart-table.min.js"></script>
 <script src="webjars/d3js/3.5.6/d3.min.js"></script>
 <script src="webjars/momentjs/2.10.6/min/moment.min.js"></script>
 <script src="webjars/lodash/3.10.1/lodash.min.js"></script>
@@ -60,7 +60,7 @@
 <script src="webjars/ng-file-upload/5.0.9/ng-file-upload.min.js"></script>
 <script src="webjars/clipboard.js/0.1.1/clipboard.js"></script>
 <script src="webjars/dashing-deps/0.0.8/echarts/2.2.7-compact/echarts-all.min.js"></script>
-<script src="webjars/dashing/0.3.7/dist/dashing.min.js"></script>
+<script src="webjars/dashing/0.3.8/dist/dashing.min.js"></script>
 
 <!-- Application -->
 <script src="dashboard.js"></script>

--- a/services/dashboard/views/apps/app/executors_table.js
+++ b/services/dashboard/views/apps/app/executors_table.js
@@ -20,28 +20,29 @@ angular.module('dashboard')
           $scope.table = {
             cols: [
               $stb.indicator().key('status').canSort().styleClass('td-no-padding').done(),
-              $stb.link('Name').key('id').canSort().sortDefault().styleClass('col-md-4').done(),
-              $stb.link('Worker ID').key('worker').canSort().styleClass('col-md-4').done(),
-              $stb.number('Task Count').key('tasks').canSort().styleClass('col-md-4')
+              $stb.link('Name').key('id').canSort().sortDefault().styleClass('col-xs-4').done(),
+              $stb.link('Worker ID').key('worker').canSort().styleClass('col-xs-4').done(),
+              $stb.number('Task Count').key('tasks').canSort().styleClass('col-xs-4')
                 .help('AppMaster is a coordinator. It does not run any computing tasks.').done()
             ],
             rows: null
           };
 
           function updateTable(executors) {
-            $scope.table.rows = _.map(executors, function(executor) {
-              return {
-                status: {
-                  tooltip: executor.status,
-                  condition: executor.isRunning ? 'good' : '',
-                  shape: 'stripe'
-                },
-                id: {href: executor.pageUrl, text: executor.executorId === -1 ?
-                  'AppMaster' : 'Executor ' + executor.executorId},
-                worker: {href: executor.workerPageUrl, text: executor.workerId},
-                tasks: executor.taskCount || 0
-              };
-            });
+            $scope.table.rows = $stb.$update($scope.table.rows,
+              _.map(executors, function(executor) {
+                return {
+                  status: {
+                    tooltip: executor.status,
+                    condition: executor.isRunning ? 'good' : '',
+                    shape: 'stripe'
+                  },
+                  id: {href: executor.pageUrl, text: executor.executorId === -1 ?
+                    'AppMaster' : 'Executor ' + executor.executorId},
+                  worker: {href: executor.workerPageUrl, text: executor.workerId},
+                  tasks: executor.taskCount || 0
+                };
+              }));
           }
 
           $scope.$watch('executors', function(executors) {

--- a/services/dashboard/views/apps/app/overview.html
+++ b/services/dashboard/views/apps/app/overview.html
@@ -2,8 +2,8 @@
   <property-table
     caption="Summary"
     props-bind="appSummary"
-    prop-name-class="col-sm-4 bold"
-    prop-value-class="col-sm-8 actor-path">
+    prop-name-class="col-xs-4 bold"
+    prop-value-class="col-xs-8 actor-path">
   </property-table>
 
   <executor-table

--- a/services/dashboard/views/apps/app/overview.js
+++ b/services/dashboard/views/apps/app/overview.js
@@ -17,8 +17,8 @@ angular.module('dashboard')
         });
     }])
 
-  .controller('AppOverviewCtrl', ['$scope', '$propertyTableBuilder',
-    function($scope, $ptb) {
+  .controller('AppOverviewCtrl', ['$scope', 'helper', '$propertyTableBuilder',
+    function($scope, helper, $ptb) {
       'use strict';
 
       $scope.appSummary = [
@@ -35,7 +35,11 @@ angular.module('dashboard')
           app.actorPath,
           app.startTime,
           app.user,
-          {href: app.configLink, target: '_blank', text: 'Config', class: 'btn-xs'}
+          [
+            {href: app.configLink, target: '_blank', text: 'Config', class: 'btn-xs'},
+            helper.withClickToCopy({text: 'Home Dir.', class: 'btn-xs'}, app.homeDirectory),
+            helper.withClickToCopy({text: 'Log Dir.', class: 'btn-xs'}, app.logFile)
+          ]
         ]);
       });
     }])

--- a/services/dashboard/views/apps/apps.js
+++ b/services/dashboard/views/apps/apps.js
@@ -65,32 +65,33 @@ angular.module('dashboard')
       };
 
       function updateTable(apps) {
-        $scope.appsTable.rows = _.map(apps, function(app) {
-          return {
-            id: {href: app.pageUrl, text: app.appId},
-            name: {href: app.pageUrl, text: app.appName},
-            state: {tooltip: app.status, condition: app.isRunning ? 'good' : '', shape: 'stripe'},
-            akkaAddr: app.akkaAddr,
-            user: app.user,
-            submissionTime: app.submissionTime,
-            startTime: app.startTime,
-            stopTime: app.finishTime || '-',
-            view: {href: app.pageUrl, text: 'Details', class: 'btn-xs btn-primary', disabled: !app.isRunning},
-            config: {href: app.configLink, target: '_blank', text: 'Config', class: 'btn-xs'},
-            kill: {
-              text: 'Kill', class: 'btn-xs', disabled: !app.isRunning,
-              click: function() {
-                app.terminate();
+        $scope.appsTable.rows = $stb.$update($scope.appsTable.rows,
+          _.map(apps, function(app) {
+            return {
+              id: {href: app.pageUrl, text: app.appId},
+              name: {href: app.pageUrl, text: app.appName},
+              state: {tooltip: app.status, condition: app.isRunning ? 'good' : '', shape: 'stripe'},
+              akkaAddr: app.akkaAddr,
+              user: app.user,
+              submissionTime: app.submissionTime,
+              startTime: app.startTime,
+              stopTime: app.finishTime || '-',
+              view: {href: app.pageUrl, text: 'Details', class: 'btn-xs btn-primary', disabled: !app.isRunning},
+              config: {href: app.configLink, target: '_blank', text: 'Config', class: 'btn-xs'},
+              kill: {
+                text: 'Kill', class: 'btn-xs', disabled: !app.isRunning,
+                click: function() {
+                  app.terminate();
+                }
+              },
+              restart: {
+                text: 'Restart', class: 'btn-xs', disabled: !app.isRunning,
+                click: function() {
+                  app.restart();
+                }
               }
-            },
-            restart: {
-              text: 'Restart', class: 'btn-xs', disabled: !app.isRunning,
-              click: function() {
-                app.restart();
-              }
-            }
-          };
-        });
+            };
+          }));
       }
 
       updateTable(apps0.$data());

--- a/services/dashboard/views/apps/streamingapp/executor.html
+++ b/services/dashboard/views/apps/streamingapp/executor.html
@@ -2,8 +2,8 @@
   <property-table
     caption="{{executorName}}"
     props-bind="overviewTable"
-    prop-name-class="col-sm-4 bold"
-    prop-value-class="col-sm-8 actor-path">
+    prop-name-class="col-xs-4 bold"
+    prop-value-class="col-xs-8 actor-path">
   </property-table>
 </div>
 

--- a/services/dashboard/views/apps/streamingapp/metrics.js
+++ b/services/dashboard/views/apps/streamingapp/metrics.js
@@ -55,34 +55,34 @@ angular.module('dashboard')
 
       $scope.meterMetricsTable = {
         cols: [
-          $stb.text('Path').key('taskPath').canSort().sortDefault().styleClass('col-xs-2').done(),
+          $stb.text('Path').key('taskPath').canSort().sortDefault().styleClass('col-sm-2').done(),
           $stb.text('Task Class').key('taskClass').canSort().styleClass('col-lg-3 hidden-md hidden-sm hidden-xs').done(),
-          $stb.number('Message Count').key('count').canSort().unit('msg').styleClass('col-xs-2').done(),
-          $stb.number('Mean Rate').key('mean').canSort().unit('msg/s').styleClass('col-xs-1').done(),
+          $stb.number('Message Count').key('count').canSort().unit('msg').styleClass('col-sm-2').done(),
+          $stb.number('Mean Rate').key('mean').canSort().unit('msg/s').styleClass('col-sm-1').done(),
           $stb.number('MA 1m').key('ma1').canSort().unit('msg/s')
-            .help('1-Minute Moving Average').styleClass('col-xs-1').done(),
+            .help('1-Minute Moving Average').styleClass('col-sm-1').done(),
           $stb.number('MA 5m').key('ma5').canSort().unit('msg/s')
-            .help('5-Minute Moving Average').styleClass('col-xs-1').done(),
+            .help('5-Minute Moving Average').styleClass('col-sm-1 hidden-xs').done(),
           $stb.number('MA 15m').key('ma15').canSort().unit('msg/s')
-            .help('15-Minute Moving Average').styleClass('col-xs-1').done()
+            .help('15-Minute Moving Average').styleClass('col-sm-1 hidden-xs').done()
         ],
         rows: null
       };
 
       $scope.histogramMetricsTable = {
         cols: [
-          $stb.text('Path').key('taskPath').canSort().sortDefault().styleClass('col-xs-2').done(),
+          $stb.text('Path').key('taskPath').canSort().sortDefault().styleClass('col-sm-2').done(),
           $stb.text('Task Class').key('taskClass').canSort().styleClass('col-lg-3 hidden-md hidden-sm hidden-xs').done(),
-          $stb.number('Sampling Points').key('count').canSort().styleClass('col-xs-2').done(),
-          $stb.number('Mean Rate').key('mean').canSort().unit('ms').styleClass('col-xs-1').done(),
-          $stb.number('Std. Dev.').key('stddev').canSort().unit('ms').styleClass('col-xs-1').done(),
-          $stb.number('Median').key('median').canSort().unit('ms').styleClass('col-xs-1').done(),
+          $stb.number('Sampling Points').key('count').canSort().styleClass('col-sm-2').done(),
+          $stb.number('Mean Rate').key('mean').canSort().unit('ms').styleClass('col-sm-1').done(),
+          $stb.number('Std. Dev.').key('stddev').canSort().unit('ms').styleClass('col-sm-1').done(),
+          $stb.number('Median').key('median').canSort().unit('ms').styleClass('col-sm-1').done(),
           $stb.number('p95%').key('p95').canSort().unit('ms')
-            .help('The 95th percentage').styleClass('col-xs-1').done(),
+            .help('The 95th percentage').styleClass('col-sm-1 hidden-xs').done(),
           $stb.number('p99%').key('p99').canSort().unit('ms')
-            .help('The 99th percentage').styleClass('col-xs-1').done(),
+            .help('The 99th percentage').styleClass('col-md-1 hidden-sm hidden-xs').done(),
           $stb.number('p99.9%').key('p999').canSort().unit('ms')
-            .help('The 99.9th percentage').styleClass('col-xs-1').done()
+            .help('The 99.9th percentage').styleClass('col-md-1  hidden-sm hidden-xs').done()
         ],
         rows: null
       };
@@ -92,33 +92,35 @@ angular.module('dashboard')
       }
 
       function updateMeterMetricsTable(metrics) {
-        $scope.meterMetricsTable.rows = _.map(metrics, function(metric) {
-          return {
-            taskPath: buildMetricsTaskPath(metric),
-            taskClass: metric.taskClass,
-            count: metric.values.count,
-            mean: metric.values.meanRate,
-            ma1: metric.values.movingAverage1m,
-            ma5: metric.values.movingAverage5m,
-            ma15: metric.values.movingAverage15m
-          };
-        });
+        $scope.meterMetricsTable.rows = $stb.$update($scope.meterMetricsTable.rows,
+          _.map(metrics, function(metric) {
+            return {
+              taskPath: buildMetricsTaskPath(metric),
+              taskClass: metric.taskClass,
+              count: metric.values.count,
+              mean: metric.values.meanRate,
+              ma1: metric.values.movingAverage1m,
+              ma5: metric.values.movingAverage5m,
+              ma15: metric.values.movingAverage15m
+            };
+          }));
       }
 
       function updateHistogramMetricsTable(metrics) {
-        $scope.histogramMetricsTable.rows = _.map(metrics, function(metric) {
-          return {
-            taskPath: buildMetricsTaskPath(metric),
-            taskClass: metric.taskClass,
-            count: metric.values.count,
-            mean: metric.values.mean,
-            stddev: metric.values.stddev,
-            median: metric.values.median,
-            p95: metric.values.p95,
-            p99: metric.values.p99,
-            p999: metric.values.p999
-          };
-        });
+        $scope.histogramMetricsTable.rows = $stb.$update($scope.histogramMetricsTable.rows,
+          _.map(metrics, function(metric) {
+            return {
+              taskPath: buildMetricsTaskPath(metric),
+              taskClass: metric.taskClass,
+              count: metric.values.count,
+              mean: metric.values.mean,
+              stddev: metric.values.stddev,
+              median: metric.values.median,
+              p95: metric.values.p95,
+              p99: metric.values.p99,
+              p999: metric.values.p999
+            };
+          }));
       }
     }])
 ;

--- a/services/dashboard/views/apps/streamingapp/overview.html
+++ b/services/dashboard/views/apps/streamingapp/overview.html
@@ -2,8 +2,8 @@
   <property-table
     caption="Summary"
     props-bind="appSummary"
-    prop-name-class="col-sm-4 bold"
-    prop-value-class="col-sm-8 actor-path">
+    prop-name-class="col-xs-4 bold"
+    prop-value-class="col-xs-8 actor-path">
   </property-table>
 
   <executor-table

--- a/services/dashboard/views/apps/streamingapp/processor.html
+++ b/services/dashboard/views/apps/streamingapp/processor.html
@@ -5,8 +5,8 @@
       <property-table
         caption="Processor {{processor.id}}"
         props-bind="processorInfoTable"
-        prop-name-class="col-sm-4 bold"
-        prop-value-class="col-sm-8 actor-path">
+        prop-name-class="col-xs-4 bold"
+        prop-value-class="col-xs-8 actor-path">
       </property-table>
     </div>
 

--- a/services/dashboard/views/apps/streamingapp/streamingapp.html
+++ b/services/dashboard/views/apps/streamingapp/streamingapp.html
@@ -1,6 +1,6 @@
 <div class="col-md-12">
   <div class="row">
-    <div class="col-md-6 col-sm-3 col-xs-6">
+    <div class="col-md-6 col-sm-4">
       <h4>
         <!-- todo: backend api should enforce user application has a readable name! -->
         <span ng-bind="app.appName"></span>
@@ -8,7 +8,7 @@
       </h4>
       <h5 ng-bind="app.description"></h5>
     </div>
-    <div class="col-md-2 col-sm-3 col-xs-6">
+    <div class="col-sm-2 col-xs-4">
       <metrics
         ng-if="app.clock"
         caption="Application Clock"
@@ -20,13 +20,13 @@
         caption="Application Clock"
         value="not started"></metrics>
     </div>
-    <div class="col-md-2 col-sm-3 hidden-xs">
+    <div class="col-sm-2 col-xs-4">
       <metrics
         caption="Up Time"
         help="Running for {{app.uptime|duration}}" remark-type="info"
         value="{{uptimeCompact.value}}" unit="{{uptimeCompact.unit}}"></metrics>
     </div>
-    <div class="col-md-2 col-sm-3 hidden-xs">
+    <div class="col-sm-2 col-xs-4">
       <metrics value="{{dag.getNumOfProcessors()}}" unit="processor" unit-plural="processors"></metrics>
       <metrics value="{{size(app.executors)}}" unit="executor" unit-plural="executors"></metrics>
     </div>

--- a/services/dashboard/views/cluster/master/master.html
+++ b/services/dashboard/views/cluster/master/master.html
@@ -2,8 +2,8 @@
   <property-table
     caption="Master Information"
     props-bind="masterInfoTable"
-    prop-name-class="col-sm-4 bold"
-    prop-value-class="col-sm-8">
+    prop-name-class="col-sm-4 col-xs-6 bold"
+    prop-value-class="col-sm-8 col-xs-6">
   </property-table>
 </div>
 

--- a/services/dashboard/views/cluster/workers/worker/worker.html
+++ b/services/dashboard/views/cluster/workers/worker/worker.html
@@ -1,26 +1,26 @@
 <!-- todo: create a header directive -->
 <div class="col-md-12">
   <div class="row">
-    <div class="col-md-6">
+    <div class="col-md-6 col-sm-4">
       <h4>
         Worker {{worker.workerId}}
         <indicator condition="{{worker.isRunning ? 'good' : ''}}"
                    tooltip="{{worker.state}}"></indicator>
       </h4>
     </div>
-    <div class="col-md-2 col-sm-3 col-xs-6">
+    <div class="col-sm-2 col-xs-4">
       <metrics
         caption="Up Time"
         help="Running for {{worker.aliveFor|duration}}" remark-type="info"
         value="{{uptimeCompact.value}}" unit="{{uptimeCompact.unit}}"></metrics>
     </div>
-    <div class="col-md-2 col-sm-3 hidden-xs">
+    <div class="col-sm-2 col-xs-4">
       <metrics
         caption="Slots Usage"
         help="Slot is a minimal compute unit. The usage indicates the computation capacity."
         value="{{worker.slots.usage|number:1}}" unit="%"></metrics>
     </div>
-    <div class="col-md-2 col-sm-3 hidden-xs">
+    <div class="col-sm-2 col-xs-4">
       <metrics value="{{worker.executors.length}}" unit="executor" unit-plural="executors"></metrics>
       <metrics value="{{appsCount}}" unit="application" unit-plural="applications"></metrics>
     </div>
@@ -32,8 +32,8 @@
   <property-table
     caption="Overview"
     props-bind="overviewTable"
-    prop-name-class="col-sm-4 bold"
-    prop-value-class="col-sm-8 actor-path">
+    prop-name-class="col-xs-4 bold"
+    prop-value-class="col-xs-8 actor-path">
   </property-table>
 
   <sortable-table

--- a/services/dashboard/views/cluster/workers/worker/worker.js
+++ b/services/dashboard/views/cluster/workers/worker/worker.js
@@ -55,9 +55,9 @@ angular.module('dashboard')
       $scope.executorsTable = {
         cols: [
           $stb.indicator().key('status').canSort().styleClass('td-no-padding').done(),
-          $stb.link('Executor ID').key('executors').canSort().styleClass('col-md-4').done(),
-          $stb.link('Application').key('id').canSort().sortDefault().styleClass('col-md-4').done(),
-          $stb.number('Slots').key('slots').canSort().styleClass('col-md-4').done()
+          $stb.link('Application').key('id').canSort().sortDefault().styleClass('col-xs-4').done(),
+          $stb.link('Executor ID').key('executors').canSort().styleClass('col-xs-4').done(),
+          $stb.number('Slots').key('slots').canSort().styleClass('col-xs-4').done()
         ],
         rows: null
       };
@@ -73,23 +73,24 @@ angular.module('dashboard')
       }
 
       function updateExecutorsTable() {
-        $scope.executorsTable.rows = _.map($scope.worker.executors, function(executor) {
-          if ($scope.apps.hasOwnProperty(executor.appId)) {
-            var app = $scope.apps[executor.appId];
-            var executorPageUrl = locator.executor(app.appId, app.type, executor.executorId);
-            var executorPath = 'app' + executor.appId + '.' +
-              (executor.executorId === -1 ?
-                'appmaster' : 'executor' + executor.executorId);
-            return {
-              status: {condition: 'good', shape: 'stripe'}, // always be good
-              id: {href: app.pageUrl, text: app.appName},
-              executors: {href: executorPageUrl, text: executorPath},
-              slots: executor.slots
-            };
-          } else {
-            console.warn({message: 'Unknown executor', executor: executor});
-          }
-        });
+        $scope.executorsTable.rows = $stb.$update($scope.executorsTable.rows,
+          _.map($scope.worker.executors, function(executor) {
+            if ($scope.apps.hasOwnProperty(executor.appId)) {
+              var app = $scope.apps[executor.appId];
+              var executorPageUrl = locator.executor(app.appId, app.type, executor.executorId);
+              var executorPath = 'app' + executor.appId + '.' +
+                (executor.executorId === -1 ?
+                  'appmaster' : 'executor' + executor.executorId);
+              return {
+                status: {condition: 'good', shape: 'stripe'}, // always be good
+                id: {href: app.pageUrl, text: app.appName},
+                executors: {href: executorPageUrl, text: executorPath},
+                slots: executor.slots
+              };
+            } else {
+              console.warn({message: 'Unknown executor', executor: executor});
+            }
+          }));
       }
 
       $scope.worker = worker0.$data();

--- a/services/dashboard/views/cluster/workers/workers_listview.js
+++ b/services/dashboard/views/cluster/workers/workers_listview.js
@@ -37,11 +37,11 @@ angular.module('dashboard')
             .help('Format: PID@hostname')
             .styleClass('col-md-2 hidden-xs').done(),
           // group 2/3 (5-col)
-          $stb.number('Executors').key('executors').canSort().styleClass('col-md-1').done(),
+          $stb.number('Executors').key('executors').canSort().styleClass('col-md-1 hidden-xs').done(),
           $stb.progressbar('Slots Usage').key('slots').sortBy('slots.usage')
             .help('Slot is a minimal compute unit. The usage indicates the computation capacity.')
             .styleClass('col-md-1').done(),
-          $stb.duration('Up Time').key('aliveFor').canSort().styleClass('col-md-3 hidden-xs').done(),
+          $stb.duration('Up Time').key('aliveFor').canSort().styleClass('col-md-3 hidden-sm hidden-xs').done(),
           // group 3/3 (3-col)
           $stb.button('Quick Links').key(['detail', 'conf']).styleClass('col-md-3').done()
         ],
@@ -49,19 +49,20 @@ angular.module('dashboard')
       };
 
       function updateTable(workers) {
-        $scope.workersTable.rows = _.map(workers, function(worker) {
-          return {
-            id: {href: worker.pageUrl, text: worker.workerId},
-            state: {tooltip: worker.state, condition: worker.isRunning ? 'good' : 'concern', shape: 'stripe'},
-            akkaAddr: worker.akkaAddr,
-            jvm: worker.jvmName,
-            aliveFor: worker.aliveFor,
-            slots: {current: worker.slots.used, max: worker.slots.total, usage: worker.slots.usage},
-            executors: worker.executors.length || 0,
-            detail: {href: worker.pageUrl, text: 'Details', class: 'btn-xs btn-primary'},
-            conf: {href: worker.configLink, target: '_blank', text: 'Config', class: 'btn-xs'}
-          };
-        });
+        $scope.workersTable.rows = $stb.$update($scope.workersTable.rows,
+          _.map(workers, function(worker) {
+            return {
+              id: {href: worker.pageUrl, text: worker.workerId},
+              state: {tooltip: worker.state, condition: worker.isRunning ? 'good' : 'concern', shape: 'stripe'},
+              akkaAddr: worker.akkaAddr,
+              jvm: worker.jvmName,
+              aliveFor: worker.aliveFor,
+              slots: {current: worker.slots.used, max: worker.slots.total, usage: worker.slots.usage},
+              executors: worker.executors.length || 0,
+              detail: {href: worker.pageUrl, text: 'Details', class: 'btn-xs btn-primary'},
+              conf: {href: worker.configLink, target: '_blank', text: 'Config', class: 'btn-xs'}
+            };
+          }));
       }
 
       updateTable(workers0.$data());

--- a/services/dashboard/views/jvm/metrics_charts.html
+++ b/services/dashboard/views/jvm/metrics_charts.html
@@ -1,8 +1,8 @@
 <property-table
   caption="JVM Metrics"
   props-bind="jvmMetricsTable"
-  prop-name-class="col-sm-4 bold"
-  prop-value-class="col-sm-8">
+  prop-name-class="col-sm-4 col-xs-6 bold"
+  prop-value-class="col-sm-8 col-xs-6 text-right">
 </property-table>
 
 <div class="row">

--- a/services/dashboard/views/landing/header.html
+++ b/services/dashboard/views/landing/header.html
@@ -1,5 +1,12 @@
 <nav class="navbar navbar-inverse navbar-fixed-top">
   <div class="navbar-header">
+    <button type="button" class="navbar-toggle collapsed"
+            bs-dropdown="dropdownMenuOptions" placement="auto bottom-left" html="true">
+      <span class="sr-only">Toggle navigation</span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+    </button>
     <a class="navbar-brand" href="#/">GearPump
       <span class="label label-primary"
             style="font-size: .6em"
@@ -14,23 +21,19 @@
   <!--</div>-->
   <div class="collapse navbar-collapse">
     <ul class="nav navbar-nav" bs-navbar>
-      <li data-match-route="/cluster"><a href="#/cluster">
-        <span class="glyphicon glyphicon-th-large"></span>
-        Cluster</a>
-      </li>
-      <li data-match-route="/apps"><a href="#/apps">
-        <span class="glyphicon glyphicon-tasks"></span>
-        Applications</a></li>
-    </ul>
-    <ul class="nav navbar-nav pull-right">
-      <li>
-        <a href="//gearpump.io" target="_blank">
-          <i class="fa fa-book"></i>&nbsp;Docs
+      <li ng-repeat="item in menu track by $index"
+          data-match-route="{{item.href}}">
+        <a href="{{item.href}}">
+          <span class="{{item.icon}}"></span>
+          {{item.text}}
         </a>
       </li>
-      <li>
-        <a href="//github.com/gearpump/gearpump" target="_blank">
-          <i class="fa fa-github"></i>&nbsp;GitHub
+    </ul>
+    <ul class="nav navbar-nav pull-right">
+      <li ng-repeat="item in links track by $index">
+        <a href="{{item.href}}" target="_blank">
+          <span class="{{item.icon}}"></span>
+          {{item.text}}
         </a>
       </li>
     </ul>

--- a/services/dashboard/views/landing/header.js
+++ b/services/dashboard/views/landing/header.js
@@ -14,7 +14,25 @@ angular.module('dashboard')
       replace: true,
       scope: {},
       controller: ['$scope', 'restapi', function($scope, restapi) {
-        $scope.version = 'beta';
+        $scope.menu = [
+          {text: 'Cluster', href: '#/cluster', icon: 'glyphicon glyphicon-th-large'},
+          {text: 'Applications', href: '#/apps', icon: 'glyphicon glyphicon-tasks'}
+        ];
+
+        $scope.links = [
+          {text: 'Docs', href: '//gearpump.io', icon: 'fa fa-book'},
+          {text: 'GitHub', href: '//github.com/gearpump/gearpump', icon: 'fa fa-github'}
+        ];
+
+        $scope.dropdownMenuOptions = ([].concat($scope.menu).concat($scope.links))
+          .map(function(item) {
+            return {
+              text: '<i class="' + item.icon + '"></i> ' + item.text,
+              href: item.href
+            };
+          });
+
+        $scope.version = '';
         restapi.repeatHealthCheck($scope, function(version) {
           $scope.version = version;
         });


### PR DESCRIPTION
1. alternatively show menu items as dropdown menu for small screen size
2. selective hide unimportant table columns for small screen size
3. more reasonable column size for small screen size
4. blue loading bar (at top) will shown when a request takes longer than 1s (previously was 200ms)
5. fixed a sorting table flicker issue