### PR TITLE
Fix #2139, Disable fatal warnings in doc

### DIFF
--- a/project/Docs.scala
+++ b/project/Docs.scala
@@ -21,7 +21,8 @@ import sbtunidoc.ScalaUnidocPlugin.autoImport.ScalaUnidoc
 
 object Docs {
   lazy val javadocSettings = Seq(
-    scalacOptions += s"-P:genjavadoc:out=${target.value}/java"
+    scalacOptions += s"-P:genjavadoc:out=${target.value}/java",
+    scalacOptions -= "-Xfatal-warnings"
   )
 
   def gearpumpUnidocSetting(projects: ProjectReference*) = Seq(


### PR DESCRIPTION
### Description
Remove `-Xfatal-warnings` for `sbt doc`.

### Checklist

 - [x] Make sure the commit message is meaningful.  
 - [x] Make sure tests pass via `sbt clean test`.
 - [x] Make sure documentation is up-to-date.

