### PR TITLE
fix #1837, Use java.net.preferIPv4Stack to force IPv4

### DIFF
--- a/core/src/main/scala/io/gearpump/util/Constants.scala
+++ b/core/src/main/scala/io/gearpump/util/Constants.scala
@@ -147,4 +147,6 @@ object Constants {
   val GEARPUMP_UI_SECURITY = "gearpump.ui-security"
   val GEARPUMP_UI_SECURITY_ENABLED = "gearpump.ui-security.authentication-enabled"
   val GEARPUMP_UI_AUTHENTICATOR_CLASS = "gearpump.ui-security.authenticator"
+
+  val PREFER_IPV4 = "java.net.preferIPv4Stack"
 }

--- a/daemon/src/main/scala/io/gearpump/cluster/worker/Worker.scala
+++ b/daemon/src/main/scala/io/gearpump/cluster/worker/Worker.scala
@@ -399,8 +399,10 @@ private[cluster] object Worker {
           List.empty[String]
         }
 
+        val ipv4 = List(s"-D${PREFER_IPV4}=true")
+
         val options = ctx.jvmArguments ++ host ++ username ++
-          logArgs ++ remoteDebugConfig ++ verboseGCConfig ++ configArgs
+          logArgs ++ remoteDebugConfig ++ verboseGCConfig ++ ipv4 ++ configArgs
 
         LOG.info(s"Launch executor, classpath: ${classPath.mkString(File.pathSeparator)}")
         val process = Util.startProcess(options, classPath, ctx.mainClass, ctx.arguments)

--- a/daemon/src/test/scala/io/gearpump/cluster/main/MainSpec.scala
+++ b/daemon/src/test/scala/io/gearpump/cluster/main/MainSpec.scala
@@ -63,8 +63,12 @@ class MainSpec extends FlatSpec with Matchers with BeforeAndAfterEach with Maste
 
     val tempTestConf = convertTestConf(getHost, getPort)
 
+    val options = Array(
+      s"-D$GEARPUMP_CUSTOM_CONFIG_FILE=${tempTestConf.toString}",
+      s"-D${PREFER_IPV4}=true"
+    ) ++ getMasterListOption()
 
