### PR TITLE
fix #1772, When upload application in UI, custom config file is not effective

### DIFF
--- a/daemon/src/main/scala/io/gearpump/util/FileDirective.scala
+++ b/daemon/src/main/scala/io/gearpump/util/FileDirective.scala
@@ -97,7 +97,9 @@ object FileDirective {
       entity(as[Multipart.FormData]) { (formdata: Multipart.FormData) =>
         val fileNameMap = formdata.parts.mapAsync(1) { p =>
           if (p.filename.isDefined) {
-            val targetPath = File.createTempFile(s"userfile_${p.name}_${p.filename.getOrElse("")}", "", rootDirectory)
+
+            //reserve the suffix
+            val targetPath = File.createTempFile(s"userfile_${p.name}_", s"${p.filename.getOrElse("")}", rootDirectory)
             val written = p.entity.dataBytes.runWith(SynchronousFileSink(targetPath))
             written.map(written =>
               if (written > 0) {


### PR DESCRIPTION
Looks like the Typesafe config will check the file suffix.