### PR TITLE
[fix:1994]unified external package name

### DIFF
--- a/external/hbase/src/main/scala/io/gearpump/streaming/hbase/HBaseSink.scala
+++ b/external/hbase/src/main/scala/io/gearpump/streaming/hbase/HBaseSink.scala
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gearpump.external.hbase
+package io.gearpump.streaming.hbase
 
 import java.io.{File, ObjectInputStream, ObjectOutputStream}
 

--- a/external/hbase/src/main/scala/io/gearpump/streaming/hbase/dsl/HBaseDSLSink.scala
+++ b/external/hbase/src/main/scala/io/gearpump/streaming/hbase/dsl/HBaseDSLSink.scala
@@ -15,11 +15,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gearpump.external.hbase.dsl
+package io.gearpump.streaming.hbase.dsl
 
+import io.gearpump.streaming.hbase.HBaseSink
 import org.apache.hadoop.conf.Configuration
 import io.gearpump.cluster.UserConfig
-import io.gearpump.external.hbase.HBaseSink
 import io.gearpump.streaming.dsl.Stream
 import Stream.Sink
 

--- a/external/hbase/src/test/scala/io/gearpump/streaming/hbase/HBaseSinkSpec.scala
+++ b/external/hbase/src/test/scala/io/gearpump/streaming/hbase/HBaseSinkSpec.scala
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gearpump.external.hbase
+package io.gearpump.streaming.hbase
 
 import org.apache.hadoop.hbase.client.{HTable, Put}
 import org.apache.hadoop.hbase.util.Bytes


### PR DESCRIPTION
In external modules , I found HBase's package is difference with other's .

I try to update it package name from io.gearpump.external.hbase to io.gearpump.streaming.hbase , make external package names are the same :dancer: 