### PR TITLE
fix #1808, configurable timeout setting for starting a new executor system

### DIFF
--- a/conf/gear.conf
+++ b/conf/gear.conf
@@ -148,6 +148,10 @@ gearpump {
     http = 8090
   }
 
+  ## Time out setting to start a new executor system
+  ## It takes a bit longer time than expected as a new JVM is created
+  start-executor-system-timeout-ms = 30000
+
   #############################################
   ## Default Configuration for Gearpump Netty transport layer
   ## If you don't know what is this about, don't change it

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -14,6 +14,10 @@ gearpump {
   ## The installation folder of gearpump
   home = ""
 
+  ## Time out setting to start a new executor system
+  ## It takes a bit longer time than expected as a new JVM is created
+  start-executor-system-timeout-ms = 30000
+
   ###########################
   ### Metrics setting,
   ### If you want to use metrics, please change

--- a/core/src/main/scala/io/gearpump/cluster/appmaster/ExecutorSystemLauncher.scala
+++ b/core/src/main/scala/io/gearpump/cluster/appmaster/ExecutorSystemLauncher.scala
@@ -22,7 +22,7 @@ import akka.actor._
 import io.gearpump.cluster.AppMasterToWorker.LaunchExecutor
 import io.gearpump.cluster.ExecutorJVMConfig
 import io.gearpump.cluster.scheduler.Resource
-import io.gearpump.util.{ActorSystemBooter, ActorUtil, LogUtil}
+import io.gearpump.util.{Constants, ActorSystemBooter, ActorUtil, LogUtil}
 import io.gearpump.cluster.WorkerToAppMaster._
 import io.gearpump.cluster.appmaster.ExecutorSystemLauncher._
 import io.gearpump.cluster.appmaster.ExecutorSystemScheduler.{ExecutorSystemJvmConfig, Session}
@@ -46,7 +46,11 @@ class ExecutorSystemLauncher (appId: Int, session: Session) extends Actor {
 
   val scheduler = context.system.scheduler
   implicit val executionContext = context.dispatcher
-  val timeout = scheduler.scheduleOnce(15 seconds, self, LaunchExecutorSystemTimeout(session))
+
+  val timeoutSetting = context.system.settings.config.getInt(Constants.GEARPUMP_START_EXECUTOR_SYSTEM_TIMEOUT_MS)
+
+  val timeout = scheduler.scheduleOnce(timeoutSetting milliseconds,
+    self, LaunchExecutorSystemTimeout(session))
 
   def receive : Receive = waitForLaunchCommand
 

--- a/core/src/main/scala/io/gearpump/util/Constants.scala
+++ b/core/src/main/scala/io/gearpump/util/Constants.scala
@@ -67,6 +67,8 @@ object Constants {
   // please use your local timeout setting instead.
   val FUTURE_TIMEOUT = akka.util.Timeout(15, TimeUnit.SECONDS)
 
+  val GEARPUMP_START_EXECUTOR_SYSTEM_TIMEOUT_MS = "gearpump.start-executor-system-timeout-ms"
+
   val APPMASTER_DEFAULT_EXECUTOR_ID = -1
 
   val NETTY_BUFFER_SIZE = "gearpump.netty.buffer-size"


### PR DESCRIPTION
On a extreme slow machine, like aws nano instance(500MB memory, 1 core), it may take a long period of time to start a new JVM, sometimes more than 20 seconds.

We should allow the timeout setting to start a new executor system JVM configurable.