### PR TITLE
fix GEARPUMP-2, Define REST API to submit job jar

### DIFF
--- a/daemon/src/main/scala/io/gearpump/util/FileDirective.scala
+++ b/daemon/src/main/scala/io/gearpump/util/FileDirective.scala
@@ -26,6 +26,7 @@ import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server._
 import akka.stream.Materializer
 import akka.stream.scaladsl.FileIO
+import akka.util.ByteString
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -52,12 +53,31 @@ object FileDirective {
    */
   case class FileInfo(originFileName: String, file: File, length: Long)
 
+  class Form(val fields: Map[Name, FormField]) {
+    def getFile(fieldName: String): Option[FileInfo] = {
+      fields.get(fieldName).flatMap {
+        case Left(file) => Option(file)
+        case Right(_) => None
+      }
+    }
+
+    def getValue(fieldName: String): Option[String] = {
+      fields.get(fieldName).flatMap {
+        case Left(_) => None
+        case Right(value) => Option(value)
+      }
+    }
+  }
+
+  type FormField = Either[FileInfo, String]
+
+
   /**
    * directive to uploadFile, it store the uploaded files
    * to temporary directory, and return a Map from form field name
    * to FileInfo.
    */
-  def uploadFile: Directive1[Map[Name, FileInfo]] = {
+  def uploadFile: Directive1[Form] = {
     uploadFileTo(null)
   }
 
@@ -67,16 +87,14 @@ object FileDirective {
    * @param rootDirectory directory to store the files.
    * @return
    */
-  def uploadFileTo(rootDirectory: File): Directive1[Map[Name, FileInfo]] = {
-    Directive[Tuple1[Map[Name, FileInfo]]] { inner =>
+  def uploadFileTo(rootDirectory: File): Directive1[Form] = {
+    Directive[Tuple1[Form]] { inner =>
       extractMaterializer {implicit mat =>
         extractExecutionContext {implicit ec =>
           uploadFileImpl(rootDirectory)(mat, ec) { filesFuture =>
             ctx => {
               filesFuture.map(map => inner(Tuple1(map))).flatMap(route => route(ctx))
             }
-
-
           }
         }
       }
@@ -94,10 +112,10 @@ object FileDirective {
     complete(responseEntity)
   }
 
-  private def uploadFileImpl(rootDirectory: File)(implicit mat: Materializer, ec: ExecutionContext): Directive1[Future[Map[Name, FileInfo]]] = {
-    Directive[Tuple1[Future[Map[Name, FileInfo]]]] { inner =>
+  private def uploadFileImpl(rootDirectory: File)(implicit mat: Materializer, ec: ExecutionContext): Directive1[Future[Form]] = {
+    Directive[Tuple1[Future[Form]]] { inner =>
       entity(as[Multipart.FormData]) { (formdata: Multipart.FormData) =>
-        val fileNameMap = formdata.parts.mapAsync(1) { p =>
+        val form = formdata.parts.mapAsync(1) { p =>
           if (p.filename.isDefined) {
 
             //reserve the suffix
@@ -105,15 +123,23 @@ object FileDirective {
             val written = p.entity.dataBytes.runWith(FileIO.toFile(targetPath))
             written.map(written =>
               if (written.count > 0) {
-                Map(p.name -> FileInfo(p.filename.get, targetPath, written.count))
+                Map(p.name -> Left(FileInfo(p.filename.get, targetPath, written.count)))
               } else {
-                Map.empty[Name, FileInfo]
+                Map.empty[Name, FormField]
               })
           } else {
-            Future(Map.empty[Name, FileInfo])
+            val valueFuture = p.entity.dataBytes.runFold(ByteString.empty){(total, input) =>
+              total ++ input
+            }
+            valueFuture.map{value =>
+              Map(p.name -> Right(value.utf8String))
+            }
           }
-        }.runFold(Map.empty[Name, FileInfo])((set, value) => set ++ value)
-        inner(Tuple1(fileNameMap))
+        }.runFold(new Form(Map.empty[Name, FormField])){(set, value) =>
+          new Form(set.fields ++ value)
+        }
+
+        inner(Tuple1(form))
       }
     }
   }

--- a/docs/dev-rest-api.md
+++ b/docs/dev-rest-api.md
@@ -304,6 +304,92 @@ Sample Response:
 }
 ```
 
+### POST api/v1.0/master/submitapp
+Submit a streaming job jar to Gearpump cluster. It functions like command line
+```
+gear app -jar xx.jar -conf yy.conf -executors 1 <command line arguments>
+```
+
+Required MIME type: "multipart/form-data"
+
+Required post form fields:
+
+1. field name "jar", job jar file.
+
+Optional post form fields:
+
+1. "configfile", configuration file, in UTF8 format.
+2. "configstring", text body of configuration file, in UTF8 format.
+3. "executorcount", The count of JVM process to start across the cluster for this application job
+4. "args", command line arguments for this job jar.
+
+Example html:
+
+```bash
+<form id="submitapp" action="http://127.0.0.1:8090/api/v1.0/master/submitapp"
+method="POST" enctype="multipart/form-data">
+ 
+Job Jar (*.jar) [Required]:  <br/>
+<input type="file" name="jar"/> <br/> <br/>
+ 
+Config file (*.conf) [Optional]:  <br/>
+<input type="file" name="configfile"/> <br/>  <br/>
+ 
+Config String, Config File in string format. [Optional]: <br/>
+<input type="text" name="configstring" value="a.b.c.d=1"/> <br/><br/>
+ 
+Executor count (integer, how many process to start for this streaming job) [Optional]: <br/>
+<input type="text" name="executorcount" value="1"/> <br/><br/>
+ 
+Application arguments (String) [Optional]: <br/>
+<input type="text" name="args" value=""/> <br/><br/>
+ 
+<input type="submit" value="Submit"/>
+ 
+</table>
+ 
+</form>
+```
+
+### POST api/v1.0/master/submitstormapp
+Submit a storm jar to Gearpump cluster. It functions like command line
+```
+storm app -jar xx.jar -conf yy.yaml <command line arguments>
+```
+
+Required MIME type: "multipart/form-data"
+
+Required post form fields:
+
+1. field name "jar", job jar file.
+
+Optional post form fields:
+
+1. "configfile", .yaml configuration file, in UTF8 format.
+2. "args", command line arguments for this job jar.
+
+Example html:
+
+```bash
+<form id="submitstormapp" action="http://127.0.0.1:8090/api/v1.0/master/submitstormapp"
+method="POST" enctype="multipart/form-data">
+ 
+Job Jar (*.jar) [Required]:  <br/>
+<input type="file" name="jar"/> <br/> <br/>
+ 
+Config file (*.yaml) [Optional]:  <br/>
+<input type="file" name="configfile"/> <br/>  <br/>
+
+Application arguments (String) [Optional]: <br/>
+<input type="text" name="args" value=""/> <br/><br/>
+ 
+<input type="submit" value="Submit"/>
+ 
+</table>
+ 
+</form>
+```
+
 ## Worker service
 
 ### GET api/v1.0/worker/&lt;workerId&gt;

--- a/integrationtest/core/src/main/scala/io/gearpump/integrationtest/minicluster/RestClient.scala
+++ b/integrationtest/core/src/main/scala/io/gearpump/integrationtest/minicluster/RestClient.scala
@@ -89,13 +89,18 @@ class RestClient(host: String, port: Int) {
 
   def submitApp(jar: String, executorNum: Int, args: String = "", config: String = ""): Boolean = try {
     var endpoint = "master/submitapp"
-    if (args.length > 0) {
-      endpoint += s"?executorNum=${executorNum}&args=" + Util.encodeUriComponent(args)
-    }
+
     var options = Seq(s"jar=@$jar")
     if (config.length > 0) {
       options :+= s"conf=@$config"
     }
+
+    options :+= s"executorcount=$executorNum"
+
+    if (args != null && !args.isEmpty) {
+      options :+= "args=\"" + args + "\""
+    }
+
     val resp = callApi(endpoint, options.map("-F " + _).mkString(" "))
     val result = decodeAs[AppSubmissionResult](resp)
     assert(result.success)

--- a/services/dashboard/services/restapi.js
+++ b/services/dashboard/services/restapi.js
@@ -118,9 +118,9 @@ angular.module('dashboard')
         },
 
         /** Submit an user defined application with user configuration */
-        submitUserApp: function(files, formFormNames, executorNum, args, onComplete) {
+        submitUserApp: function(files, fileFieldNames, executorNum, args, onComplete) {
           return self._submitApp(restapiV1Root + 'master/submitapp',
-            files, formFormNames, executorNum, args, onComplete);
+            files, fileFieldNames, executorNum, args, onComplete);
         },
 
         /** Submit a Storm application */
@@ -129,13 +129,16 @@ angular.module('dashboard')
             files, formFormNames, executorNum, args, onComplete);
         },
 
-        _submitApp: function(url, files, formFormNames, executorNum, args, onComplete) {
-          var params = '?executorNum=' + executorNum + '&args=' + encodeURIComponent(args);
+        _submitApp: function(url, files, fileFieldNames, executorNum, args, onComplete) {
           var upload = Upload.upload({
-            url: url + params,
+            url: url,
             method: 'POST',
             file: files,
-            fileFormDataName: formFormNames
+            fileFormDataName: fileFieldNames,
+            fields: {
+              "executorcount": executorNum,
+              "args": args
+            }
           });
 
           upload.then(function(response) {

--- a/services/dashboard/views/apps/submit/submit.html
+++ b/services/dashboard/views/apps/submit/submit.html
@@ -41,7 +41,8 @@
               ng-model="conf" accept-pattern="{{confFileSuffix}}"></form-control>
             <!-- input 3 -->
             <form-control
-              type="integer" min="1" label="Executor Number" ng-hide="isStormApp"
+              type="integer" min="1" label="Executor Count" ng-hide="isStormApp"
+              help="How many JVM processes to start for this job in the whole cluster. E.g. set it as 12 will start 12 executor processes spanning across the cluster"
               ng-model="executorNum"></form-control>
             <!-- input 4 -->
             <form-control

--- a/services/dashboard/views/apps/submit/submit.js
+++ b/services/dashboard/views/apps/submit/submit.js
@@ -27,7 +27,7 @@ angular.module('dashboard')
         var fileFormNames = ['jar'];
         if ($scope.conf) {
           files.push($scope.conf);
-          fileFormNames.push('conf');
+          fileFormNames.push('configfile');
         }
         $scope.uploading = true;
         submitFn(files, fileFormNames, $scope.executorNum, $scope.launchArgs, function(response) {

--- a/services/jvm/src/main/scala/io/gearpump/services/AppMasterService.scala
+++ b/services/jvm/src/main/scala/io/gearpump/services/AppMasterService.scala
@@ -67,8 +67,9 @@ class AppMasterService(val master: ActorRef,
         val msg = java.net.URLDecoder.decode(args)
         val dagOperation = read[DAGOperation](msg)
         (post & entity(as[Multipart.FormData])) { _ =>
-        uploadFile { fileMap =>
-          val jar = fileMap.get("jar").map(_.file)
+        uploadFile { form =>
+          val jar = form.getFile("jar").map(_.file)
+
           if (jar.nonEmpty) {
             dagOperation match {
               case replace: ReplaceProcessor =>


### PR DESCRIPTION
The Github/Apache Jira integration is not complete yet, here is the jira link:
https://issues.apache.org/jira/browse/GEARPUMP-2

The original discussion can be found at: https://github.com/gearpump/gearpump/issues/1977

Changes:
1. Document how to submit an application jar by REST api.
2. Allow user to compose the config that need to be submitted in javascript. This is done by adding an additional field "configstring".