### PR TITLE
fix #1754 standardize archive name

### DIFF
--- a/conf/gear.conf
+++ b/conf/gear.conf
@@ -186,7 +186,7 @@ gearpump {
   ###########################
   yarn {
     client {
-      package-path = "/user/gearpump/gearpump.zip"
+      package-path = "/usr/lib/gearpump/gearpump.zip"
     }
 
     applicationmaster {

--- a/docs/deployment-security.md
+++ b/docs/deployment-security.md
@@ -9,9 +9,9 @@ Until now Gearpump support being launched in a secured Yarn cluster and writing 
 Further security related feature is in progress.
 
 ## How to launch GearPump in a secured Yarn cluster
-Suppose user ```gearpump``` will launch gearpump on YARN, then the corresponding principal `gearpump` should be created in KDC server.
+Suppose user ```gear``` will launch gearpump on YARN, then the corresponding principal `gear` should be created in KDC server.
 
-1. Create Kerberos principal for user ```gearpump```, on the KDC machine run
+1. Create Kerberos principal for user ```gear```, on the KDC machine run
  
    ``` 
    sudo kadmin.local
@@ -20,19 +20,22 @@ Suppose user ```gearpump``` will launch gearpump on YARN, then the corresponding
    In the kadmin.local or kadmin shell, create the principal
    
    ```
-   kadmin:  addprinc gearpump/fully.qualified.domain.name@YOUR-REALM.COM
+   kadmin:  addprinc gear/fully.qualified.domain.name@YOUR-REALM.COM
    ```
    
-   Remember that user ```gearpump``` must exist on every node of Yarn. 
-   
-2. Create HDFS folder /user/gearpump/, make sure all read-write rights are granted for user ```gearpump```
+   Remember that user ```gear``` must exist on every node of Yarn. 
+
+2. Upload the gearpump-${version}.zip to remote HDFS Folder, suggest to put it under /usr/lib/gearpump/gearpump-${version}.zip
+3. Create HDFS folder /user/gear/, make sure all read-write rights are granted for user ```gear```
 
    ```
-   drwxr-xr-x   - gearpump  gearpump           0 2015-11-27 14:03 /user/gearpump
+   drwxr-xr-x   - gear  gear           0 2015-11-27 14:03 /user/gear
    ```
    
-3. Upload the gearpump-pack-2.11.5-{{ site.GEARPUMP_VERSION }}.tar.gz jars to HDFS folder: /user/gearpump/, you can refer to [How to get gearpump distribution](get-gearpump-distribution.html) to get the Gearpump binary.
-4. Modify the config file ```conf/yarn.conf``` or create your own config file, the ```gearpump.yarn.client.hdfsRoot``` should point to the hdfs folder just created.
+4. Put the YARN configurations under classpath.
+  Before calling "yarnclient launch", make sure you have put all yarn configuration files under classpath.
+  Typically, you can just copy all files under $HADOOP_HOME/etc/hadoop from one of the YARN Cluster machine to conf/yarnconf of gearpump.
+  $HADOOP_HOME points to the Hadoop installation directory. 
 5. Get Kerberos credentials to sumbit the job:
 
    ```
@@ -42,7 +45,7 @@ Suppose user ```gearpump``` will launch gearpump on YARN, then the corresponding
    Here you can login with keytab or password, please refer Kerberos's document for details.
     
    ``` bash
-   bin/yarnclient -version gearpump-pack-2.11.5-{{ site.GEARPUMP_VERSION }} -config conf/yarn.conf
+   yarnclient launch -package /usr/lib/gearpump/gearpump-${version}.zip
    ```
   
 ## How to write to secured HBase

--- a/docs/deployment-yarn.md
+++ b/docs/deployment-yarn.md
@@ -6,18 +6,19 @@ title: Deployment with YARN
 
 ### How to launch a Gearpump cluster on YARN
 
-1. Upload the gearpump-${version}.zip to remote HDFS Folder, suggest to put it under /user/gearpump/gearpump-version.zip
-2. Put the YARN configurations under classpath.
+1. Upload the gearpump-${version}.zip to remote HDFS Folder, suggest to put it under /usr/lib/gearpump/gearpump-${version}.zip
+2. Make sure the home directory on Hdfs is already created and all read-write rights are granted for user, for example, user ```gear```'s home directory is ```/user/gear```
+3. Put the YARN configurations under classpath.
   Before calling "yarnclient launch", make sure you have put all yarn configuration files under classpath.
   Typically, you can just copy all files under $HADOOP_HOME/etc/hadoop from one of the YARN Cluster machine to conf/yarnconf of gearpump.
   $HADOOP_HOME points to the Hadoop installation directory. 
-3. Launch the gearpump cluster on YARN
+4. Launch the gearpump cluster on YARN
   ```bash
-    yarnclient launch -package /user/gearpump/gearpump-version.zip
+    yarnclient launch -package /usr/lib/gearpump/gearpump-${version}.zip
   ```
   If you don't specify package path, it will read default package-path from gear.conf(gearpump.yarn.client.package-path).
-4. Before step 3, You can change gear.conf configuration section "gearpump.yarn" to config the cluster.
-5. After launching, you can browser the Gearpump UI via YARN resource manager dashboard.
+5. Before step 4, You can change gear.conf configuration section "gearpump.yarn" to config the cluster.
+6. After launching, you can browser the Gearpump UI via YARN resource manager dashboard.
 
 ### How to submit a application to Gearpump cluster.
 
@@ -27,7 +28,7 @@ a active configuration file first.
 There are two ways to get an active configuration file:
 1. Option 1: specify "-output" option when you launch the cluster.
   ```bash
-    yarnclient launch -package /user/gearpump/gearpump-${version}.zip -output /tmp/mycluster.conf
+    yarnclient launch -package /usr/lib/gearpump/gearpump-${version}.zip -output /tmp/mycluster.conf
    ```
    It will return in console like this:
    ```bash

--- a/experiments/yarn/README.md
+++ b/experiments/yarn/README.md
@@ -2,18 +2,19 @@
 
 ### How to launch a Gearpump cluster on YARN
 
-1. Upload the gearpump-${version}.zip to remote HDFS Folder, suggest to put it under /user/gearpump/gearpump-version.zip
-2. Put the YARN configurations under classpath.
+1. Upload the gearpump-${version}.zip to remote HDFS Folder, suggest to put it under /usr/lib/gearpump/gearpump-${version}.zip
+2. Make sure the home directory on Hdfs is already created and all read-write rights are granted for user, for example, user ```gear```'s home directory is ```/user/gear```
+3. Put the YARN configurations under classpath.
   Before calling "yarnclient launch", make sure you have put all yarn configuration files under classpath.
   Typically, you can just copy all files under $HADOOP_HOME/etc/hadoop from one of the YARN Cluster machine to conf/yarnconf of gearpump.
   $HADOOP_HOME points to the Hadoop installation directory. 
-3. Launch the gearpump cluster on YARN
+4. Launch the gearpump cluster on YARN
   ```bash
-    yarnclient launch -package /user/gearpump/gearpump-version.zip
+    yarnclient launch -package /usr/lib/gearpump/gearpump-${version}.zip
   ```
   If you don't specify package path, it will read default package-path from gear.conf(gearpump.yarn.client.package-path).
-4. Before step 3, You can change gear.conf configuration section "gearpump.yarn" to config the cluster.
-5. After launching, you can browser the Gearpump UI via YARN resource manager dashboard.
+5. Before step 4, You can change gear.conf configuration section "gearpump.yarn" to config the cluster.
+6. After launching, you can browser the Gearpump UI via YARN resource manager dashboard.
 
 ### How to submit a application to Gearpump cluster.
 
@@ -23,7 +24,7 @@ a active configuration file first.
 There are two ways to get an active configuration file:
 1. Option 1: specify "-output" option when you launch the cluster.
   ```bash
-    yarnclient launch -package /user/gearpump/gearpump-${version}.zip -output /tmp/mycluster.conf
+    yarnclient launch -package /usr/lib/gearpump/gearpump-${version}.zip -output /tmp/mycluster.conf
    ```
    It will return in console like this:
    ```bash

--- a/experiments/yarn/src/main/resources/reference.conf
+++ b/experiments/yarn/src/main/resources/reference.conf
@@ -4,7 +4,7 @@ gearpump {
   ###########################
   yarn {
     client {
-      package-path = "/user/gearpump/gearpump.zip"
+      package-path = "/usr/lib/gearpump/gearpump.zip"
     }
 
     applicationmaster {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -49,6 +49,7 @@ object Build extends sbt.Build {
   val chillVersion = "0.6.0"
 
   val distDirectory = "output"
+  val projectName = "gearpump"
 
   override def projects: Seq[Project] = (super.projects.toList ++ BuildExample.projects.toList
       ++ Pack.projects.toList).toSeq

--- a/project/Pack.scala
+++ b/project/Pack.scala
@@ -80,7 +80,7 @@ object Pack extends sbt.Build {
             "storm" -> stormClassPath
           ),
 
-          packArchivePrefix := name.value + "-" + scalaVersion.value
+          packArchivePrefix := projectName + "-" + scalaBinaryVersion.value
 
         )
   ).dependsOn(core, streaming, services, yarn, storm)


### PR DESCRIPTION
The original archive name is like ```gearpump-pack-2.11.5-0.7.1-SNAPSHOT.tar.gz```,
 now it will be ```gearpump-2.11-0.7.1-SNAPSHOT.tar.gz```