### PR TITLE
Stop all executors before shutting down app

### DIFF
--- a/core/src/main/scala/io/gearpump/cluster/appmaster/AppMasterRuntimeEnvironment.scala
+++ b/core/src/main/scala/io/gearpump/cluster/appmaster/AppMasterRuntimeEnvironment.scala
@@ -73,7 +73,7 @@ class AppMasterRuntimeEnvironment(
       context.stop(self)
     case Terminated(actor) => actor match {
       case `appMaster` =>
-        LOG.error(s"AppMaster $appId is stopped, shutdown myself")
+        LOG.info(s"AppMaster $appId is stopped, shutdown myself")
         context.stop(self)
       case `masterConnectionKeeper` =>
         LOG.error(s"Master connection keeper is stopped, appId: $appId, shutdown myself")
@@ -132,7 +132,6 @@ object AppMasterRuntimeEnvironment {
 
     def terminationWatch(appMaster: ActorRef): Receive = {
       case Terminated(appMaster) =>
-        LOG.error("appmaster is stopped")
         context.stop(self)
     }
 


### PR DESCRIPTION
### Description
Shutdown an application gracefully (invoking Task `onStop` methods and stopping all executors) before informing the client.

### Checklist

 - [x] Make sure the commit message is meaningful.  
 - [x] Make sure tests pass via `sbt clean test`.
 - [x] Make sure documentation is up-to-date.

