### PR TITLE
fix #1779: non-source processors will not calculate receive latency 

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -286,8 +286,8 @@ object Build extends sbt.Build {
       "org.webjars.bower" % "ng-file-upload" % "5.0.9",
       "org.webjars.bower" % "vis" % "4.7.0",
       "org.webjars.bower" % "clipboard.js" % "0.1.1",
-      "org.webjars.npm" % "dashing-deps" % "0.0.8",
-      "org.webjars.npm" % "dashing" % "0.3.8"
+      "org.webjars.npm" % "dashing-deps" % "0.1.2",
+      "org.webjars.npm" % "dashing" % "0.4.0"
   ).map(_.exclude("org.scalamacros", "quasiquotes_2.10")).map(_.exclude("org.scalamacros", "quasiquotes_2.10.3")))
 
   lazy val serviceJSSettings = Seq(

--- a/services/dashboard/index.html
+++ b/services/dashboard/index.html
@@ -17,10 +17,10 @@
   <link rel="stylesheet" href="webjars/angular-ui-select/0.13.2/dist/select.min.css"/>
   <link rel="stylesheet" href="webjars/angular-loading-bar/0.8.0/build/loading-bar.min.css"/>
   <link rel="stylesheet" href="webjars/vis/4.7.0/dist/vis.min.css"/>
-  <link rel="stylesheet" href="webjars/dashing/0.3.8/dist/dashing.min.css"/>
+  <link rel="stylesheet" href="webjars/dashing/0.4.0/dist/dashing.min.css"/>
 
   <!-- Site styles -->
-  <link rel="stylesheet" href="webjars/dashing-deps/0.0.8/roboto/roboto.min.css"/>
+  <link rel="stylesheet" href="webjars/dashing-deps/0.1.2/roboto/roboto.min.css"/>
   <link rel="stylesheet" href="webjars/font-awesome/4.5.0/css/font-awesome.min.css"/>
   <link rel="stylesheet" href="styles/bootstrap-override.css"/>
   <link rel="stylesheet" href="styles/bootstrap-doc.css"/><!-- todo: should be absorbed -->
@@ -59,8 +59,8 @@
 <script src="webjars/ng-file-upload/5.0.9/ng-file-upload-shim.min.js"></script>
 <script src="webjars/ng-file-upload/5.0.9/ng-file-upload.min.js"></script>
 <script src="webjars/clipboard.js/0.1.1/clipboard.js"></script>
-<script src="webjars/dashing-deps/0.0.8/echarts/2.2.7-compact/echarts-all.min.js"></script>
-<script src="webjars/dashing/0.3.8/dist/dashing.min.js"></script>
+<script src="webjars/dashing-deps/0.1.2/echarts/2.2.7-compact/echarts-all.min.js"></script>
+<script src="webjars/dashing/0.4.0/dist/dashing.min.js"></script>
 
 <!-- Application -->
 <script src="dashboard.js"></script>

--- a/services/dashboard/styles/bootstrap-override.css
+++ b/services/dashboard/styles/bootstrap-override.css
@@ -54,20 +54,6 @@ html, body {
   padding-right: 7px;
 }
 
-/* Remove 1px border from stripped table (2 rules) */
-.table-striped tbody > tr:first-child td {
-  border-top: 0 none transparent;
-}
-
-.table-striped thead > tr > th {
-  border-bottom: 0 none transparent;
-}
-
-/* Table header column should not be wrapped */
-.table thead > tr > th {
-  white-space: nowrap;
-}
-
 /* Increase the distance of table footer and table body */
 .table tfoot > tr > td {
   padding: 14px 0 0;

--- a/services/dashboard/styles/dashboard.css
+++ b/services/dashboard/styles/dashboard.css
@@ -3,16 +3,6 @@
  * See accompanying LICENSE file.
  */
 
-/* Reset to use specified fonts */
-* {
-  font-family: lato, roboto, 'helvetica neue', 'segoe ui', arial, helvetica, sans-serif;
-}
-
-/* Set default font size (depends on the font face) */
-body, .form-control {
-  font-size: 13px;
-}
-
 /* bolder text */
 .bold {
   font-weight: 500;
@@ -140,4 +130,18 @@ h4, table > caption {
   padding: 3px 6px;
   position: relative;
   top: -2px;
+}
+
+/* Empty table description (3 rules) */
+.table-no-data {
+  padding-bottom: 20px;
+}
+
+.table-no-data .glyphicon,
+.table-no-data-sm .glyphicon {
+  color: #bbb;
+}
+
+.table-no-data-sm .glyphicon {
+  margin-right: 6px;
 }

--- a/services/dashboard/views/apps/apps.html
+++ b/services/dashboard/views/apps/apps.html
@@ -1,7 +1,7 @@
 <div class="col-md-12">
   <!-- control toolbar -->
   <div class="row">
-    <div class="col-md-6">
+    <div class="col-md-6 col-sm-6">
       <span class="table-caption-ext pull-left">Applications</span>
       <!-- dropdown button -->
       <div class="btn-group">
@@ -14,9 +14,10 @@
         </button>
       </div>
     </div>
-    <div class="col-md-3">
+    <div class="col-md-3 col-sm-6 text-right">
+       <!--FILTER-->
     </div>
-    <div class="col-md-3 hidden-sm hidden-xs pull-right">
+    <div class="col-md-3 hidden-sm hidden-xs">
       <searchbox ng-model="search" placeholder="Search Anything"></searchbox>
     </div>
   </div>
@@ -29,5 +30,10 @@
     records-bind="appsTable.rows"
     search-bind="search"
     pagination="10">
+    <div class="table-no-data">
+      <h2 class="glyphicon glyphicon-bullhorn"></h2>
+      <h4>No application is running</h4>
+      <p>Please submit an user application first.</p>
+    </div>
   </sortable-table>
 </div>

--- a/services/dashboard/views/apps/streamingapp/metrics_charts.js
+++ b/services/dashboard/views/apps/streamingapp/metrics_charts.js
@@ -76,7 +76,8 @@ angular.module('dashboard')
             } else {
               $scope[chartNameBase + 'HistChartOptions'] =
                 angular.extend({}, $scope[chartNameBase+ 'ChartOptions'], {
-                  visibleDataPointsNum: Math.max(chartData.length, histChartPoints),
+                  visibleDataPointsNum: chartData.length ?
+                    Math.max(chartData.length, histChartPoints) : 0, // 0 means to show "no data" animation
                   data: chartData
                 });
             }
@@ -89,6 +90,7 @@ angular.module('dashboard')
           var queryMetricsPromise = $scope.showCurrentMetrics ?
             models.$get.appMetrics($scope.app.appId, $scope.metricsConfig.retainRecentDataIntervalMs) :
             models.$get.appHistMetrics($scope.app.appId);
+
           queryMetricsPromise.then(function(metrics) {
             var data = metrics.$data();
             _batch('sendThroughput', 'toHistoricalMessageSendThroughputData', data);

--- a/services/dashboard/views/apps/streamingapp/metrics_table.html
+++ b/services/dashboard/views/apps/streamingapp/metrics_table.html
@@ -15,22 +15,18 @@
 </div>
 
 <div class="col-md-12">
-  <ng-switch on="metricType">
-    <!-- meter -->
-    <sortable-table
-      ng-switch-when="meter"
-      search-bind="search"
-      columns-bind="meterMetricsTable.cols"
-      records-bind="meterMetricsTable.rows"
-      pagination="10">
-    </sortable-table>
-    <!-- histogram -->
-    <sortable-table
-      ng-switch-when="histogram"
+  <sortable-table
+    ng-if="metricType == 'meter'"
+    search-bind="search"
+    columns-bind="meterMetricsTable.cols"
+    records-bind="meterMetricsTable.rows"
+    pagination="10">
+  </sortable-table>
+  <sortable-table
+    ng-if="metricType == 'histogram'"
       search-bind="search"
       columns-bind="histogramMetricsTable.cols"
       records-bind="histogramMetricsTable.rows"
       pagination="10">
-    </sortable-table>
-  </ng-switch>
+  </sortable-table>
 </div>

--- a/services/dashboard/views/apps/streamingapp/processor.js
+++ b/services/dashboard/views/apps/streamingapp/processor.js
@@ -121,8 +121,8 @@ angular.module('dashboard')
             options: {
               height: '110px',
               seriesNames: [''],
-              barMinWidth: 2,
-              barMinSpacing: 2,
+              barMinWidth: 4,
+              barMinSpacing: 1,
               valueFormatter: function(value) {
                 var unit = $scope.metricType === 'meter' ? 'msg/s' : 'ms';
                 return helper.metricValue(value) + ' ' + unit;
@@ -143,7 +143,7 @@ angular.module('dashboard')
 
         var i = 0;
         var metricField = $scope.metricType === 'meter' ? 'movingAverage1m' : 'mean';
-        _.forEach(metrics, function(metric, taskId) {
+        _.forEach(metrics, function(metric) {
           data[i].y = metric[metricField]
           ;
           i++;

--- a/services/dashboard/views/apps/streamingapp/processor_task_table.html
+++ b/services/dashboard/views/apps/streamingapp/processor_task_table.html
@@ -1,18 +1,14 @@
 <div>
-  <ng-switch on="metricType">
-    <!-- meter -->
-    <sortable-table
-      ng-switch-when="meter"
-      columns-bind="meterMetricsTable.cols"
-      records-bind="meterMetricsTable.rows"
-      pagination="10">
-    </sortable-table>
-    <!-- histogram -->
-    <sortable-table
-      ng-switch-when="histogram"
-      columns-bind="histogramMetricsTable.cols"
-      records-bind="histogramMetricsTable.rows"
-      pagination="10">
-    </sortable-table>
-  </ng-switch>
+  <sortable-table
+    ng-if="metricType == 'meter'"
+    columns-bind="meterMetricsTable.cols"
+    records-bind="meterMetricsTable.rows"
+    pagination="10">
+  </sortable-table>
+  <sortable-table
+    ng-if="metricType == 'histogram'"
+    columns-bind="histogramMetricsTable.cols"
+    records-bind="histogramMetricsTable.rows"
+    pagination="10">
+  </sortable-table>
 </div>

--- a/services/dashboard/views/cluster/workers/worker/worker.html
+++ b/services/dashboard/views/cluster/workers/worker/worker.html
@@ -41,6 +41,10 @@
     columns-bind="executorsTable.cols"
     records-bind="executorsTable.rows"
     pagination="4">
+    <div class="table-no-data-sm">
+      <h5><span class="glyphicon glyphicon-bullhorn"></span>
+        No application is running on this worker</h5>
+    </div>
   </sortable-table>
 </div>
 

--- a/services/dashboard/views/cluster/workers/workers_listview.html
+++ b/services/dashboard/views/cluster/workers/workers_listview.html
@@ -1,10 +1,10 @@
 <div class="col-md-12">
   <!-- control toolbar -->
   <div class="row">
-    <div class="col-md-9">
+    <div class="col-md-6">
       <span class="table-caption-ext">Worker Instances</span>
     </div>
-    <div class="col-md-3 hidden-sm hidden-xs pull-right">
+    <div class="col-md-3 col-md-offset-3 hidden-sm hidden-xs">
       <searchbox ng-model="search" placeholder="Search Anything"></searchbox>
     </div>
   </div>
@@ -17,5 +17,10 @@
     records-bind="workersTable.rows"
     search-bind="search"
     pagination="10">
+    <div class="table-no-data">
+      <h2 class="glyphicon glyphicon-bullhorn"></h2>
+      <h4>No worker instance is running</h4>
+      <p>Please contact your administrator to launch worker for applications.</p>
+    </div>
   </sortable-table>
 </div>

--- a/services/dashboard/views/cluster/workers/workers_listview.js
+++ b/services/dashboard/views/cluster/workers/workers_listview.js
@@ -31,16 +31,14 @@ angular.module('dashboard')
         cols: [
           // group 1/3 (4-col)
           $stb.indicator().key('state').canSort('state.condition+"_"+aliveFor').styleClass('td-no-padding').done(),
-          $stb.link('ID').key('id').canSort().styleClass('col-md-1').done(),
-          $stb.text('Address').key('akkaAddr').canSort().sortDefault().styleClass('col-md-1').done(),
-          $stb.text('JVM Info').key('jvm').canSort()
+          $stb.link('ID').key('id').canSort().sortDefaultDescent().styleClass('col-md-1').done(),
+          $stb.text('Address').key('akkaAddr').canSort().styleClass('col-md-1').done(),
+          $stb.text('JVM Info').key('jvm')
             .help('Format: PID@hostname')
             .styleClass('col-md-2 hidden-xs').done(),
           // group 2/3 (5-col)
           $stb.number('Executors').key('executors').canSort().styleClass('col-md-1 hidden-xs').done(),
-          $stb.progressbar('Slots Usage').key('slots').sortBy('slots.usage')
-            .help('Slot is a minimal compute unit. The usage indicates the computation capacity.')
-            .styleClass('col-md-1').done(),
+          $stb.progressbar('Slots Usage').key('slots').sortBy('slots.usage').styleClass('col-md-1').done(),
           $stb.duration('Uptime').key('aliveFor').canSort().styleClass('col-md-3 hidden-sm hidden-xs').done(),
           // group 3/3 (3-col)
           $stb.button('Quick Links').key(['detail', 'conf']).styleClass('col-md-3').done()


### PR DESCRIPTION
the PR also includes some UI changes:

1. Chart's tooltip will disappear when mouse is out of the chart control area
2. Empty table (e.g. empty application list table) now has a better description panel
3. Click on table column's sort arrow will have animation effect 
4. Pagination control would not update when the table is showing some search results.
5. The first hour application will not receive any historical metrics, so the chart for "Past 72 Hours" will show "No Graph Data Available".