### PR TITLE
fix #1868: show correct data points when switch current and past view

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -290,7 +290,7 @@ object Build extends sbt.Build {
       "org.webjars.bower" % "vis" % "4.7.0",
       "org.webjars.bower" % "clipboard.js" % "0.1.1",
       "org.webjars.npm" % "dashing-deps" % "0.1.2",
-      "org.webjars.npm" % "dashing" % "0.4.0"
+      "org.webjars.npm" % "dashing" % "0.4.1"
   ).map(_.exclude("org.scalamacros", "quasiquotes_2.10")).map(_.exclude("org.scalamacros", "quasiquotes_2.10.3")))
 
   lazy val serviceJSSettings = Seq(

--- a/services/dashboard/dashboard.js
+++ b/services/dashboard/dashboard.js
@@ -82,12 +82,13 @@ angular.module('dashboard', [
   .run(['$modal', 'HealthCheckService', 'conf', function($modal, HealthCheckService, conf) {
     'use strict';
 
+    var dialog = $modal({
+      templateUrl: 'views/service_unreachable_notice.html',
+      backdrop: 'static',
+      show: false
+    });
+
     var showDialogFn = function() {
-      var dialog = $modal({
-        templateUrl: 'views/service_unreachable_notice.html',
-        backdrop: 'static',
-        show: false
-      });
       dialog.$promise.then(dialog.show);
     };
 

--- a/services/dashboard/index.html
+++ b/services/dashboard/index.html
@@ -17,7 +17,7 @@
   <link rel="stylesheet" href="webjars/angular-ui-select/0.13.2/dist/select.min.css"/>
   <link rel="stylesheet" href="webjars/angular-loading-bar/0.8.0/build/loading-bar.min.css"/>
   <link rel="stylesheet" href="webjars/vis/4.7.0/dist/vis.min.css"/>
-  <link rel="stylesheet" href="webjars/dashing/0.4.0/dist/dashing.min.css"/>
+  <link rel="stylesheet" href="webjars/dashing/0.4.1/dist/dashing.min.css"/>
 
   <!-- Site styles -->
   <link rel="stylesheet" href="webjars/dashing-deps/0.1.2/roboto/roboto.min.css"/>
@@ -63,7 +63,7 @@
 <script src="webjars/ng-file-upload/5.0.9/ng-file-upload.min.js"></script>
 <script src="webjars/clipboard.js/0.1.1/clipboard.js"></script>
 <script src="webjars/dashing-deps/0.1.2/echarts/2.2.7-compact/echarts-all.min.js"></script>
-<script src="webjars/dashing/0.4.0/dist/dashing.min.js"></script>
+<script src="webjars/dashing/0.4.1/dist/dashing.min.js"></script>
 
 <!-- Application -->
 <script src="dashboard.js"></script>
@@ -84,7 +84,7 @@
 <script src="views/cluster/master/master.js"></script>
 <script src="views/cluster/workers/workers_listview.js"></script>
 <script src="views/cluster/workers/worker/worker.js"></script>
-<script src="views/jvm/jvm_metrics.js"></script>
+<script src="views/jvm/jvm_metrics_view.js"></script>
 <script src="views/apps/apps.js"></script>
 <script src="views/apps/compose/compose.js"></script>
 <script src="views/apps/compose/popups/choose_processor.js"></script>

--- a/services/dashboard/services/models/dag.js
+++ b/services/dashboard/services/models/dag.js
@@ -46,11 +46,11 @@ angular.module('io.gearpump.models')
 
       /** Return the number of processors on the longest path. */
       hierarchyDepth: function() {
-        return _.max(_.pluck(this.processors, 'hierarchy'));
+        return _.max(_.map(this.processors, 'hierarchy'));
       },
 
       _getProcessorIdsByTopologicalOrdering: function() {
-        return _(this.processors).sortBy('hierarchy').pluck('id').value();
+        return _(this.processors).sortBy('hierarchy').map('id').value();
       },
 
       _getPredecessorIds: function() {
@@ -112,10 +112,10 @@ angular.module('io.gearpump.models')
         }, this);
 
         // find the critical path latency
-        var criticalPathLatency = _.max(_.pluck(candidates, 'latency'));
+        var criticalPathLatency = _.max(_.map(candidates, 'latency'));
 
         // find the critical paths
-        var criticalPaths = _.pluck(_.pick(candidates, function(candidate) {
+        var criticalPaths = _.map(_.pick(candidates, function(candidate) {
           return candidate.latency === criticalPathLatency;
         }), 'path');
 

--- a/services/dashboard/services/models/models.js
+++ b/services/dashboard/services/models/models.js
@@ -198,7 +198,7 @@ angular.module('io.gearpump.models', [])
           }
 
           // upickle conversion 2a: convert array to dictionary
-          obj.executors = _.object(_.pluck(obj.executors, 'executorId'), obj.executors);
+          obj.executors = _.object(_.map(obj.executors, 'executorId'), obj.executors);
 
           // upickle conversion 2b: add extra executor properties and methods
           _.forEach(obj.executors, function(executor) {
@@ -247,7 +247,7 @@ angular.module('io.gearpump.models', [])
         appStallingTasks: function(wrapper) {
           var result = _.groupBy(wrapper.tasks, 'processorId');
           _.forEach(result, function(processor, processorId) {
-            result[processorId] = _.pluck(processor, 'index');
+            result[processorId] = _.map(processor, 'index');
           });
           return result;
         },
@@ -467,7 +467,8 @@ angular.module('io.gearpump.models', [])
               return onComplete(response);
             });
           });
-        }
+        },
+        DAG_DEATH_UNSPECIFIED: '9223372036854775807' /* Long.max */
       };
     }])
 ;