-    val worker = Util.startProcess(Array(s"-D$GEARPUMP_CUSTOM_CONFIG_FILE=${tempTestConf.toString}") ++ getMasterListOption(),
+    val worker = Util.startProcess(options,
       getContextClassPath,
       getMainClassName(Worker),
       Array.empty)
@@ -141,7 +145,8 @@ class MainSpec extends FlatSpec with Matchers with BeforeAndAfterEach with Maste
   "Local" should "be started without exception" in {
     val port = Util.findFreePort.get
     val options = Array(s"-D${Constants.GEARPUMP_CLUSTER_MASTERS}.0=$getHost:$port",
-      s"-D${Constants.GEARPUMP_HOSTNAME}=$getHost")
+      s"-D${Constants.GEARPUMP_HOSTNAME}=$getHost",
+      s"-D${PREFER_IPV4}=true")
 
     val local = Util.startProcess(options,
       getContextClassPath,

--- a/experiments/storm/src/main/scala/io/gearpump/experiments/storm/StormRunner.scala
+++ b/experiments/storm/src/main/scala/io/gearpump/experiments/storm/StormRunner.scala
@@ -32,6 +32,7 @@ import io.gearpump.experiments.storm.Commands.{GetClusterInfo, _}
 import io.gearpump.experiments.storm.topology.GearpumpStormTopology
 import io.gearpump.experiments.storm.util.{GraphBuilder, StormConstants}
 import io.gearpump.streaming.StreamApplication
+import io.gearpump.util.Constants._
 import io.gearpump.util.{AkkaApp, Constants, LogUtil, Util}
 
 import scala.collection.JavaConverters._
@@ -68,7 +69,8 @@ object StormRunner extends AkkaApp with ArgumentsParser {
 
     val stormOptions = Array("-Dstorm.options=" +
       s"${Config.NIMBUS_HOST}=127.0.0.1,${Config.NIMBUS_THRIFT_PORT}=${GearpumpThriftServer.THRIFT_PORT}",
-      "-Dstorm.jar=" + jar
+      "-Dstorm.jar=" + jar,
+      s"-D${PREFER_IPV4}=true"
     )
 
     val classPath = Array(System.getProperty("java.class.path"), jar)

--- a/project/Pack.scala
+++ b/project/Pack.scala
@@ -43,7 +43,8 @@ object Pack extends sbt.Build {
     settings = commonSettings ++ noPublish  ++
         packSettings ++
         Seq(
-          packMain := Map("gear" -> "io.gearpump.cluster.main.Gear",
+          packMain := Map(
+            "gear" -> "io.gearpump.cluster.main.Gear",
             "local" -> "io.gearpump.cluster.main.Local",
             "master" -> "io.gearpump.cluster.main.Master",
             "worker" -> "io.gearpump.cluster.main.Worker",
@@ -52,12 +53,13 @@ object Pack extends sbt.Build {
             "storm" -> "io.gearpump.experiments.storm.StormRunner"
           ),
           packJvmOpts := Map(
-            "local" -> Seq("-server", "-DlogFilename=local", "-Dgearpump.home=${PROG_HOME}", "-Djava.rmi.server.hostname=localhost"),
-            "master" -> Seq("-server", "-DlogFilename=master", "-Dgearpump.home=${PROG_HOME}", "-Djava.rmi.server.hostname=localhost"),
-            "worker" -> Seq("-server", "-DlogFilename=worker", "-Dgearpump.home=${PROG_HOME}", "-Djava.rmi.server.hostname=localhost"),
-            "services" -> Seq("-server", "-Dgearpump.home=${PROG_HOME}", "-Djava.rmi.server.hostname=localhost"),
-            "yarnclient" -> Seq("-server", "-Dgearpump.home=${PROG_HOME}", "-Djava.rmi.server.hostname=localhost"),
-            "storm" -> Seq("-server", "-Dgearpump.home=${PROG_HOME}", "-Djava.rmi.server.hostname=localhost")
+            "gear" -> Seq("-Djava.net.preferIPv4Stack=true", "-Dgearpump.home=${PROG_HOME}"),
+            "local" -> Seq("-server", "-Djava.net.preferIPv4Stack=true", "-DlogFilename=local", "-Dgearpump.home=${PROG_HOME}", "-Djava.rmi.server.hostname=localhost"),
+            "master" -> Seq("-server", "-Djava.net.preferIPv4Stack=true", "-DlogFilename=master", "-Dgearpump.home=${PROG_HOME}", "-Djava.rmi.server.hostname=localhost"),
+            "worker" -> Seq("-server", "-Djava.net.preferIPv4Stack=true", "-DlogFilename=worker", "-Dgearpump.home=${PROG_HOME}", "-Djava.rmi.server.hostname=localhost"),
+            "services" -> Seq("-server", "-Djava.net.preferIPv4Stack=true", "-Dgearpump.home=${PROG_HOME}", "-Djava.rmi.server.hostname=localhost"),
+            "yarnclient" -> Seq("-server", "-Djava.net.preferIPv4Stack=true", "-Dgearpump.home=${PROG_HOME}", "-Djava.rmi.server.hostname=localhost"),
+            "storm" -> Seq("-server", "-Djava.net.preferIPv4Stack=true", "-Dgearpump.home=${PROG_HOME}", "-Djava.rmi.server.hostname=localhost")
           ),
           packLibDir := Map(
             "lib" -> new ProjectsToPack(core.id, streaming.id),

--- a/services/jvm/src/main/scala/io/gearpump/services/MasterService.scala
+++ b/services/jvm/src/main/scala/io/gearpump/services/MasterService.scala
@@ -40,6 +40,7 @@ import io.gearpump.jarstore.JarStoreService
 import io.gearpump.partitioner.{PartitionerByClassName, PartitionerDescription}
 import io.gearpump.streaming.{ProcessorDescription, ProcessorId, StreamApplication}
 import io.gearpump.util.ActorUtil.{askActor, _}
+import io.gearpump.util.Constants._
 import io.gearpump.util.FileDirective._
 import io.gearpump.util.{Graph, Constants, Util, FileUtils}
 import io.gearpump.util.ActorUtil._
@@ -203,7 +204,8 @@ object MasterService {
 
       val hostname = sysConfig.getString(Constants.GEARPUMP_HOSTNAME)
       var options = Array(
-        s"-D${Constants.GEARPUMP_HOSTNAME}=$hostname"
+        s"-D${Constants.GEARPUMP_HOSTNAME}=$hostname",
+        s"-D${PREFER_IPV4}=true"
       ) ++ mastersOption
 
       if (userConf.isDefined) {


### PR DESCRIPTION
Reason:
1. Be consistent with hadoop.
2. Avoid confusion in configuring hostname and master address.