### PR TITLE
Upgrade sbt-pack to 0.11

### DIFF
--- a/project/BuildDashboard.scala
+++ b/project/BuildDashboard.scala
@@ -27,9 +27,8 @@ object BuildDashboard extends sbt.Build {
     .settings(serviceJvmSettings: _*)
     .dependsOn(core % "provided", streaming % "test->test; provided")
     .enablePlugins(GenJavadocPlugin)
-    .disablePlugins(sbtassembly.AssemblyPlugin)
 
-  private lazy val serviceJvmSettings = commonSettings ++ noPublish ++
+  private lazy val serviceJvmSettings = commonSettings ++ noPublish ++ myAssemblySettings ++
     javadocSettings ++ Seq(
       libraryDependencies ++= Seq(
         "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpVersion % "test",

--- a/project/BuildGearpump.scala
+++ b/project/BuildGearpump.scala
@@ -219,7 +219,7 @@ object BuildGearpump extends sbt.Build {
   lazy val gearpumpHadoop = Project(
     id = "gearpump-hadoop",
     base = file("gearpump-hadoop"),
-    settings = commonSettings ++ noPublish ++
+    settings = commonSettings ++ noPublish ++ myAssemblySettings ++
       Seq(
         libraryDependencies ++= Seq(
           "org.apache.hadoop" % "hadoop-hdfs" % hadoopVersion,
@@ -227,7 +227,7 @@ object BuildGearpump extends sbt.Build {
         ).map(_.exclude("org.slf4j", "slf4j-api"))
           .map(_.exclude("org.slf4j", "slf4j-log4j12"))
       )
-  ).dependsOn(core % "provided").disablePlugins(sbtassembly.AssemblyPlugin)
+  ).dependsOn(core % "provided")
 
   private def changeShadedDeps(toExclude: Set[String], toInclude: List[xml.Node],
       node: xml.Node): xml.Node = {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,7 +21,7 @@ object Dependencies {
   val scalaVersionNumber = crossScalaVersionNumbers.last
   val akkaVersion = "2.5.18"
   val akkaHttpVersion = "10.1.3"
-  val hadoopVersion = "2.6.0"
+  val hadoopVersion = "3.1.1"
   val commonsHttpVersion = "3.1"
   val commonsLoggingVersion = "1.1.3"
   val commonsLangVersion = "2.6"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,3 @@
-resolvers += Resolver.bintrayIvyRepo("fvunicorn", "sbt-plugins")
-
 resolvers += Resolver.bintrayIvyRepo("manuzhang", "sbt-plugins")
 
 resolvers += Classpaths.sbtPluginReleases
@@ -7,7 +5,7 @@ resolvers += Classpaths.sbtPluginReleases
 addSbtPlugin("io.gearpump.sbt" % "sbt-assembly" % "0.14.5"
   exclude("org.apache.maven", "maven-plugin-api"))
 
-addSbtPlugin("io.gearpump.sbt" % "sbt-pack" % "0.7.7")
+addSbtPlugin("org.xerial.sbt" % "sbt-pack" % "0.11")
 
 addSbtPlugin("de.johoop" % "jacoco4sbt" % "2.1.6")
 


### PR DESCRIPTION
Currently, gearpump uses @huafengw [sbt-pack fork](https://github.com/huafengw/sbt-pack) to divide dependencies into sub-directories under `lib`, i.e. `lib/hadoop` and `lib/services`, which won't be put on user's classpath by default. I find it difficult to port the feature to [latest sbt-pack](https://github.com/xerial/sbt-pack) so I've come up with a different approach for `sbt-pack 0.11`

1. Assemble services codes and dependencies into a uber jar and pack it to `${GEARPUMP_HOME}/services` (previously `${GEARPUMP_HOME}/lib/services`). Note that `${GEARPUMP_HOME}/lib` is on classpath by default.
2. The same is done for `gearpump-hadoop` module and hadoop version has been upgraded to `3.1.1` to resolve dependency conflicts.