--- a/services/dashboard/styles/dashboard.css
+++ b/services/dashboard/styles/dashboard.css
@@ -34,10 +34,6 @@ body {
   margin-bottom: 6px;
 }
 
-.metric-chart-placeholder {
-  min-height: 108px;
-}
-
 /* For dashing widget "indicator" shape="stripe", need to remove parent element padding (2 rules) */
 th.td-no-padding {
   padding-left: 0 !important;

--- a/services/dashboard/views/apps/compose/compose.js
+++ b/services/dashboard/views/apps/compose/compose.js
@@ -127,7 +127,7 @@ angular.module('dashboard')
           .filter(function(edge) {
             return processorId == edge.from || processorId == edge.to;
           })
-          .pluck('id')
+          .map('id')
           .value();
         $scope.visGraph.data.edges.remove(edgeIds);
       }
@@ -173,7 +173,7 @@ angular.module('dashboard')
             }];
           }),
           dag: {
-            vertexList: _.pluck(processors, 'id'),
+            vertexList: _.map(processors, 'id'),
             edgeList: edges.map(function(edge) {
               return [edge.from, edge.partitionerClass, edge.to]
             })

--- a/services/dashboard/views/apps/streamingapp/executor.html
+++ b/services/dashboard/views/apps/streamingapp/executor.html
@@ -8,8 +8,8 @@
 </div>
 
 <div class="col-md-6">
-  <jvm-metrics
+  <jvm-metrics-view
     sampling-config="metricsConfig"
     query-metrics-fn-ref="queryMetricsFnRef">
-  </jvm-metrics>
+  </jvm-metrics-view>
 </div>

--- a/services/dashboard/views/apps/streamingapp/metrics_charts.html
+++ b/services/dashboard/views/apps/streamingapp/metrics_charts.html
@@ -2,7 +2,7 @@
   <div class="col-md-12">
     <metrics-period-switcher
       past-hours="metricsConfig.retainHistoryDataHours"
-      view-current="showCurrentMetrics">
+      view-current="isShowingCurrentMetrics">
     </metrics-period-switcher>
   </div>
 </div>
@@ -17,17 +17,10 @@
         sub-text="Total: {{totalSentMessages|metric}}">
       </metrics>
     </div>
-    <div ng-if="showCurrentMetrics">
+    <div>
       <line-chart
-        options-bind="::sendThroughputChartOptions"
-        datasource-bind="sendThroughputData">
-      </line-chart>
-    </div>
-    <div ng-hide="showCurrentMetrics"
-         class="metric-chart-placeholder">
-      <line-chart
-        ng-if="sendThroughputHistChartOptions != null"
-        options-bind="::sendThroughputHistChartOptions">
+        options-bind="sendThroughputChart.options"
+        datasource-bind="sendThroughputChart.data">
       </line-chart>
     </div>
   </div>
@@ -41,17 +34,10 @@
         sub-text="Total: {{totalReceivedMessages|metric}}">
       </metrics>
     </div>
-    <div ng-if="showCurrentMetrics">
+    <div>
       <line-chart
-        options-bind="::receiveThroughputChartOptions"
-        datasource-bind="receiveThroughputData">
-      </line-chart>
-    </div>
-    <div ng-hide="showCurrentMetrics"
-         class="metric-chart-placeholder">
-      <line-chart
-        ng-if="receiveThroughputHistChartOptions != null"
-        options-bind="receiveThroughputHistChartOptions">
+        options-bind="receiveThroughputChart.options"
+        datasource-bind="receiveThroughputChart.data">
       </line-chart>
     </div>
   </div>
@@ -64,17 +50,10 @@
         value="{{messageReceiveLatency|metric}}" unit="ms">
       </metrics>
     </div>
-    <div ng-if="showCurrentMetrics">
+    <div>
       <line-chart
-        options-bind="::messageReceiveLatencyChartOptions"
-        datasource-bind="messageReceiveLatencyData">
-      </line-chart>
-    </div>
-    <div ng-hide="showCurrentMetrics"
-         class="metric-chart-placeholder">
-      <line-chart
-        ng-if="messageReceiveLatencyHistChartOptions != null"
-        options-bind="messageReceiveLatencyHistChartOptions">
+        options-bind="messageReceiveLatencyChart.options"
+        datasource-bind="messageReceiveLatencyChart.data">
       </line-chart>
     </div>
   </div>
@@ -87,17 +66,10 @@
         value="{{averageProcessingTime|metric}}" unit="ms">
       </metrics>
     </div>
-    <div ng-if="showCurrentMetrics">
+    <div>
       <line-chart
-        options-bind="::averageProcessingTimeChartOptions"
-        datasource-bind="averageProcessingTimeData">
-      </line-chart>
-    </div>
-    <div ng-hide="showCurrentMetrics"
-         class="metric-chart-placeholder">
-      <line-chart
-        ng-if="averageProcessingTimeHistChartOptions != null"
-        options-bind="averageProcessingTimeHistChartOptions">
+        options-bind="averageProcessingTimeChart.options"
+        datasource-bind="averageProcessingTimeChart.data">
       </line-chart>
     </div>
   </div>

--- a/services/dashboard/views/apps/streamingapp/popups/dag_edit.js
+++ b/services/dashboard/views/apps/streamingapp/popups/dag_edit.js
@@ -4,8 +4,8 @@
  */
 angular.module('dashboard')
 
-  .controller('StreamingAppDagEditCtrl', ['$scope',
-    function($scope) {
+  .controller('StreamingAppDagEditCtrl', ['$scope', 'models',
+    function($scope, models) {
       'use strict';
 
       var options = $scope.modifyOptions || {};
@@ -48,7 +48,7 @@ angular.module('dashboard')
           var transitUnixTime = moment(timeString).valueOf();
           newProcessor.life = {
             birth: transitUnixTime.toString(),
-            death: '9223372036854775807' /* Long.max */
+            death: models.DAG_DEATH_UNSPECIFIED
           };
         }
 

--- a/services/dashboard/views/apps/streamingapp/processor.html
+++ b/services/dashboard/views/apps/streamingapp/processor.html
@@ -51,7 +51,7 @@
           <div style="height: 110px">
             <bar-chart
               ng-if="tasksBarChart != null"
-              options-bind="::tasksBarChart.options"
+              options-bind="tasksBarChart.options"
               datasource-bind="tasksBarChart.data">
             </bar-chart>
           </div>

--- a/services/dashboard/views/cluster/master/master.html
+++ b/services/dashboard/views/cluster/master/master.html
@@ -8,8 +8,8 @@
 </div>
 
 <div class="col-md-6">
-  <jvm-metrics
+  <jvm-metrics-view
     sampling-config="metricsConfig"
     query-metrics-fn-ref="queryMetricsFnRef">
-  </jvm-metrics>
+  </jvm-metrics-view>
 </div>

--- a/services/dashboard/views/cluster/workers/worker/worker.html
+++ b/services/dashboard/views/cluster/workers/worker/worker.html
@@ -49,8 +49,8 @@
 </div>
 
 <div class="col-md-6">
-  <jvm-metrics
+  <jvm-metrics-view
     sampling-config="metricsConfig"
     query-metrics-fn-ref="queryMetricsFnRef">
-  </jvm-metrics>
+  </jvm-metrics-view>
 </div>

--- a/services/dashboard/views/helper.js
+++ b/services/dashboard/views/helper.js
@@ -6,7 +6,7 @@
 angular.module('dashboard')
 
 /** Provides widgets/directive related helper functions */
-  .factory('helper', ['$filter', function($filter) {
+  .factory('helper', ['$filter', '$echarts', function($filter, $echarts) {
     'use strict';
 
     return {
@@ -29,8 +29,11 @@ angular.module('dashboard')
       },
       /* Return a readable metric value. */
       readableMetricValue: function(value) {
-        var precision = Math.abs(value) < 100 ? 2 : 0;
-        return $filter('number')(value, precision);
+        if (angular.isNumber(value)) {
+          var precision = Math.abs(value) < 100 ? 2 : 0;
+          return $filter('number')(value, precision);
+        }
+        return value;
       },
       /* Make metric precision consistent */
       metricRounded: function(value) {
@@ -39,6 +42,10 @@ angular.module('dashboard')
       /* Create a proper chart time label for echart */
       timeToChartTimeLabel: function(time, shortForm) {
         return moment(time).format(shortForm ? 'HH:mm:ss': 'ddd DD, HH:mm');
+      },
+      /* Return a y-axis label formatter that will not show 0 on y-axis */
+      yAxisLabelFormatterWithoutValue0: function(unit) {
+        return $echarts.axisLabelFormatter(unit, {0: ''});
       }
     };
   }])

--- a/services/dashboard/views/jvm/jvm_metrics_view.html
+++ b/services/dashboard/views/jvm/jvm_metrics_view.html
@@ -9,7 +9,7 @@
   <div class="col-md-12">
     <metrics-period-switcher
       past-hours="samplingConfig.retainHistoryDataHours"
-      view-current="showCurrentMetrics">
+      view-current="isShowingCurrentMetrics">
     </metrics-period-switcher>
   </div>
 </div>
@@ -17,16 +17,9 @@
 <div class="row">
   <div class="col-md-12">
     <h5>Memory Usage</h5>
-
-    <div ng-if="showCurrentMetrics">
-      <line-chart
-        options-bind="::memoryRecentUsageChart.options"
-        datasource-bind="memoryRecentUsageChart.data"></line-chart>
-    </div>
-    <div>
-      <line-chart
-        ng-if="memoryHistUsageChartOptions != null"
-        options-bind="::memoryHistUsageChartOptions"></line-chart>
-    </div>
+    <line-chart
+      options-bind="memoryUsageChart.options"
+      datasource-bind="memoryUsageChart.data">
+    </line-chart>
   </div>
 </div>


### PR DESCRIPTION
The RP also includes:

1. Overhauled the chart implementation, so that we can show different set of data points (of past view and current view) in single chart instance.
2. Show past data points in chart, when there are at least 2 data points
3. Renamed `jvm-metrics` to `jvm-metrics-view`, which is for better code understanding
4. Changed `_.pluck` to `_.map` regarding lodash's suggestion
5. Created a constant `DAG_DEATH_UNSPEICIFED` instead of using a magic number
6. Health check dialog might be invisible in some case.