### PR TITLE
Upgrade sbt-scoverage to 1.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,11 @@ script:
 - set -o pipefail; set -e; skipLogs="Resolving |Compiling |Done updating|Updating |scoverage|coverage-report";
   if [[ $TRAVIS_PULL_REQUEST != "false" || $TRAVIS_REPO_SLUG != "gearpump/gearpump" ]]; then 
     sbt -jvm-opts project/travis/jvmopts clean +assembly scalastyle test:scalastyle unidoc coverage test | grep -v -E "$skipLogs";
-    sbt coverageReport;
+    sbt coverageAggregate;
   elif [[ $TRAVIS_BRANCH == "master" ]]; then
     sbt -jvm-opts project/travis/jvmopts clean +assembly +publish | grep -v -E "$skipLogs";
     sbt -jvm-opts project/travis/jvmopts scalastyle test:scalastyle unidoc coverage test  | grep -v -E "$skipLogs";
-    sbt coverageReport;
+    sbt coverageAggregate;
   elif [[ $TRAVIS_TAG != "" ]]; then
     sbt -jvm-opts project/travis/jvmopts clean +assembly +packArchiveZip | grep -v -E "$skipLogs";
   fi

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,7 +10,7 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.10")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")
 
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "5.2.4")
 


### PR DESCRIPTION
### Description
As suggested by https://github.com/gearpump/gearpump/pull/2157 and also use `coverageAggregate` to accelerate build as mentioned in https://github.com/scoverage/sbt-scoverage#notes-on-upgrading-to-version-160

### Checklist

 - [x] Make sure the commit message is meaningful.  
 - [x] Make sure tests pass via `sbt clean test`.
 - [x] Make sure documentation is up-to-date.

