### PR TITLE
fix #1641, add exactly-once it

### DIFF
--- a/examples/streaming/kafka/src/main/scala/io/gearpump/streaming/examples/kafka/wordcount/KafkaWordCount.scala
+++ b/examples/streaming/kafka/src/main/scala/io/gearpump/streaming/examples/kafka/wordcount/KafkaWordCount.scala
@@ -37,10 +37,10 @@ object KafkaWordCount extends AkkaApp with ArgumentsParser {
   private val LOG: Logger = LogUtil.getLogger(getClass)
 
   override val options: Array[(String, CLIOption[Any])] = Array(
-    "source" -> CLIOption[Int]("<hom many kafka producer tasks>", required = false, defaultValue = Some(1)),
+    "source" -> CLIOption[Int]("<how many kafka source tasks>", required = false, defaultValue = Some(1)),
     "split" -> CLIOption[Int]("<how many split tasks>", required = false, defaultValue = Some(1)),
     "sum" -> CLIOption[Int]("<how many sum tasks>", required = false, defaultValue = Some(1)),
-    "sink" -> CLIOption[Int]("<hom many kafka processor tasks", required = false, defaultValue = Some(1))
+    "sink" -> CLIOption[Int]("<how many kafka sink tasks>", required = false, defaultValue = Some(1))
     )
 
   def application(config: ParseResult, system: ActorSystem) : StreamApplication = {

--- a/examples/streaming/state/src/main/scala/io/gearpump/streaming/examples/state/processor/CountProcessor.scala
+++ b/examples/streaming/state/src/main/scala/io/gearpump/streaming/examples/state/processor/CountProcessor.scala
@@ -27,15 +27,15 @@ import io.gearpump.cluster.UserConfig
 import io.gearpump.Message
 
 class CountProcessor(taskContext: TaskContext, conf: UserConfig)
-  extends PersistentTask[Long](taskContext, conf) {
+  extends PersistentTask[Int](taskContext, conf) {
 
-  override def persistentState: PersistentState[Long] = {
-    import com.twitter.algebird.Monoid.longMonoid
-    new NonWindowState[Long](new AlgebirdMonoid(longMonoid), new ChillSerializer[Long])
+  override def persistentState: PersistentState[Int] = {
+    import com.twitter.algebird.Monoid.intMonoid
+    new NonWindowState[Int](new AlgebirdMonoid(intMonoid), new ChillSerializer[Int])
   }
 
-  override def processMessage(state: PersistentState[Long], message: Message): Unit = {
-    state.update(message.timestamp, 1L)
+  override def processMessage(state: PersistentState[Int], message: Message): Unit = {
+    state.update(message.timestamp, 1)
   }
 }
 

--- a/examples/streaming/state/src/test/scala/io/gearpump/streaming/examples/state/MessageCountAppSpec.scala
+++ b/examples/streaming/state/src/test/scala/io/gearpump/streaming/examples/state/MessageCountAppSpec.scala
@@ -18,11 +18,13 @@
 
 package io.gearpump.streaming.examples.state
 
+import io.gearpump.streaming.examples.state.MessageCountApp._
 import io.gearpump.cluster.ClientToMaster.SubmitApplication
 import io.gearpump.cluster.MasterToClient.SubmitApplicationResult
 import io.gearpump.cluster.{MasterHarness, TestUtil}
 import org.scalatest.{Matchers, BeforeAndAfter, PropSpec}
 import org.scalatest.prop.PropertyChecks
+
 
 import scala.concurrent.Future
 import scala.util.Success
@@ -40,10 +42,17 @@ class MessageCountAppSpec extends PropSpec with PropertyChecks with Matchers wit
   override def config = TestUtil.DEFAULT_CONFIG
 
   property("MessageCount should succeed to submit application with required arguments") {
-    val requiredArgs = Array.empty[String]
+    val requiredArgs = Array(
+      s"-$SOURCE_TOPIC", "source",
+      s"-$SINK_TOPIC", "sink",
+      s"-$ZOOKEEPER_CONNECT", "localhost:2181",
+      s"-$BROKER_LIST", "localhost:9092",
+      s"-$DEFAULT_FS", "hdfs://localhost:9000"
+    )
     val optionalArgs = Array(
-      "-gen", "2",
-      "-count", "2"
+      s"-$SOURCE_TASK", "2",
+      s"-$COUNT_TASK", "2",
+      s"-$SINK_TASK", "2"
     )
 
     val args = {
@@ -51,9 +60,11 @@ class MessageCountAppSpec extends PropSpec with PropertyChecks with Matchers wit
         ("requiredArgs", "optionalArgs"),
         (requiredArgs, optionalArgs.take(0)),
         (requiredArgs, optionalArgs.take(2)),
+        (requiredArgs, optionalArgs.take(4)),
         (requiredArgs, optionalArgs)
       )
     }
+
     val masterReceiver = createMockMaster()
     forAll(args) { (requiredArgs: Array[String], optionalArgs: Array[String]) =>
       val args = requiredArgs ++ optionalArgs

--- a/integrationtest/core/src/it/scala/io/gearpump/integrationtest/checklist/MessageDeliverySpec.scala
+++ b/integrationtest/core/src/it/scala/io/gearpump/integrationtest/checklist/MessageDeliverySpec.scala
@@ -1,0 +1,78 @@
+package io.gearpump.integrationtest.checklist
+
+import io.gearpump.integrationtest.hadoop.HadoopCluster._
+import io.gearpump.integrationtest.{Util, TestSpecBase}
+import io.gearpump.integrationtest.kafka.{SimpleKafkaReader, MessageLossDetector, NumericalDataProducer}
+import io.gearpump.integrationtest.kafka.KafkaCluster._
+
+class MessageDeliverySpec extends TestSpecBase {
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+  }
+
+  override def afterAll(): Unit = {
+    super.afterAll()
+  }
+
+  override def afterEach() = {
+    super.afterEach()
+  }
+
+  "Gearpump" should {
+    "support exactly-once message delivery" in {
+      withKafkaCluster(cluster) { kafkaCluster =>
+        // setup
+        val sourcePartitionNum = 1
+        val sourceTopic = "topic1"
+        val sinkTopic = "topic2"
+
+        // Generate number sequence (1, 2, 3, ...) to the topic
+        kafkaCluster.createTopic(sourceTopic, sourcePartitionNum)
+
+        withDataProducer(sourceTopic, kafkaCluster.getBrokerListConnectString) { producer =>
+
+          withHadoopCluster { hadoopCluster =>
+            // exercise
+            val args = Array("io.gearpump.streaming.examples.state.MessageCountApp",
+              "-defaultFS", hadoopCluster.getDefaultFS,
+              "-zookeeperConnect", kafkaCluster.getZookeeperConnectString,
+              "-brokerList", kafkaCluster.getBrokerListConnectString,
+              "-sourceTopic", sourceTopic,
+              "-sinkTopic", sinkTopic,
+              "-sourceTask", sourcePartitionNum).mkString(" ")
+            val appId = restClient.getNextAvailableAppId()
+
+            val stateJar = cluster.queryBuiltInExampleJars("state-").head
+            val success = restClient.submitApp(stateJar, args)
+            success shouldBe true
+
+            // verify #1
+            expectAppIsRunning(appId, "MessageCount")
+            Util.retryUntil(restClient.queryStreamingAppDetail(appId).clock > 0)
+
+            // wait for checkpoint to take place
+            Thread.sleep(1000)
+
+            // verify #2
+            val executorToKill = restClient.queryExecutorBrief(appId).map(_.executorId).max
+            restClient.killExecutor(appId, executorToKill) shouldBe true
+            Util.retryUntil(restClient.queryExecutorBrief(appId).map(_.executorId).max > executorToKill)
+
+            producer.stop()
+
+            // verify #3
+            val count = kafkaCluster.getLatestOffset(sourceTopic) + 1
+            val detector = new MessageLossDetector(count)
+            val kafkaReader = new SimpleKafkaReader(detector, sinkTopic,
+              host = kafkaCluster.advertisedHost, port = kafkaCluster.advertisedPort)
+            Util.retryUntil({
+              kafkaReader.read()
+              detector.received(count)
+            })
+          }
+        }
+      }
+    }
+  }
+}

--- a/integrationtest/core/src/it/scala/io/gearpump/integrationtest/checklist/StormCompatibilitySpec.scala
+++ b/integrationtest/core/src/it/scala/io/gearpump/integrationtest/checklist/StormCompatibilitySpec.scala
@@ -17,7 +17,7 @@
  */
 package io.gearpump.integrationtest.checklist
 
-import io.gearpump.integrationtest.kafka.{KafkaCluster, MessageLossDetector, NumericalDataProducer, SimpleKafkaReader}
+import io.gearpump.integrationtest.kafka.{KafkaCluster, MessageLossDetector, SimpleKafkaReader}
 import io.gearpump.integrationtest.storm.StormClient
 import io.gearpump.integrationtest.{TestSpecBase, Util}
 
@@ -41,27 +41,6 @@ class StormCompatibilitySpec extends TestSpecBase {
   def withStorm(testCode: String => Unit): Unit = {
     testCode("09")
     testCode("010")
-  }
-
-  def withKafkaCluster(testCode: KafkaCluster => Unit): Unit = {
-    val kafkaCluster = new KafkaCluster(cluster.getNetworkGateway, "kafka")
-    try {
-      kafkaCluster.start()
-      testCode(kafkaCluster)
-    } finally {
-      kafkaCluster.shutDown()
-    }
-  }
-
-  def withDataProducer(topic: String, brokerList: String)
-      (testCode: NumericalDataProducer => Unit): Unit = {
-    val producer = new NumericalDataProducer(topic, brokerList)
-    try {
-      producer.start()
-      testCode(producer)
-    } finally {
-      producer.stop()
-    }
   }
 
   def getTopologyName(name: String, stormVersion: String): String = {
@@ -146,7 +125,8 @@ class StormCompatibilitySpec extends TestSpecBase {
         val topologyName = getTopologyName("storm_kafka", stormVersion)
         val stormKafkaTopology = s"io.gearpump.integrationtest.storm.Storm${stormVersion}KafkaTopology"
 
-        withKafkaCluster {
+        import KafkaCluster._
+        withKafkaCluster(cluster) {
           kafkaCluster =>
             val sourcePartitionNum = 2
             val sinkPartitionNum = 1

--- a/integrationtest/core/src/it/scala/io/gearpump/integrationtest/suites/StandaloneModeSuite.scala
+++ b/integrationtest/core/src/it/scala/io/gearpump/integrationtest/suites/StandaloneModeSuite.scala
@@ -33,7 +33,8 @@ class StandaloneModeSuite extends Suites(
   new ExampleSpec,
   new DynamicDagSpec,
   new StabilitySpec,
-  new StormCompatibilitySpec
+  new StormCompatibilitySpec,
+  new MessageDeliverySpec
 
 ) with BeforeAndAfterAll {
 

--- a/integrationtest/core/src/main/scala/io/gearpump/integrationtest/hadoop/HadoopCluster.scala
+++ b/integrationtest/core/src/main/scala/io/gearpump/integrationtest/hadoop/HadoopCluster.scala
@@ -1,0 +1,41 @@
+package io.gearpump.integrationtest.hadoop
+
+import io.gearpump.integrationtest.Docker
+import org.apache.log4j.Logger
+
+object HadoopCluster {
+
+  def withHadoopCluster(testCode: HadoopCluster => Unit): Unit = {
+    val hadoopCluster = new HadoopCluster
+    try {
+      hadoopCluster.start()
+      testCode(hadoopCluster)
+    } finally {
+      hadoopCluster.shutDown()
+    }
+  }
+}
+/**
+ * This class maintains a single node Hadoop cluster
+ */
+class HadoopCluster {
+
+  private val LOG = Logger.getLogger(getClass)
+  private val HADOOP_DOCKER_IMAGE = "sequenceiq/hadoop-docker:2.6.0"
+  private val HADOOP_HOST = "hadoop0"
+
+  def start(): Unit = {
+    Docker.createAndStartContainer(HADOOP_HOST, HADOOP_DOCKER_IMAGE, "")
+    LOG.info("Hadoop cluster is started.")
+  }
+
+  def getDefaultFS: String = {
+    val hostIPAddr = Docker.getContainerIPAddr(HADOOP_HOST)
+    s"hdfs://$hostIPAddr:9000"
+  }
+
+  def shutDown(): Unit = {
+    Docker.killAndRemoveContainer(HADOOP_HOST)
+  }
+
+}

--- a/integrationtest/core/src/main/scala/io/gearpump/integrationtest/kafka/KafkaCluster.scala
+++ b/integrationtest/core/src/main/scala/io/gearpump/integrationtest/kafka/KafkaCluster.scala
@@ -17,8 +17,34 @@
  */
 package io.gearpump.integrationtest.kafka
 
+import io.gearpump.integrationtest.minicluster.MiniCluster
 import io.gearpump.integrationtest.{Docker, Util}
 import org.apache.log4j.Logger
+
+object KafkaCluster {
+
+  def withKafkaCluster(cluster: MiniCluster)(testCode: KafkaCluster => Unit): Unit = {
+    val kafkaCluster = new KafkaCluster(cluster.getNetworkGateway, "kafka")
+    try {
+      kafkaCluster.start()
+      testCode(kafkaCluster)
+    } finally {
+      kafkaCluster.shutDown()
+    }
+  }
+
+  def withDataProducer(topic: String, brokerList: String)
+                      (testCode: NumericalDataProducer => Unit): Unit = {
+    val producer = new NumericalDataProducer(topic, brokerList)
+    try {
+      producer.start()
+      testCode(producer)
+    } finally {
+      producer.stop()
+    }
+  }
+
+}
 
 /**
  * This class maintains a single node Kafka cluster with integrated Zookeeper.

--- a/integrationtest/core/src/main/scala/io/gearpump/integrationtest/kafka/NumericalDataProducer.scala
+++ b/integrationtest/core/src/main/scala/io/gearpump/integrationtest/kafka/NumericalDataProducer.scala
@@ -19,7 +19,7 @@ package io.gearpump.integrationtest.kafka
 
 import java.util.Properties
 
-import com.twitter.bijection.Injection
+import io.gearpump.streaming.serializer.ChillSerializer
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord}
 import org.apache.kafka.common.serialization.ByteArraySerializer
 import org.apache.log4j.Logger
@@ -29,6 +29,7 @@ class NumericalDataProducer(topic: String, bootstrapServers: String) {
   private val LOG = Logger.getLogger(getClass)
   private val producer = createProducer
   private val WRITE_SLEEP_NANOS = 10
+  private val serializer = new ChillSerializer[Int]
   var lastWriteNum = 0
 
   def start(): Unit = {
@@ -54,7 +55,7 @@ class NumericalDataProducer(topic: String, bootstrapServers: String) {
       try {
         while (!Thread.currentThread.isInterrupted) {
           lastWriteNum += 1
-          val msg = Injection[String, Array[Byte]](lastWriteNum.toString)
+          val msg = serializer.serialize(lastWriteNum)
           val record = new ProducerRecord[Array[Byte], Array[Byte]](topic, msg)
           producer.send(record)
           Thread.sleep(0, WRITE_SLEEP_NANOS)

--- a/integrationtest/core/src/main/scala/io/gearpump/integrationtest/kafka/ResultVerifier.scala
+++ b/integrationtest/core/src/main/scala/io/gearpump/integrationtest/kafka/ResultVerifier.scala
@@ -20,19 +20,22 @@ package io.gearpump.integrationtest.kafka
 import scala.collection.mutable
 
 trait ResultVerifier {
-  def onNext(msg: String): Unit
+  def onNext(num: Int): Unit
 }
 
 class MessageLossDetector(totalNum: Int) extends ResultVerifier {
   private val bitSets = new mutable.BitSet(totalNum)
 
-  override def onNext(msg: String): Unit = {
-    val num = msg.toInt
+  override def onNext(num: Int): Unit = {
     bitSets.add(num)
   }
 
   def allReceived: Boolean = {
     1.to(totalNum).forall(bitSets)
+  }
+
+  def received(num: Int): Boolean = {
+    bitSets(num)
   }
 
 }

--- a/project/BuildExample.scala
+++ b/project/BuildExample.scala
@@ -176,7 +176,7 @@ object BuildExample extends sbt.Build {
       target in assembly := baseDirectory.value.getParentFile.getParentFile / "target" /
           CrossVersion.binaryScalaVersion(scalaVersion.value)
     )
-  ) dependsOn (streaming % "test->test; provided", external_hadoopfs, external_monoid, external_serializer)
+  ) dependsOn (streaming % "test->test; provided", external_hadoopfs, external_monoid, external_serializer, external_kafka)
 
   lazy val pagerank = Project(
     id = "gearpump-examples-pagerank",

--- a/project/BuildIntegrationTest.scala
+++ b/project/BuildIntegrationTest.scala
@@ -34,7 +34,8 @@ object BuildIntegrationTest extends sbt.Build {
         streaming % "test->test; provided",
         services % "test->test; provided",
         external_kafka,
-        storm
+        storm,
+        external_serializer
       )
 
   // integration test for Storm 0.9.x


### PR DESCRIPTION
1. add exactly-once integration test using `MessageCountApp` example .
2. add `sequenceiq/hadoop-docker:2.6.0` image which is required for checkpoint storage.
3. `MessageCountApp` is turned into `KafkaSource ~> Count ~> KafkaSink` pipeline such that we are able to feed input and verify output through Kafka.
4. `CountProcessor` counts the number of input messages and output the count after checkpoint. If the final count is correct on system failures, then exactly-once message delivery is guaranteed.
5. `PersistentTask` periodically sends a `CHECKPOINT` message to try committing checkpoint. The benefits are 
        - avoid checking `upstreamMinClock` on each input message
        - able to check `upstreamMinClock` and try committing checkpoint even if there no more input messages
6. checkpoint is committed synchronously which will introduce performance impact. I'd like to fix it in the following up PR.
7. it's hard-coded to output state after checkpoint. Another follow up is to provide users with a trigger API. 