### PR TITLE
[codex] migrate to pekko, scala 2.13, and github actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@
 [![codecov.io](https://codecov.io/github/gearpump/gearpump/coverage.svg?branch=master)](https://codecov.io/github/gearpump/gearpump?branch=master)
 [![Join the chat at https://gitter.im/gearpump/gearpump](https://badges.gitter.im/gearpump/gearpump.svg)](https://gitter.im/gearpump/gearpump)
 
-Gearpump is a lightweight real-time big data streaming engine. It is inspired by recent advances in the [Akka](https://github.com/akka/akka) framework and a desire to improve on existing streaming frameworks.
+Gearpump is a lightweight real-time big data streaming engine. It is inspired by recent advances in the [Apache Pekko](https://pekko.apache.org/) framework and a desire to improve on existing streaming frameworks.
 
 The name Gearpump is a reference to the engineering term "gear pump", which is a super simple pump that consists of only two gears, but is very powerful at streaming water.
 
 ![](http://gearpump.apache.org/img/dashboard.gif)
 
-We model streaming within the Akka actor hierarchy.
+We model streaming within the Pekko actor hierarchy.
 
 ![](docs/contents/img/actor_hierarchy.png)
 
@@ -25,7 +25,7 @@ For steps to reproduce the performance test, please check [Performance benchmark
 
 ## Useful Resources
 
-* Read the [Introduction on TypeSafe's Blog](https://typesafe.com/blog/gearpump-real-time-streaming-engine-using-akka)
+* Read the [Introduction on TypeSafe's Blog](https://typesafe.com/blog/gearpump-real-time-streaming-engine-using-pekko)
 * Learn the [Basic Concepts](http://gearpump.apache.org/releases/latest/introduction/basic-concepts/index.html)
 * How to [Develop your first application](http://gearpump.apache.org/releases/latest/dev/dev-write-1st-app/index.html)
 * How to [Submit your first application](http://gearpump.apache.org/releases/latest/introduction/submit-your-1st-application/index.html)

--- a/build.sbt
+++ b/build.sbt
@@ -70,7 +70,7 @@ lazy val core = Project(
       pomPostProcess := {
         (node: xml.Node) => changeShadedDeps(
           Set(
-            "com.github.romix.akka",
+            "io.altoo",
             "com.google.guava",
             "com.codahale.metrics",
             "org.scoverage"
@@ -184,5 +184,4 @@ lazy val distributedshell = Project(
   base = file("examples/distributedshell"))
   .settings(exampleSettings("io.gearpump.examples.distributedshell.DistributedShell"))
   .dependsOn(core % "compile; test->test")
-
 

--- a/conf/gear.conf
+++ b/conf/gear.conf
@@ -105,7 +105,7 @@ gearpump {
 
     # reporter = "logfile"
     # reporter = "graphite"
-    reporter = "akka"
+    reporter = "pekko"
 
     graphite {
       ## Graphite host settings
@@ -140,7 +140,7 @@ gearpump {
       # time interval between two data points for recent data (unit: ms)
       intervalMs = 15000
     }
-    akka {
+    pekko {
       ### For this reporter, at most we will return max-limit-on-query metric item.
       max-limit-on-query = 1000
 
@@ -264,11 +264,11 @@ gearpump {
   }
 
   ##################################
-  ### Akka Dispatcher configurations
+  ### Pekko Dispatcher configurations
   ### If you don't know what is this about, don't change it
   ##################################
   shared-thread-pool-dispatcher {
-    mailbox-type = "akka.dispatch.SingleConsumerOnlyUnboundedMailbox"
+    mailbox-type = "org.apache.pekko.dispatch.SingleConsumerOnlyUnboundedMailbox"
     throughput = 100
     fork-join-executor {
       parallelism-factor = 2
@@ -325,10 +325,7 @@ gearpump {
 
 ### Configuration only visible to master nodes..
 gearpump-master {
-  extensions = [
-    "akka.cluster.ddata.DistributedData$"
-  ]
-  akka {
+  pekko {
     #########################################
     ### For log level of Master, you need to change both log4j.properties and this entry
     #########################################
@@ -337,8 +334,8 @@ gearpump-master {
     log-dead-letters = off
     log-dead-letters-during-shutdown = off
     actor {
-      ## Master forms a akka cluster
-      provider = "akka.cluster.ClusterActorRefProvider"
+      ## Master forms a pekko cluster
+      provider = "cluster"
     }
     cluster {
       roles = ["master"]
@@ -347,16 +344,14 @@ gearpump-master {
       ## The value of this setting will impact master HA recovery time
       auto-down-unreachable-after = 15s
     }
-    remote {
-      log-remote-lifecycle-events = off
-    }
+    remote.classic.log-remote-lifecycle-events = off
   }
 }
 
 ### Configuration only visible to worker nodes...
 gearpump-worker {
   ## Add worker overrided config
-  akka {
+  pekko {
     #########################################
     ### For log level of Worker, you need to change both log4j.properties and this entry
     #########################################
@@ -364,21 +359,19 @@ gearpump-worker {
     log-dead-letters = off
     log-dead-letters-during-shutdown = off
     actor {
-      provider = "akka.remote.RemoteActorRefProvider"
+      provider = "remote"
     }
     cluster {
       roles = ["worker"]
     }
-    remote {
-      log-remote-lifecycle-events = off
-    }
+    remote.classic.log-remote-lifecycle-events = off
   }
 }
 
 #########################################
-### For log level of Akka class, you need to change both log4j.properties and this entry
+### For log level of Pekko class, you need to change both log4j.properties and this entry
 #########################################
-#akka.loglevel = "INFO"
+#pekko.loglevel = "INFO"
 
 ### configurations only visible to UI server.
 gearpump-ui {
@@ -534,20 +527,20 @@ gearpump-ui {
     }
   }
 
-  ## Akka http dispatcher settings.
-  akka.stream.materializer.dispatcher = "gearpump.ui-default-dispatcher"
+  ## Pekko HTTP dispatcher settings.
+  pekko.stream.materializer.dispatcher = "gearpump.ui-default-dispatcher"
 
-  ## Timeout settings for akka-http
-  akka.http.server.idle-timeout = 300 s
+  ## Timeout settings for Pekko HTTP
+  pekko.http.server.idle-timeout = 300 s
 
   ## When uploading a large job jar, it takes a long time to launch the job jar in cluster
   ## before we respond to client.
-  akka.http.server.request-timeout = 600 s
+  pekko.http.server.request-timeout = 600 s
 }
 
 ## Configurations only visible on Linux or Mac.
 gearpump-linux {
   ### On windows, the value must be larger than 10ms, check
   ### https://github.com/akka/akka/blob/master/akka-actor/src/main/scala/akka/actor/Scheduler.scala#L204
-  akka.scheduler.tick-duration = 1
+  pekko.scheduler.tick-duration = 1
 }

--- a/conf/log4j.properties
+++ b/conf/log4j.properties
@@ -12,8 +12,8 @@
 # limitations under the License.
 #
 
-# For messages from akka, you also need to configure the loglevel in akka configuration
-# Please check http://doc.akka.io/docs/akka/snapshot/scala/logging.html for
+# For messages from Pekko, you also need to configure the loglevel in Pekko configuration.
+# Please check https://pekko.apache.org/docs/pekko/current/logging.html for
 # more information.
 
 # The logger for all Gearpump daemon processes (including master, worker, local)
@@ -62,13 +62,13 @@ log4j.threshhold=ALL
 
 # =====================================================================
 # Customize logger for a specific class
-# For example, if you want to enable debug log for specific akka class
-# akka.remote.RemoteWatcher, you can do like this:
-# 1. configure akka.loglevel = "DEBUG" in gear.conf
+# For example, if you want to enable debug log for a specific Pekko class
+# org.apache.pekko.remote.RemoteWatcher, you can do like this:
+# 1. configure pekko.loglevel = "DEBUG" in gear.conf
 # 2. set specific logger like this:
-#  log4j.logger.akka.remote.RemoteWatcher=DEBUG,${log4j.rootAppender}
+#  log4j.logger.org.apache.pekko.remote.RemoteWatcher=DEBUG,${log4j.rootAppender}
 # =====================================================================
-# log4j.logger.akka.remote.RemoteWatcher=DEBUG,${log4j.rootAppender}
+# log4j.logger.org.apache.pekko.remote.RemoteWatcher=DEBUG,${log4j.rootAppender}
 
 # =====================================================================
 # Appenders
@@ -106,4 +106,3 @@ log4j.appender.ApplicationLogAppender.MaxFileSize=100MB
 log4j.appender.ApplicationLogAppender.MaxBackupIndex=30
 log4j.appender.ApplicationLogAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.ApplicationLogAppender.layout.ConversionPattern=[%p] [%d{MM/dd/yyyy HH:mm:ss.SSS}] [%c{1}] %m%n
-

--- a/core/src/main/java/io/gearpump/util/AkkaHelper.java
+++ b/core/src/main/java/io/gearpump/util/AkkaHelper.java
@@ -14,23 +14,11 @@
 
 package io.gearpump.util;
 
-import akka.actor.ActorRef;
-import akka.actor.ActorSystem;
+/**
+ * Compatibility shim for code that still calls AkkaHelper.actorFor.
+ */
+public final class AkkaHelper extends PekkoHelper {
 
-public class AkkaHelper {
-
-  /**
-   * Helper util to access the private[akka] system.actorFor method
-   *
-   * This is used for performance optimization, we encode the session Id
-   * in the ActorRef path. Session Id is used to identity sender Task.
-   *
-   * @param system ActorSystem
-   * @param path Relative or absolute path of this Actor System.
-   * @return Full qualified ActorRef.
-   */
-  @SuppressWarnings("deprecation")
-  public static ActorRef actorFor(ActorSystem system, String path) {
-    return system.actorFor(path);
+  private AkkaHelper() {
   }
 }

--- a/core/src/main/java/io/gearpump/util/PekkoHelper.java
+++ b/core/src/main/java/io/gearpump/util/PekkoHelper.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gearpump.util;
+
+import org.apache.pekko.actor.ActorRef;
+import org.apache.pekko.actor.ActorSystem;
+
+public class PekkoHelper {
+
+  /**
+   * Helper util to access the deprecated actorFor method.
+   *
+   * This is used for performance optimization, we encode the session Id
+   * in the ActorRef path. Session Id is used to identity sender Task.
+   *
+   * @param system ActorSystem
+   * @param path Relative or absolute path of this Actor System.
+   * @return Full qualified ActorRef.
+   */
+  @SuppressWarnings("deprecation")
+  public static ActorRef actorFor(ActorSystem system, String path) {
+    return system.actorFor(path);
+  }
+}

--- a/core/src/main/resources/geardefault.conf
+++ b/core/src/main/resources/geardefault.conf
@@ -112,7 +112,7 @@ gearpump {
   ### If you want to use metrics, please change
   ###########################
 
-  ## Akka Http Dispatcher settings for UI service.
+  ## Pekko HTTP dispatcher settings for UI service.
   ui-default-dispatcher {
     type = "Dispatcher"
     executor = "thread-pool-executor"
@@ -137,7 +137,7 @@ gearpump {
 
     # reporter = "logfile"
     # reporter = "graphite"
-    reporter = "akka"
+    reporter = "pekko"
 
     graphite {
       ## Graphite host settings
@@ -172,7 +172,7 @@ gearpump {
       # time interval between two data points for recent data (unit: ms)
       intervalMs = 15000
     }
-    akka {
+    pekko {
       ### For this reporter, at most we will return max-limit-on-query metric item.
       max-limit-on-query = 1000
 
@@ -214,7 +214,7 @@ gearpump {
     "scala.Tuple4" = ""
     "scala.Tuple5" = ""
     "scala.Tuple6" = ""
-    "akka.actor.LocalActorRef" = ""
+    "org.apache.pekko.actor.LocalActorRef" = ""
   }
 
   ### client's timeout (in second) to connect to master and wait for the response
@@ -312,11 +312,11 @@ gearpump {
   }
 
   ##################################
-  ### Akka Dispatcher configurations
+  ### Pekko Dispatcher configurations
   ### If you don't know what is this about, don't change it
   ##################################
   shared-thread-pool-dispatcher {
-    mailbox-type = "akka.dispatch.SingleConsumerOnlyUnboundedMailbox"
+    mailbox-type = "org.apache.pekko.dispatch.SingleConsumerOnlyUnboundedMailbox"
     throughput = 100
     fork-join-executor {
       parallelism-factor = 2
@@ -368,20 +368,20 @@ gearpump {
 
 ### Configuration only visible to master nodes..
 gearpump-master {
-  ## NOTE: Please add akka-related settings in gear.conf to avoid confusion in
+  ## NOTE: Please add pekko-related settings in gear.conf to avoid confusion in
   ## config overriding.
 }
 
 ### Configuration only visible to worker nodes...
 gearpump-worker {
-  ## NOTE: Please add akka-related settings in gear.conf to avoid confusion in
+  ## NOTE: Please add pekko-related settings in gear.conf to avoid confusion in
   ## config overriding.
 }
 
 #########################################
-### For log level of Akka class, you need to change both log4j.properties and this entry
+### For log level of Pekko class, you need to change both log4j.properties and this entry
 #########################################
-#akka.loglevel = "INFO"
+#pekko.loglevel = "INFO"
 
 ### configurations only visible to UI server.
 gearpump-ui {
@@ -539,20 +539,36 @@ gearpump-ui {
 
 ###################################################################
 ###################################################################
-## The following configurations supercede the default akka config
+## The following configurations supercede the default pekko config
 ###################################################################
 ###################################################################
 
-## work-around to fix akka io performance issue on windows
+## work-around to fix pekko io performance issue on windows
 ## reference: http://stackoverflow.com/questions/29453848/high-cpu-on-akka-io-pinned-dispatcher-on-windows
 ## ticket: https://github.com/akka/akka/issues/16295
-akka.io.tcp.windows-connection-abort-workaround-enabled = off
+pekko.io.tcp.windows-connection-abort-workaround-enabled = off
 
 ### On windows, the value must be larger than 10ms, check
 ### https://github.com/akka/akka/blob/master/akka-actor/src/main/scala/akka/actor/Scheduler.scala#L204
-akka.scheduler.tick-duration = 10
+pekko.scheduler.tick-duration = 10
 
-akka {
+pekko-kryo-serialization {
+  buffer-size = 4096
+  classes = [
+  ]
+  id-strategy = "incremental"
+  implicit-registration-logging = true
+  kryo-initializer = "io.gearpump.serializer.GearpumpPekkoKryoInitializer"
+  kryo-reference-map = true
+  kryo-trace = false
+  mappings {
+  }
+  max-buffer-size = -1
+  type = "graph"
+  use-manifests = false
+}
+
+pekko {
   http {
     client {
       parsing {
@@ -567,28 +583,10 @@ akka {
       }
     }
 
-    ## Akka-http session related settings
-    session {
-
-      server-secret = "Please change this to a value only you know! At least 64 chars!!!"
-
-      cookie {
-        name = "gearpump_token"
-        ## domain = "..."
-        path = "/"
-        ## maxAge = 0
-        secure = false
-        http-only = true
-      }
-
-      ## Session lifetime. Default value is about 1 week
-      max-age = 604800
-      encrypt-data = true
-    }
   }
 
   test {
-    ##  duration to wait in expectMsg in akka test
+    ## duration to wait in expectMsg in pekko test
     single-expect-default = 10s
   }
 
@@ -599,12 +597,12 @@ akka {
     "io.gearpump.metrics.Metrics$"
   ]
   loglevel = "INFO"
-  loggers = ["akka.event.slf4j.Slf4jLogger"]
-  logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
+  loggers = ["org.apache.pekko.event.slf4j.Slf4jLogger"]
+  logging-filter = "org.apache.pekko.event.slf4j.Slf4jLoggingFilter"
   log-dead-letters = off
   log-dead-letters-during-shutdown = off
   actor {
-    provider = "akka.remote.RemoteActorRefProvider"
+    provider = "remote"
 
     ## Doesn't warn on Java serializer usage
     ##
@@ -617,7 +615,7 @@ akka {
     ## TODO: in integration test, may need to enable this
     ##creation-timeout=100s
     default-mailbox {
-      mailbox-type = "akka.dispatch.SingleConsumerOnlyUnboundedMailbox"
+      mailbox-type = "org.apache.pekko.dispatch.SingleConsumerOnlyUnboundedMailbox"
     }
     default-dispatcher {
       throughput = 10
@@ -627,46 +625,50 @@ akka {
         parallelism-min = 4
       }
     }
-    kryo {
-      buffer-size = 4096
-      classes = [
-      ]
-
-      compression = off
-      idstrategy = "incremental"
-      implicit-registration-logging = true
-      kryo-reference-map = true
-      kryo-trace = false
-      mappings {
-      }
-      max-buffer-size = -1
-      serializer-pool-size = 16
-      type = "graph"
-      use-manifests = false
-    }
   }
   remote {
-    log-remote-lifecycle-events = off
-    use-dispatcher = "akka.remote.default-remote-dispatcher"
-    enabled-transports = ["akka.remote.netty.tcp"]
-    netty.tcp {
-      hostname = "127.0.0.1"
-      port = 0
-      send-buffer-size = 4096000b
-      receive-buffer-size = 4096000b
-      maximum-frame-size = 2048000b
-    }
+    artery.enabled = off
     default-remote-dispatcher {
       throughput = 5
       type = Dispatcher
       executor = "fork-join-executor"
     }
+    classic {
+      log-remote-lifecycle-events = off
+      use-dispatcher = "pekko.remote.default-remote-dispatcher"
+      enabled-transports = ["pekko.remote.classic.netty.tcp"]
+      netty.tcp {
+        hostname = "127.0.0.1"
+        port = 0
+        send-buffer-size = 4096000b
+        receive-buffer-size = 4096000b
+        maximum-frame-size = 2048000b
+      }
+    }
   }
+}
+
+## The pekko-http-session library still expects akka.http.session.* configuration keys.
+akka.http.session {
+  server-secret = "Please change this to a value only you know! At least 64 chars!!!"
+
+  cookie {
+    name = "gearpump_token"
+    ## domain = "..."
+    path = "/"
+    ## maxAge = 0
+    secure = false
+    http-only = true
+  }
+
+  ## Session lifetime. Default value is about 1 week
+  max-age = 604800
+  encrypt-data = true
 }
 
 ## Configurations only visible on Linux or Mac.
 gearpump-linux {
   ### On windows, the value must be larger than 10ms, check
   ### https://github.com/akka/akka/blob/master/akka-actor/src/main/scala/akka/actor/Scheduler.scala#L204
-  akka.scheduler.tick-duration = 1
+  pekko.scheduler.tick-duration = 1
 }

--- a/core/src/main/scala/io/gearpump/cluster/AppDescription.scala
+++ b/core/src/main/scala/io/gearpump/cluster/AppDescription.scala
@@ -14,7 +14,7 @@
 
 package io.gearpump.cluster
 
-import akka.actor.{Actor, ActorRef}
+import org.apache.pekko.actor.{Actor, ActorRef}
 import com.typesafe.config.{Config, ConfigFactory}
 import io.gearpump.cluster.MasterToClient.{ApplicationFailed, ApplicationResult, ApplicationSucceeded, ApplicationTerminated}
 import io.gearpump.cluster.appmaster.WorkerInfo
@@ -86,7 +86,7 @@ case class ExecutorContext(
  * @param mainClass Executor main class name like io.gearpump.xx.AppMaster
  * @param arguments Executor command line arguments
  * @param jar application jar
- * @param executorAkkaConfig Akka config used to initialize the actor system of this executor.
+ * @param executorPekkoConfig Pekko config used to initialize the actor system of this executor.
  *                           It uses io.gearpump.util.Constants.GEARPUMP_CUSTOM_CONFIG_FILE
  *                           to pass the config to executor process
  */
@@ -94,7 +94,7 @@ case class ExecutorContext(
 case class ExecutorJVMConfig(
     classPath: Array[String], jvmArguments: Array[String], mainClass: String,
     arguments: Array[String], jar: Option[AppJar], username: String,
-    executorAkkaConfig: Config = ConfigFactory.empty())
+    executorPekkoConfig: Config = ConfigFactory.empty())
 
 sealed abstract class ApplicationStatus(val status: String)
   extends Serializable{

--- a/core/src/main/scala/io/gearpump/cluster/Application.scala
+++ b/core/src/main/scala/io/gearpump/cluster/Application.scala
@@ -14,7 +14,7 @@
 
 package io.gearpump.cluster
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import scala.reflect.ClassTag
 
 /**

--- a/core/src/main/scala/io/gearpump/cluster/ClusterConfig.scala
+++ b/core/src/main/scala/io/gearpump/cluster/ClusterConfig.scala
@@ -23,7 +23,7 @@ import java.io.File
  *
  * All Gearpump application should use this class to load configurations.
  *
- * Compared with Akka built-in com.typesafe.config.ConfigFactory, this class also
+ * Compared with Pekko's built-in com.typesafe.config.ConfigFactory usage, this class also
  * resolve config from file gear.conf and geardefault.conf.
  *
  * Overriding order:
@@ -104,7 +104,7 @@ object ClusterConfig {
     }
   }
 
-  /** filter JVM reserved keys and akka default reference.conf */
+  /** filter JVM reserved keys and Pekko default reference.conf */
   def filterOutDefaultConfig(input: Config): Config = {
     val updated = filterOutJvmReservedKeys(input)
     Util.filterOutOrigin(updated, "reference.conf")
@@ -129,9 +129,9 @@ object ClusterConfig {
     var basic = all.withoutPath(MASTER_CONFIG).withoutPath(WORKER_CONFIG).
       withoutPath(UI_CONFIG).withoutPath(LINUX_CONFIG)
 
-    if (!akka.util.Helpers.isWindows) {
+    if (!org.apache.pekko.util.Helpers.isWindows) {
 
-      // Change the akka.scheduler.tick-duration to 1 ms for Linux or Mac
+      // Change the pekko.scheduler.tick-duration to 1 ms for Linux or Mac
       basic = linux.withFallback(basic)
     }
 

--- a/core/src/main/scala/io/gearpump/cluster/ClusterMessage.scala
+++ b/core/src/main/scala/io/gearpump/cluster/ClusterMessage.scala
@@ -14,7 +14,7 @@
 
 package io.gearpump.cluster
 
-import akka.actor.ActorRef
+import org.apache.pekko.actor.ActorRef
 import com.typesafe.config.Config
 import io.gearpump.Time.MilliSeconds
 import io.gearpump.cluster.appmaster.WorkerInfo

--- a/core/src/main/scala/io/gearpump/cluster/DaemonMessage.scala
+++ b/core/src/main/scala/io/gearpump/cluster/DaemonMessage.scala
@@ -13,7 +13,7 @@
  */
 package io.gearpump.cluster
 
-import akka.actor.ActorRef
+import org.apache.pekko.actor.ActorRef
 import io.gearpump.cluster.master.Master.MasterInfo
 import io.gearpump.cluster.scheduler.Resource
 import io.gearpump.cluster.worker.WorkerId

--- a/core/src/main/scala/io/gearpump/cluster/UserConfig.scala
+++ b/core/src/main/scala/io/gearpump/cluster/UserConfig.scala
@@ -14,8 +14,8 @@
 
 package io.gearpump.cluster
 
-import akka.actor.{ActorSystem, ExtendedActorSystem}
-import akka.serialization.JavaSerializer
+import org.apache.pekko.actor.{ActorSystem, ExtendedActorSystem}
+import org.apache.pekko.serialization.JavaSerializer
 import com.google.common.io.BaseEncoding
 
 
@@ -103,11 +103,11 @@ final class UserConfig(private val _config: Map[String, String]) extends Seriali
    * This de-serializes value to object instance
    *
    * To do de-serialization, this requires an implicit ActorSystem, as
-   * the ActorRef and possibly other akka classes deserialization
+   * the ActorRef and possibly other Pekko classes deserialization
    * requires an implicit ActorSystem.
    *
    * See Link:
-   * http://doc.akka.io/docs/akka/snapshot/scala/serialization.html#A_Word_About_Java_Serialization
+   * https://pekko.apache.org/docs/pekko/current/serialization.html
    */
 
   def getValue[T](key: String)(implicit system: ActorSystem): Option[T] = {
@@ -120,11 +120,11 @@ final class UserConfig(private val _config: Map[String, String]) extends Seriali
    * This serializes the object and store it as string.
    *
    * To do serialization, this requires an implicit ActorSystem, as
-   * the ActorRef and possibly other akka classes serialization
+   * the ActorRef and possibly other Pekko classes serialization
    * requires an implicit ActorSystem.
    *
    * See Link:
-   * http://doc.akka.io/docs/akka/snapshot/scala/serialization.html#A_Word_About_Java_Serialization
+   * https://pekko.apache.org/docs/pekko/current/serialization.html
    */
   def withValue[T <: AnyRef](key: String, value: T)(implicit system: ActorSystem): UserConfig = {
 

--- a/core/src/main/scala/io/gearpump/cluster/appmaster/AppMasterRuntimeEnvironment.scala
+++ b/core/src/main/scala/io/gearpump/cluster/appmaster/AppMasterRuntimeEnvironment.scala
@@ -14,7 +14,7 @@
 
 package io.gearpump.cluster.appmaster
 
-import akka.actor._
+import org.apache.pekko.actor._
 import io.gearpump.cluster.{AppDescription, AppMasterContext}
 import io.gearpump.cluster.AppMasterToMaster.RegisterAppMaster
 import io.gearpump.cluster.appmaster.AppMasterRuntimeEnvironment.{AppId, ListenerActorRef, MasterActorRef, StartAppMaster}

--- a/core/src/main/scala/io/gearpump/cluster/appmaster/ApplicationRuntimeInfo.scala
+++ b/core/src/main/scala/io/gearpump/cluster/appmaster/ApplicationRuntimeInfo.scala
@@ -14,7 +14,7 @@
 
 package io.gearpump.cluster.appmaster
 
-import akka.actor.ActorRef
+import org.apache.pekko.actor.ActorRef
 import com.typesafe.config.{Config, ConfigFactory}
 import io.gearpump.Time.MilliSeconds
 import io.gearpump.cluster.{ApplicationStatus, ApplicationTerminalStatus}

--- a/core/src/main/scala/io/gearpump/cluster/appmaster/ExecutorSystem.scala
+++ b/core/src/main/scala/io/gearpump/cluster/appmaster/ExecutorSystem.scala
@@ -14,7 +14,7 @@
 
 package io.gearpump.cluster.appmaster
 
-import akka.actor.{ActorRef, Address, PoisonPill}
+import org.apache.pekko.actor.{ActorRef, Address, PoisonPill}
 import io.gearpump.cluster.scheduler.Resource
 import io.gearpump.util.ActorSystemBooter.BindLifeCycle
 

--- a/core/src/main/scala/io/gearpump/cluster/appmaster/ExecutorSystemLauncher.scala
+++ b/core/src/main/scala/io/gearpump/cluster/appmaster/ExecutorSystemLauncher.scala
@@ -14,7 +14,7 @@
 
 package io.gearpump.cluster.appmaster
 
-import akka.actor._
+import org.apache.pekko.actor._
 import io.gearpump.cluster.AppMasterToWorker.LaunchExecutor
 import io.gearpump.cluster.ExecutorJVMConfig
 import io.gearpump.cluster.WorkerToAppMaster._
@@ -102,7 +102,7 @@ object ExecutorSystemLauncher {
     Option(conf).map { conf =>
       import conf._
       ExecutorJVMConfig(classPath, jvmArguments, classOf[ActorSystemBooter].getName,
-        Array(systemName, reportBack), jar, username, executorAkkaConfig)
+        Array(systemName, reportBack), jar, username, executorPekkoConfig)
     }.orNull
   }
 }

--- a/core/src/main/scala/io/gearpump/cluster/appmaster/ExecutorSystemScheduler.scala
+++ b/core/src/main/scala/io/gearpump/cluster/appmaster/ExecutorSystemScheduler.scala
@@ -14,7 +14,7 @@
 
 package io.gearpump.cluster.appmaster
 
-import akka.actor._
+import org.apache.pekko.actor._
 import com.typesafe.config.Config
 import io.gearpump.cluster._
 import io.gearpump.cluster.AppMasterToMaster.RequestResource
@@ -130,7 +130,7 @@ object ExecutorSystemScheduler {
   case object StartExecutorSystemTimeout
 
   case class ExecutorSystemJvmConfig(classPath: Array[String], jvmArguments: Array[String],
-      jar: Option[AppJar], username: String, executorAkkaConfig: Config = null)
+      jar: Option[AppJar], username: String, executorPekkoConfig: Config = null)
 
   /**
    * For each client which ask for an executor system, the scheduler will create a session for it.

--- a/core/src/main/scala/io/gearpump/cluster/appmaster/MasterConnectionKeeper.scala
+++ b/core/src/main/scala/io/gearpump/cluster/appmaster/MasterConnectionKeeper.scala
@@ -14,7 +14,7 @@
 
 package io.gearpump.cluster.appmaster
 
-import akka.actor._
+import org.apache.pekko.actor._
 import io.gearpump.cluster.AppMasterToMaster.RegisterAppMaster
 import io.gearpump.cluster.MasterToAppMaster.AppMasterRegistered
 import io.gearpump.cluster.appmaster.MasterConnectionKeeper.AppMasterRegisterTimeout

--- a/core/src/main/scala/io/gearpump/cluster/appmaster/WorkerInfo.scala
+++ b/core/src/main/scala/io/gearpump/cluster/appmaster/WorkerInfo.scala
@@ -14,7 +14,7 @@
 
 package io.gearpump.cluster.appmaster
 
-import akka.actor.ActorRef
+import org.apache.pekko.actor.ActorRef
 import io.gearpump.cluster.worker.WorkerId
 
 case class WorkerInfo(workerId: WorkerId, ref: ActorRef)

--- a/core/src/main/scala/io/gearpump/cluster/client/ClientContext.scala
+++ b/core/src/main/scala/io/gearpump/cluster/client/ClientContext.scala
@@ -14,8 +14,8 @@
 
 package io.gearpump.cluster.client
 
-import akka.actor.{ActorRef, ActorSystem}
-import akka.util.Timeout
+import org.apache.pekko.actor.{ActorRef, ActorSystem}
+import org.apache.pekko.util.Timeout
 import com.typesafe.config.{Config, ConfigValueFactory}
 import io.gearpump.cluster.{ClusterConfig, _}
 import io.gearpump.cluster.ClientToMaster.{ResolveAppId, ShutdownApplication, SubmitApplication}

--- a/core/src/main/scala/io/gearpump/cluster/client/RunningApplication.scala
+++ b/core/src/main/scala/io/gearpump/cluster/client/RunningApplication.scala
@@ -13,9 +13,9 @@
  */
 package io.gearpump.cluster.client
 
-import akka.actor.ActorRef
-import akka.pattern.ask
-import akka.util.Timeout
+import org.apache.pekko.actor.ActorRef
+import org.apache.pekko.pattern.ask
+import org.apache.pekko.util.Timeout
 import io.gearpump.cluster.ClientToMaster.{RegisterAppResultListener, ResolveAppId, ShutdownApplication}
 import io.gearpump.cluster.MasterToClient._
 import io.gearpump.cluster.client.RunningApplication._
@@ -76,7 +76,6 @@ class RunningApplication(val appId: Int, master: ActorRef, timeout: Timeout) {
 
 object RunningApplication {
   private val LOG: Logger = LogUtil.getLogger(getClass)
-  // This magic number is derived from Akka's configuration, which is the maximum delay
+  // This magic number is derived from Pekko's configuration, which is the maximum delay
   private val INF_DURATION = Duration.ofSeconds(2147482)
 }
-

--- a/core/src/main/scala/io/gearpump/cluster/embedded/EmbeddedCluster.scala
+++ b/core/src/main/scala/io/gearpump/cluster/embedded/EmbeddedCluster.scala
@@ -14,7 +14,7 @@
 
 package io.gearpump.cluster.embedded
 
-import akka.actor.{ActorRef, ActorSystem, Props}
+import org.apache.pekko.actor.{ActorRef, ActorSystem, Props}
 import com.typesafe.config.{Config, ConfigValueFactory}
 import io.gearpump.cluster.ClusterConfig
 import io.gearpump.cluster.master.Master
@@ -46,14 +46,14 @@ class EmbeddedCluster(inputConfig: Config) {
 
   private def getConfig(inputConfig: Config, port: Int): Config = {
     val config = inputConfig.
-      withValue("akka.remote.netty.tcp.port", ConfigValueFactory.fromAnyRef(port)).
+      withValue("pekko.remote.classic.netty.tcp.port", ConfigValueFactory.fromAnyRef(port)).
       withValue(GEARPUMP_CLUSTER_MASTERS,
         ConfigValueFactory.fromIterable(List(s"127.0.0.1:$port").asJava)).
       withValue(GEARPUMP_CLUSTER_EXECUTOR_WORKER_SHARE_SAME_PROCESS,
         ConfigValueFactory.fromAnyRef(true)).
       withValue(GEARPUMP_METRIC_ENABLED, ConfigValueFactory.fromAnyRef(true)).
-      withValue("akka.actor.provider",
-        ConfigValueFactory.fromAnyRef("akka.cluster.ClusterActorRefProvider"))
+      withValue("pekko.actor.provider",
+        ConfigValueFactory.fromAnyRef("cluster"))
     config
   }
 }

--- a/core/src/main/scala/io/gearpump/cluster/main/AppSubmitter.scala
+++ b/core/src/main/scala/io/gearpump/cluster/main/AppSubmitter.scala
@@ -40,7 +40,7 @@ object AppSubmitter extends MasterClientCommand with ArgumentsParser {
     Gear.OPTION_CONFIG -> CLIOption("custom configuration file", required = false,
       defaultValue = None))
 
-  def main(akkaConf: Config, args: Array[String]): Unit = {
+  def main(pekkoConf: Config, args: Array[String]): Unit = {
 
     val config = parse(args)
     if (null != config) {

--- a/core/src/main/scala/io/gearpump/cluster/main/Info.scala
+++ b/core/src/main/scala/io/gearpump/cluster/main/Info.scala
@@ -30,8 +30,8 @@ object Info extends MasterClientCommand with ArgumentsParser {
   override val description = "Query the Application list"
 
   // scalastyle:off println
-  def main(akkaConf: Config, args: Array[String]): Unit = {
-    val client = ClientContext(akkaConf)
+  def main(pekkoConf: Config, args: Array[String]): Unit = {
+    val client = ClientContext(pekkoConf)
 
     val AppMastersData(appMasters) = client.listApps
     Console.println("== Application Information ==")

--- a/core/src/main/scala/io/gearpump/cluster/main/Kill.scala
+++ b/core/src/main/scala/io/gearpump/cluster/main/Kill.scala
@@ -29,11 +29,11 @@ object Kill extends MasterClientCommand with ArgumentsParser {
 
   override val description = "Kill an application with application Id"
 
-  def main(akkaConf: Config, args: Array[String]): Unit = {
+  def main(pekkoConf: Config, args: Array[String]): Unit = {
     val config = parse(args)
 
     if (null != config) {
-      val client = ClientContext(akkaConf)
+      val client = ClientContext(pekkoConf)
       client.shutdown(config.getInt("appid"))
       client.close()
     }

--- a/core/src/main/scala/io/gearpump/cluster/main/Local.scala
+++ b/core/src/main/scala/io/gearpump/cluster/main/Local.scala
@@ -14,7 +14,7 @@
 
 package io.gearpump.cluster.main
 
-import akka.actor.{ActorSystem, Props}
+import org.apache.pekko.actor.{ActorSystem, Props}
 import com.typesafe.config.ConfigValueFactory
 import io.gearpump.cluster.ClusterConfig
 import io.gearpump.cluster.master.{Master => MasterActor}
@@ -28,7 +28,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
 object Local extends MasterClientCommand with ArgumentsParser {
-  override def akkaConfig: Config = ClusterConfig.master()
+  override def pekkoConfig: Config = ClusterConfig.master()
 
   var LOG: Logger = LogUtil.getLogger(getClass)
 
@@ -39,27 +39,27 @@ object Local extends MasterClientCommand with ArgumentsParser {
 
   override val description = "Start a local cluster"
 
-  def main(akkaConf: Config, args: Array[String]): Unit = {
+  def main(pekkoConf: Config, args: Array[String]): Unit = {
 
     this.LOG = {
-      LogUtil.loadConfiguration(akkaConf, ProcessType.LOCAL)
+      LogUtil.loadConfiguration(pekkoConf, ProcessType.LOCAL)
       LogUtil.getLogger(getClass)
     }
 
     val config = parse(args)
     if (null != config) {
-      local(config.getInt("workernum"), config.getBoolean("sameprocess"), akkaConf)
+      local(config.getInt("workernum"), config.getBoolean("sameprocess"), pekkoConf)
     }
   }
 
-  def local(workerCount: Int, sameProcess: Boolean, akkaConf: Config): Unit = {
+  def local(workerCount: Int, sameProcess: Boolean, pekkoConf: Config): Unit = {
     if (sameProcess) {
       LOG.info("Starting local in same process")
       System.setProperty("LOCAL", "true")
     }
-    val masters = akkaConf.getStringList(Constants.GEARPUMP_CLUSTER_MASTERS)
+    val masters = pekkoConf.getStringList(Constants.GEARPUMP_CLUSTER_MASTERS)
       .asScala.flatMap(Util.parseHostList)
-    val local = akkaConf.getString(Constants.GEARPUMP_HOSTNAME)
+    val local = pekkoConf.getString(Constants.GEARPUMP_HOSTNAME)
 
     if (masters.size != 1 && masters.head.host != local) {
       LOG.error(s"The ${Constants.GEARPUMP_CLUSTER_MASTERS} is not match " +
@@ -67,8 +67,8 @@ object Local extends MasterClientCommand with ArgumentsParser {
     } else {
 
       val hostPort = masters.head
-      implicit val system = ActorSystem(MASTER, akkaConf.
-        withValue("akka.remote.netty.tcp.port", ConfigValueFactory.fromAnyRef(hostPort.port))
+      implicit val system = ActorSystem(MASTER, pekkoConf.
+        withValue("pekko.remote.classic.netty.tcp.port", ConfigValueFactory.fromAnyRef(hostPort.port))
       )
 
       val master = system.actorOf(Props[MasterActor], MASTER)

--- a/core/src/main/scala/io/gearpump/cluster/main/MainRunner.scala
+++ b/core/src/main/scala/io/gearpump/cluster/main/MainRunner.scala
@@ -25,7 +25,7 @@ object MainRunner extends MasterClientCommand with ArgumentsParser {
     Gear.OPTION_CONFIG -> CLIOption("custom configuration file", required = false,
       defaultValue = None))
 
-  def main(akkaConf: Config, args: Array[String]): Unit = {
+  def main(pekkoConf: Config, args: Array[String]): Unit = {
     val mainClazz = args(0)
     val commandArgs = args.drop(1)
 

--- a/core/src/main/scala/io/gearpump/cluster/main/Master.scala
+++ b/core/src/main/scala/io/gearpump/cluster/main/Master.scala
@@ -14,13 +14,13 @@
 
 package io.gearpump.cluster.main
 
-import akka.actor.{ActorSystem, PoisonPill, Props}
-import akka.cluster.Cluster
-import akka.cluster.ddata.DistributedData
-import akka.cluster.singleton.{ClusterSingletonManager, ClusterSingletonManagerSettings, ClusterSingletonProxy, ClusterSingletonProxySettings}
+import org.apache.pekko.actor.{ActorSystem, PoisonPill, Props}
+import org.apache.pekko.cluster.Cluster
+import org.apache.pekko.cluster.ddata.DistributedData
+import org.apache.pekko.cluster.singleton.{ClusterSingletonManager, ClusterSingletonManagerSettings, ClusterSingletonProxy, ClusterSingletonProxySettings}
 import com.typesafe.config.ConfigValueFactory
 import io.gearpump.cluster.ClusterConfig
-import io.gearpump.util.{AkkaApp, Constants, LogUtil}
+import io.gearpump.util.{PekkoApp, Constants, LogUtil}
 import io.gearpump.util.Constants._
 import io.gearpump.util.LogUtil.ProcessType
 import java.util.concurrent.TimeUnit
@@ -29,11 +29,11 @@ import scala.collection.JavaConverters._
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-object Master extends AkkaApp with ArgumentsParser {
+object Master extends PekkoApp with ArgumentsParser {
 
   private var LOG: Logger = LogUtil.getLogger(getClass)
 
-  override def akkaConfig: Config = ClusterConfig.master()
+  override def pekkoConfig: Config = ClusterConfig.master()
 
   override val options: Array[(String, CLIOption[Any])] =
     Array("ip" -> CLIOption[String]("<master ip address>", required = true),
@@ -41,15 +41,15 @@ object Master extends AkkaApp with ArgumentsParser {
 
   override val description = "Start Master daemon"
 
-  def main(akkaConf: Config, args: Array[String]): Unit = {
+  def main(pekkoConf: Config, args: Array[String]): Unit = {
 
     this.LOG = {
-      LogUtil.loadConfiguration(akkaConf, ProcessType.MASTER)
+      LogUtil.loadConfiguration(pekkoConf, ProcessType.MASTER)
       LogUtil.getLogger(getClass)
     }
 
     val config = parse(args)
-    master(config.getString("ip"), config.getInt("port"), akkaConf)
+    master(config.getString("ip"), config.getInt("port"), pekkoConf)
   }
 
   private def verifyMaster(master: String, port: Int, masters: Iterable[String]) = {
@@ -58,8 +58,8 @@ object Master extends AkkaApp with ArgumentsParser {
     }
   }
 
-  private def master(ip: String, port: Int, akkaConf: Config): Unit = {
-    val masters = akkaConf.getStringList(Constants.GEARPUMP_CLUSTER_MASTERS).asScala
+  private def master(ip: String, port: Int, pekkoConf: Config): Unit = {
+    val masters = pekkoConf.getStringList(Constants.GEARPUMP_CLUSTER_MASTERS).asScala
 
     if (!verifyMaster(ip, port, masters)) {
       LOG.error(s"The provided ip $ip and port $port doesn't conform with config at " +
@@ -67,13 +67,13 @@ object Master extends AkkaApp with ArgumentsParser {
       System.exit(-1)
     }
 
-    val masterList = masters.map(master => s"akka.tcp://${MASTER}@$master").toList.asJava
+    val masterList = masters.map(master => s"pekko.tcp://${MASTER}@$master").toList.asJava
     val quorum = masterList.size() / 2 + 1
-    val masterConfig = akkaConf.
-      withValue("akka.remote.netty.tcp.port", ConfigValueFactory.fromAnyRef(port)).
+    val masterConfig = pekkoConf.
+      withValue("pekko.remote.classic.netty.tcp.port", ConfigValueFactory.fromAnyRef(port)).
       withValue(NETTY_TCP_HOSTNAME, ConfigValueFactory.fromAnyRef(ip)).
-      withValue("akka.cluster.seed-nodes", ConfigValueFactory.fromAnyRef(masterList)).
-      withValue(s"akka.cluster.role.${MASTER}.min-nr-of-members",
+      withValue("pekko.cluster.seed-nodes", ConfigValueFactory.fromAnyRef(masterList)).
+      withValue(s"pekko.cluster.role.${MASTER}.min-nr-of-members",
         ConfigValueFactory.fromAnyRef(quorum))
 
     LOG.info(s"Starting Master Actor system $ip:$port, master list: ${masters.mkString(";")}")

--- a/core/src/main/scala/io/gearpump/cluster/main/MasterWatcher.scala
+++ b/core/src/main/scala/io/gearpump/cluster/main/MasterWatcher.scala
@@ -14,9 +14,9 @@
 
 package io.gearpump.cluster.main
 
-import akka.actor.{Actor, ActorLogging, ActorRef, Props}
-import akka.cluster.{Cluster, Member, MemberStatus}
-import akka.cluster.ClusterEvent.{CurrentClusterState, MemberEvent, MemberExited, MemberRemoved, MemberUp}
+import org.apache.pekko.actor.{Actor, ActorLogging, ActorRef, Props}
+import org.apache.pekko.cluster.{Cluster, Member, MemberStatus}
+import org.apache.pekko.cluster.ClusterEvent.{CurrentClusterState, MemberEvent, MemberExited, MemberRemoved, MemberUp}
 import io.gearpump.cluster.master.{Master => MasterActor, MasterNode}
 import io.gearpump.cluster.master.Master.MasterListUpdated
 import io.gearpump.util.Constants.MASTER
@@ -31,7 +31,7 @@ class MasterWatcher(role: String) extends Actor with ActorLogging {
   val cluster = Cluster(context.system)
 
   val config = context.system.settings.config
-  val masters = config.getList("akka.cluster.seed-nodes")
+  val masters = config.getList("pekko.cluster.seed-nodes")
   val quorum = masters.size() / 2 + 1
 
   val system = context.system

--- a/core/src/main/scala/io/gearpump/cluster/main/Replay.scala
+++ b/core/src/main/scala/io/gearpump/cluster/main/Replay.scala
@@ -28,11 +28,11 @@ object Replay extends MasterClientCommand with ArgumentsParser {
 
   override val description = "Replay the application from current min clock(low watermark)"
 
-  def main(akkaConf: Config, args: Array[String]): Unit = {
+  def main(pekkoConf: Config, args: Array[String]): Unit = {
     val config = parse(args)
 
     if (null != config) {
-      val client = ClientContext(akkaConf)
+      val client = ClientContext(pekkoConf)
       client.replayFromTimestampWindowTrailingEdge(config.getInt("appid"))
       client.close()
     }

--- a/core/src/main/scala/io/gearpump/cluster/main/Worker.scala
+++ b/core/src/main/scala/io/gearpump/cluster/main/Worker.scala
@@ -14,12 +14,12 @@
 
 package io.gearpump.cluster.main
 
-import akka.actor.{ActorSystem, Props}
+import org.apache.pekko.actor.{ActorSystem, Props}
 import io.gearpump.cluster.ClusterConfig
 import io.gearpump.cluster.master.MasterProxy
 import io.gearpump.cluster.worker.{Worker => WorkerActor}
 import io.gearpump.transport.HostPort
-import io.gearpump.util.{AkkaApp, LogUtil}
+import io.gearpump.util.{PekkoApp, LogUtil}
 import io.gearpump.util.Constants._
 import io.gearpump.util.LogUtil.ProcessType
 import org.slf4j.Logger
@@ -28,8 +28,8 @@ import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
 /** Tool to start a worker daemon process */
-object Worker extends AkkaApp with ArgumentsParser {
-  protected override def akkaConfig = ClusterConfig.worker()
+object Worker extends PekkoApp with ArgumentsParser {
+  protected override def pekkoConfig = ClusterConfig.worker()
 
   override val description = "Start a worker daemon"
 
@@ -37,19 +37,19 @@ object Worker extends AkkaApp with ArgumentsParser {
 
   private def uuid = java.util.UUID.randomUUID.toString
 
-  def main(akkaConf: Config, args: Array[String]): Unit = {
+  def main(pekkoConf: Config, args: Array[String]): Unit = {
     val id = uuid
 
     this.LOG = {
-      LogUtil.loadConfiguration(akkaConf, ProcessType.WORKER)
+      LogUtil.loadConfiguration(pekkoConf, ProcessType.WORKER)
       // Delay creation of LOG instance to avoid creating an empty log file as we
       // reset the log file name here
       LogUtil.getLogger(getClass)
     }
 
-    val system = ActorSystem(id, akkaConf)
+    val system = ActorSystem(id, pekkoConf)
 
-    val masterAddress = akkaConf.getStringList(GEARPUMP_CLUSTER_MASTERS).asScala.map { address =>
+    val masterAddress = pekkoConf.getStringList(GEARPUMP_CLUSTER_MASTERS).asScala.map { address =>
       val hostAndPort = address.split(":")
       HostPort(hostAndPort(0), hostAndPort(1).toInt)
     }

--- a/core/src/main/scala/io/gearpump/cluster/master/AppManager.scala
+++ b/core/src/main/scala/io/gearpump/cluster/master/AppManager.scala
@@ -14,8 +14,8 @@
 
 package io.gearpump.cluster.master
 
-import akka.actor._
-import akka.pattern.ask
+import org.apache.pekko.actor._
+import org.apache.pekko.pattern.ask
 import com.typesafe.config.{Config, ConfigFactory}
 import io.gearpump.Time.MilliSeconds
 import io.gearpump.cluster.{ApplicationStatus, ApplicationTerminalStatus}

--- a/core/src/main/scala/io/gearpump/cluster/master/AppMasterLauncher.scala
+++ b/core/src/main/scala/io/gearpump/cluster/master/AppMasterLauncher.scala
@@ -14,7 +14,7 @@
 
 package io.gearpump.cluster.master
 
-import akka.actor.{Actor, ActorRef, Props, _}
+import org.apache.pekko.actor.{Actor, ActorRef, Props, _}
 import com.typesafe.config.Config
 import io.gearpump.cluster.{AppDescription, AppJar, _}
 import io.gearpump.cluster.AppMasterToMaster.RequestResource
@@ -49,7 +49,7 @@ class AppMasterLauncher(
   private val systemConfig = context.system.settings.config
   private val TIMEOUT = Duration(15, TimeUnit.SECONDS)
 
-  private val appMasterAkkaConfig: Config = app.clusterConfig
+  private val appMasterPekkoConfig: Config = app.clusterConfig
 
   LOG.info(s"Ask Master resource to start AppMaster $appId...")
   master ! RequestResource(appId, ResourceRequest(Resource(1), WorkerId.unspecified))
@@ -68,10 +68,10 @@ class AppMasterLauncher(
       val selfPath = ActorUtil.getFullPath(context.system, self.path)
 
       val jvmSetting =
-        Util.resolveJvmSetting(appMasterAkkaConfig.withFallback(systemConfig)).appMater
+        Util.resolveJvmSetting(appMasterPekkoConfig.withFallback(systemConfig)).appMater
       val executorJVM = ExecutorJVMConfig(jvmSetting.classPath, jvmSetting.vmargs,
         classOf[ActorSystemBooter].getName, Array(name, selfPath), jar,
-        username, appMasterAkkaConfig)
+        username, appMasterPekkoConfig)
 
       worker ! LaunchExecutor(appId, executorId, resource, executorJVM)
       context.become(waitForActorSystemToStart(worker, appMasterContext, resource))

--- a/core/src/main/scala/io/gearpump/cluster/master/InMemoryKVService.scala
+++ b/core/src/main/scala/io/gearpump/cluster/master/InMemoryKVService.scala
@@ -14,10 +14,10 @@
 
 package io.gearpump.cluster.master
 
-import akka.actor._
-import akka.cluster.Cluster
-import akka.cluster.ddata.{DistributedData, LWWMap, LWWMapKey}
-import akka.cluster.ddata.Replicator._
+import org.apache.pekko.actor._
+import org.apache.pekko.cluster.Cluster
+import org.apache.pekko.cluster.ddata.{DistributedData, LWWMap, LWWMapKey}
+import org.apache.pekko.cluster.ddata.Replicator._
 import io.gearpump.util.LogUtil
 import java.util.concurrent.TimeUnit
 import org.slf4j.Logger

--- a/core/src/main/scala/io/gearpump/cluster/master/Master.scala
+++ b/core/src/main/scala/io/gearpump/cluster/master/Master.scala
@@ -14,8 +14,8 @@
 
 package io.gearpump.cluster.master
 
-import akka.actor._
-import akka.remote.DisassociatedEvent
+import org.apache.pekko.actor._
+import org.apache.pekko.remote.DisassociatedEvent
 import com.typesafe.config.Config
 import io.gearpump.cluster.AppMasterToMaster._
 import io.gearpump.cluster.ClientToMaster._

--- a/core/src/main/scala/io/gearpump/cluster/master/MasterProxy.scala
+++ b/core/src/main/scala/io/gearpump/cluster/master/MasterProxy.scala
@@ -14,7 +14,7 @@
 
 package io.gearpump.cluster.master
 
-import akka.actor._
+import org.apache.pekko.actor._
 import io.gearpump.transport.HostPort
 import io.gearpump.util.{ActorUtil, LogUtil}
 import org.slf4j.Logger

--- a/core/src/main/scala/io/gearpump/cluster/scheduler/PriorityScheduler.scala
+++ b/core/src/main/scala/io/gearpump/cluster/scheduler/PriorityScheduler.scala
@@ -14,7 +14,7 @@
 
 package io.gearpump.cluster.scheduler
 
-import akka.actor.ActorRef
+import org.apache.pekko.actor.ActorRef
 import io.gearpump.cluster.AppMasterToMaster.RequestResource
 import io.gearpump.cluster.MasterToAppMaster.ResourceAllocated
 import io.gearpump.cluster.scheduler.Relaxation._

--- a/core/src/main/scala/io/gearpump/cluster/scheduler/Resource.scala
+++ b/core/src/main/scala/io/gearpump/cluster/scheduler/Resource.scala
@@ -14,7 +14,7 @@
 
 package io.gearpump.cluster.scheduler
 
-import akka.actor.ActorRef
+import org.apache.pekko.actor.ActorRef
 import io.gearpump.cluster.scheduler.Priority.NORMAL
 import io.gearpump.cluster.scheduler.Priority.Priority
 import io.gearpump.cluster.scheduler.Relaxation.ANY

--- a/core/src/main/scala/io/gearpump/cluster/scheduler/Scheduler.scala
+++ b/core/src/main/scala/io/gearpump/cluster/scheduler/Scheduler.scala
@@ -13,7 +13,7 @@
  */
 package io.gearpump.cluster.scheduler
 
-import akka.actor.{Actor, ActorRef}
+import org.apache.pekko.actor.{Actor, ActorRef}
 import io.gearpump.Time.MilliSeconds
 import io.gearpump.cluster.MasterToWorker.{UpdateResourceFailed, UpdateResourceSucceed, WorkerRegistered}
 import io.gearpump.cluster.WorkerToMaster.ResourceUpdate

--- a/core/src/main/scala/io/gearpump/cluster/worker/Worker.scala
+++ b/core/src/main/scala/io/gearpump/cluster/worker/Worker.scala
@@ -14,8 +14,8 @@
 
 package io.gearpump.cluster.worker
 
-import akka.actor._
-import akka.actor.SupervisorStrategy.Stop
+import org.apache.pekko.actor._
+import org.apache.pekko.actor.SupervisorStrategy.Stop
 import com.typesafe.config.{Config, ConfigFactory, ConfigValueFactory}
 import io.gearpump.cluster.{ClusterConfig, ExecutorJVMConfig}
 import io.gearpump.cluster.AppMasterToMaster.{GetWorkerData, WorkerData}
@@ -343,7 +343,7 @@ private[cluster] object Worker {
       val workerConfig = context.system.settings.config
 
       val submissionConfig = Option(launch.executorJvmConfig).flatMap { jvmConfig =>
-        Option(jvmConfig.executorAkkaConfig)
+        Option(jvmConfig.executorPekkoConfig)
       }.getOrElse(ConfigFactory.empty())
 
       resolveExecutorConfig(workerConfig, submissionConfig)
@@ -361,11 +361,11 @@ private[cluster] object Worker {
         // Falls back to workerConfig
         .withFallback(workerConfig)
 
-      // Minimum supported akka.scheduler.tick-duration on Windows is 10ms
-      val duration = config.getInt(AKKA_SCHEDULER_TICK_DURATION)
-      val updatedConf = if (akka.util.Helpers.isWindows && duration < 10) {
-        LOG.warn(s"$AKKA_SCHEDULER_TICK_DURATION on Windows must be larger than 10ms, set to 10ms")
-        config.withValue(AKKA_SCHEDULER_TICK_DURATION, ConfigValueFactory.fromAnyRef(10))
+      // Minimum supported pekko.scheduler.tick-duration on Windows is 10ms
+      val duration = config.getInt(PEKKO_SCHEDULER_TICK_DURATION)
+      val updatedConf = if (org.apache.pekko.util.Helpers.isWindows && duration < 10) {
+        LOG.warn(s"$PEKKO_SCHEDULER_TICK_DURATION on Windows must be larger than 10ms, set to 10ms")
+        config.withValue(PEKKO_SCHEDULER_TICK_DURATION, ConfigValueFactory.fromAnyRef(10))
       } else {
         config
       }

--- a/core/src/main/scala/io/gearpump/jarstore/FileDirective.scala
+++ b/core/src/main/scala/io/gearpump/jarstore/FileDirective.scala
@@ -14,20 +14,20 @@
 
 package io.gearpump.jarstore
 
-import akka.http.scaladsl.model.{HttpEntity, MediaTypes, Multipart}
-import akka.http.scaladsl.server._
-import akka.http.scaladsl.server.Directives._
-import akka.stream.Materializer
-import akka.stream.scaladsl.{FileIO, StreamConverters}
-import akka.util.ByteString
+import org.apache.pekko.http.scaladsl.model.{HttpEntity, MediaTypes, Multipart}
+import org.apache.pekko.http.scaladsl.server._
+import org.apache.pekko.http.scaladsl.server.Directives._
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.{FileIO, StreamConverters}
+import org.apache.pekko.util.ByteString
 import java.io.File
 import java.time.Instant
 import scala.concurrent.{ExecutionContext, Future}
 
 
 /**
- * FileDirective is a set of Akka-http directive to upload/download
- * huge binary files to/from Akka-Http server.
+ * FileDirective is a set of Pekko HTTP directives to upload/download
+ * huge binary files to/from a Pekko HTTP server.
  */
 object FileDirective {
 

--- a/core/src/main/scala/io/gearpump/jarstore/FileServer.scala
+++ b/core/src/main/scala/io/gearpump/jarstore/FileServer.scala
@@ -13,18 +13,18 @@
  */
 package io.gearpump.jarstore
 
-import akka.Done
-import akka.actor.ActorSystem
-import akka.http.scaladsl.Http
-import akka.http.scaladsl.Http.ServerBinding
-import akka.http.scaladsl.marshalling.Marshal
-import akka.http.scaladsl.model.{HttpEntity, HttpRequest, MediaTypes, Multipart, _}
-import akka.http.scaladsl.model.Uri.{Path, Query}
-import akka.http.scaladsl.server._
-import akka.http.scaladsl.server.Directives._
-import akka.http.scaladsl.unmarshalling.Unmarshal
-import akka.stream.{ActorMaterializer, IOResult}
-import akka.stream.scaladsl.{FileIO, Sink, Source}
+import org.apache.pekko.Done
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.Http
+import org.apache.pekko.http.scaladsl.Http.ServerBinding
+import org.apache.pekko.http.scaladsl.marshalling.Marshal
+import org.apache.pekko.http.scaladsl.model.{HttpEntity, HttpRequest, MediaTypes, Multipart, _}
+import org.apache.pekko.http.scaladsl.model.Uri.{Path, Query}
+import org.apache.pekko.http.scaladsl.server._
+import org.apache.pekko.http.scaladsl.server.Directives._
+import org.apache.pekko.http.scaladsl.unmarshalling.Unmarshal
+import org.apache.pekko.stream.{IOResult, Materializer}
+import org.apache.pekko.stream.scaladsl.{FileIO, Sink, Source}
 import io.gearpump.jarstore.FileDirective._
 import io.gearpump.jarstore.FileServer.Port
 import java.io.File
@@ -33,13 +33,13 @@ import spray.json.DefaultJsonProtocol._
 import spray.json.JsonFormat
 
 /**
- * A simple file server implemented with akka-http to store/fetch large
+ * A simple file server implemented with Pekko HTTP to store/fetch large
  * binary files.
  */
 class FileServer(system: ActorSystem, host: String, port: Int = 0, jarStore: JarStore) {
   import system.dispatcher
   implicit val actorSystem = system
-  implicit val materializer = ActorMaterializer()
+  implicit val materializer: Materializer = Materializer(actorSystem)
   implicit def ec: ExecutionContext = system.dispatcher
 
   val route: Route = {
@@ -82,7 +82,7 @@ class FileServer(system: ActorSystem, host: String, port: Int = 0, jarStore: Jar
   private var connection: Future[ServerBinding] = _
 
   def start: Future[Port] = {
-    connection = Http().bindAndHandle(Route.handlerFlow(route), host, port)
+    connection = Http().newServerAt(host, port).bind(route)
     connection.map(address => Port(address.localAddress.getPort))
   }
 
@@ -107,7 +107,7 @@ object FileServer {
     }
 
     private implicit val actorSystem = system
-    private implicit val materializer = ActorMaterializer()
+    private implicit val materializer: Materializer = Materializer(actorSystem)
     private implicit val ec = system.dispatcher
 
     val server = Uri(s"http://$host:$port")

--- a/core/src/main/scala/io/gearpump/jarstore/JarStoreClient.scala
+++ b/core/src/main/scala/io/gearpump/jarstore/JarStoreClient.scala
@@ -13,8 +13,8 @@
  */
 package io.gearpump.jarstore
 
-import akka.actor.{ActorRef, ActorSystem}
-import akka.pattern.ask
+import org.apache.pekko.actor.{ActorRef, ActorSystem}
+import org.apache.pekko.pattern.ask
 import com.typesafe.config.Config
 import io.gearpump.cluster.ClientToMaster.{GetJarStoreServer, JarStoreServerAddress}
 import io.gearpump.cluster.master.MasterProxy

--- a/core/src/main/scala/io/gearpump/jarstore/JarStoreServer.scala
+++ b/core/src/main/scala/io/gearpump/jarstore/JarStoreServer.scala
@@ -14,8 +14,8 @@
 
 package io.gearpump.jarstore
 
-import akka.actor.{Actor, Stash}
-import akka.pattern.pipe
+import org.apache.pekko.actor.{Actor, Stash}
+import org.apache.pekko.pattern.pipe
 import io.gearpump.cluster.ClientToMaster.{GetJarStoreServer, JarStoreServerAddress}
 import io.gearpump.util.Constants
 

--- a/core/src/main/scala/io/gearpump/metrics/AkkaReporter.scala
+++ b/core/src/main/scala/io/gearpump/metrics/AkkaReporter.scala
@@ -14,57 +14,7 @@
 
 package io.gearpump.metrics
 
-import akka.actor.ActorRef
-import com.codahale.metrics.{Gauge => CodaGauge, MetricRegistry}
-import io.gearpump.metrics.Metrics.{Counter => CounterData, Gauge => GaugeData, Histogram => HistogramData, Meter => MeterData}
-import io.gearpump.metrics.MetricsReporterService.ReportTo
-import io.gearpump.util.LogUtil
-import scala.collection.JavaConverters._
+import com.codahale.metrics.MetricRegistry
 
-/**
- * A reporter class for logging metrics values to a remote actor periodically
- */
-class AkkaReporter(registry: MetricRegistry)
-  extends ReportTo {
-  private val LOG = LogUtil.getLogger(getClass)
-  LOG.info("Start Metrics AkkaReporter")
-
-  override def report(to: ActorRef): Unit = {
-    val counters = registry.getCounters()
-    val histograms = registry.getHistograms()
-    val meters = registry.getMeters()
-    val gauges = registry.getGauges()
-
-    counters.entrySet().asScala.foreach { pair =>
-      to ! CounterData(pair.getKey, pair.getValue.getCount)
-    }
-
-    histograms.entrySet().asScala.foreach { pair =>
-      val key = pair.getKey
-      val value = pair.getValue
-      val s = value.getSnapshot
-      to ! HistogramData(
-        key, s.getMean, s.getStdDev, s.getMedian,
-        s.get95thPercentile, s.get99thPercentile, s.get999thPercentile)
-    }
-
-    meters.entrySet().asScala.foreach { pair =>
-      val key = pair.getKey
-      val value = pair.getValue
-      to ! MeterData(key,
-        value.getCount,
-        value.getMeanRate,
-        value.getOneMinuteRate,
-        getRateUnit)
-    }
-
-    gauges.entrySet().asScala.foreach { kv =>
-      val value = kv.getValue.asInstanceOf[CodaGauge[Number]].getValue.longValue()
-      to ! GaugeData(kv.getKey, value)
-    }
-  }
-
-  private def getRateUnit: String = {
-    "events/s"
-  }
-}
+/** Compatibility shim for code that still references AkkaReporter. */
+class AkkaReporter(registry: MetricRegistry) extends PekkoReporter(registry)

--- a/core/src/main/scala/io/gearpump/metrics/Metrics.scala
+++ b/core/src/main/scala/io/gearpump/metrics/Metrics.scala
@@ -14,7 +14,7 @@
 
 package io.gearpump.metrics
 
-import akka.actor._
+import org.apache.pekko.actor._
 import com.codahale.metrics._
 import io.gearpump
 import io.gearpump.util.Constants._

--- a/core/src/main/scala/io/gearpump/metrics/MetricsReporterService.scala
+++ b/core/src/main/scala/io/gearpump/metrics/MetricsReporterService.scala
@@ -14,7 +14,7 @@
 
 package io.gearpump.metrics
 
-import akka.actor.{Actor, ActorRef}
+import org.apache.pekko.actor.{Actor, ActorRef}
 import com.codahale.metrics.{MetricFilter, Slf4jReporter}
 import com.codahale.metrics.graphite.{Graphite, GraphiteReporter}
 import io.gearpump.metrics.Metrics.{DemandMoreMetrics, ReportMetrics}
@@ -26,7 +26,7 @@ import java.util.concurrent.TimeUnit
 import scala.concurrent.duration._
 
 /**
- * Reports the metrics data to some where, like Ganglia, remote Akka actor, log files...
+ * Reports the metrics data to some where, like Ganglia, a remote Pekko actor, or log files.
  *
  * @param metrics Holds a list of metrics object.
  */
@@ -78,8 +78,8 @@ class MetricsReporterService(metrics: Metrics) extends Actor {
     }
   }
 
-  def startAkkaReporter(): ReportTo = {
-    new AkkaReporter(metrics.registry)
+  def startPekkoReporter(): ReportTo = {
+    new PekkoReporter(metrics.registry)
   }
 
   def getReporter: ReportTo = {
@@ -88,7 +88,8 @@ class MetricsReporterService(metrics: Metrics) extends Actor {
     val reporter = reporterType match {
       case "graphite" => startGraphiteReporter()
       case "logfile" => startSlf4jReporter()
-      case "akka" => startAkkaReporter()
+      case "pekko" => startPekkoReporter()
+      case "akka" => startPekkoReporter()
     }
     reporter
   }

--- a/core/src/main/scala/io/gearpump/metrics/PekkoReporter.scala
+++ b/core/src/main/scala/io/gearpump/metrics/PekkoReporter.scala
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gearpump.metrics
+
+import org.apache.pekko.actor.ActorRef
+import com.codahale.metrics.{Gauge => CodaGauge, MetricRegistry}
+import io.gearpump.metrics.Metrics.{Counter => CounterData, Gauge => GaugeData, Histogram => HistogramData, Meter => MeterData}
+import io.gearpump.metrics.MetricsReporterService.ReportTo
+import io.gearpump.util.LogUtil
+import scala.collection.JavaConverters._
+
+/**
+ * A reporter class for logging metrics values to a remote actor periodically
+ */
+class PekkoReporter(registry: MetricRegistry)
+  extends ReportTo {
+  private val LOG = LogUtil.getLogger(getClass)
+  LOG.info("Start Metrics PekkoReporter")
+
+  override def report(to: ActorRef): Unit = {
+    val counters = registry.getCounters()
+    val histograms = registry.getHistograms()
+    val meters = registry.getMeters()
+    val gauges = registry.getGauges()
+
+    counters.entrySet().asScala.foreach { pair =>
+      to ! CounterData(pair.getKey, pair.getValue.getCount)
+    }
+
+    histograms.entrySet().asScala.foreach { pair =>
+      val key = pair.getKey
+      val value = pair.getValue
+      val s = value.getSnapshot
+      to ! HistogramData(
+        key, s.getMean, s.getStdDev, s.getMedian,
+        s.get95thPercentile, s.get99thPercentile, s.get999thPercentile)
+    }
+
+    meters.entrySet().asScala.foreach { pair =>
+      val key = pair.getKey
+      val value = pair.getValue
+      to ! MeterData(key,
+        value.getCount,
+        value.getMeanRate,
+        value.getOneMinuteRate,
+        getRateUnit)
+    }
+
+    gauges.entrySet().asScala.foreach { kv =>
+      val value = kv.getValue.asInstanceOf[CodaGauge[Number]].getValue.longValue()
+      to ! GaugeData(kv.getKey, value)
+    }
+  }
+
+  private def getRateUnit: String = {
+    "events/s"
+  }
+}

--- a/core/src/main/scala/io/gearpump/serializer/FastKryoSerializationFramework.scala
+++ b/core/src/main/scala/io/gearpump/serializer/FastKryoSerializationFramework.scala
@@ -14,7 +14,7 @@
 
 package io.gearpump.serializer
 
-import akka.actor.ExtendedActorSystem
+import org.apache.pekko.actor.ExtendedActorSystem
 import io.gearpump.cluster.UserConfig
 
 /**

--- a/core/src/main/scala/io/gearpump/serializer/FastKryoSerializer.scala
+++ b/core/src/main/scala/io/gearpump/serializer/FastKryoSerializer.scala
@@ -14,24 +14,15 @@
 
 package io.gearpump.serializer
 
-import akka.actor.ExtendedActorSystem
-import com.esotericsoftware.kryo.Kryo.DefaultInstantiatorStrategy
-import com.romix.akka.serialization.kryo.{KryoBasedSerializer, KryoSerializer}
+import org.apache.pekko.actor.ExtendedActorSystem
+import io.altoo.serialization.kryo.pekko.PekkoKryoSerializer
 import io.gearpump.serializer.FastKryoSerializer.KryoSerializationException
 import io.gearpump.util.LogUtil
-import org.objenesis.strategy.StdInstantiatorStrategy
 
 class FastKryoSerializer(system: ExtendedActorSystem) extends Serializer {
 
   private val LOG = LogUtil.getLogger(getClass)
-  private val config = system.settings.config
-
-  private val kryoSerializer: KryoBasedSerializer = new KryoSerializer(system).serializer
-  private val kryo = kryoSerializer.kryo
-  val strategy = new DefaultInstantiatorStrategy
-  strategy.setFallbackInstantiatorStrategy(new StdInstantiatorStrategy)
-  kryo.setInstantiatorStrategy(strategy)
-  new GearpumpSerialization(config).customize(kryo)
+  private val kryoSerializer = new PekkoKryoSerializer(system)
 
   override def serialize(message: Any): Array[Byte] = {
     try {
@@ -68,7 +59,7 @@ class FastKryoSerializer(system: ExtendedActorSystem) extends Serializer {
   }
 
   override def deserialize(msg: Array[Byte]): Any = {
-    kryoSerializer.fromBinary(msg)
+    kryoSerializer.fromBinary(msg, None)
   }
 }
 

--- a/core/src/main/scala/io/gearpump/serializer/GearpumpPekkoKryoInitializer.scala
+++ b/core/src/main/scala/io/gearpump/serializer/GearpumpPekkoKryoInitializer.scala
@@ -12,25 +12,15 @@
  * limitations under the License.
  */
 
-package io.gearpump.transport.netty
+package io.gearpump.serializer
 
-import org.apache.pekko.actor.ActorRef
-import io.gearpump.transport.{ActorLookupById, HostPort}
+import io.altoo.serialization.kryo.pekko.DefaultKryoInitializer
+import io.altoo.serialization.kryo.scala.serializer.ScalaKryo
 
-trait IContext {
+class GearpumpPekkoKryoInitializer extends DefaultKryoInitializer {
 
-  /**
-   * Create a Netty server connection.
-   */
-  def bind(name: String, lookupActor: ActorLookupById, deserializeFlag: Boolean, port: Int): Int
-
-  /**
-   * Create a Netty client actor
-   */
-  def connect(hostPort: HostPort): ActorRef
-
-  /**
-   * Close resource for this context
-   */
-  def close()
+  override def postInit(kryo: ScalaKryo): Unit = {
+    super.postInit(kryo)
+    new GearpumpSerialization(system.settings.config).customize(kryo)
+  }
 }

--- a/core/src/main/scala/io/gearpump/serializer/GearpumpSerialization.scala
+++ b/core/src/main/scala/io/gearpump/serializer/GearpumpSerialization.scala
@@ -14,7 +14,7 @@
 
 package io.gearpump.serializer
 
-import com.esotericsoftware.kryo.{Kryo, Serializer => KryoSerializer}
+import com.esotericsoftware.kryo.kryo5.{Kryo, Serializer => KryoSerializer}
 import com.typesafe.config.Config
 import io.gearpump.util.{Constants, LogUtil}
 import org.slf4j.Logger
@@ -38,7 +38,7 @@ class GearpumpSerialization(config: Config) {
       } else {
         val valueClass = Class.forName(value)
         val register = kryo.register(keyClass,
-          valueClass.newInstance().asInstanceOf[KryoSerializer[_]])
+          valueClass.getDeclaredConstructor().newInstance().asInstanceOf[KryoSerializer[_]])
         LOG.debug(s"Registering ${keyClass}, id: ${register.getId}")
       }
     }

--- a/core/src/main/scala/io/gearpump/serializer/SerializationFramework.scala
+++ b/core/src/main/scala/io/gearpump/serializer/SerializationFramework.scala
@@ -14,7 +14,7 @@
 
 package io.gearpump.serializer
 
-import akka.actor.ExtendedActorSystem
+import org.apache.pekko.actor.ExtendedActorSystem
 import io.gearpump.cluster.UserConfig
 
 /**

--- a/core/src/main/scala/io/gearpump/transport/Express.scala
+++ b/core/src/main/scala/io/gearpump/transport/Express.scala
@@ -14,8 +14,7 @@
 
 package io.gearpump.transport
 
-import akka.actor._
-import akka.agent.Agent
+import org.apache.pekko.actor._
 import com.github.ghik.silencer.silent
 import io.gearpump.transport.netty.{Context, TaskMessage}
 import io.gearpump.transport.netty.Client.Close
@@ -23,6 +22,7 @@ import io.gearpump.util.LogUtil
 import org.slf4j.Logger
 import scala.collection.immutable.LongMap
 import scala.concurrent._
+import java.util.concurrent.atomic.AtomicReference
 
 trait ActorLookupById {
 
@@ -40,10 +40,10 @@ class Express(val system: ExtendedActorSystem) extends Extension with ActorLooku
 
   import io.gearpump.transport.Express._
   import system.dispatcher
-  @silent val localActorMap = Agent(LongMap.empty[ActorRef])
-  @silent val remoteAddressMap = Agent(Map.empty[Long, HostPort])
+  @silent val localActorMap = StateRef(LongMap.empty[ActorRef])
+  @silent val remoteAddressMap = StateRef(Map.empty[Long, HostPort])
 
-  @silent val remoteClientMap = Agent(Map.empty[HostPort, ActorRef])
+  @silent val remoteClientMap = StateRef(Map.empty[HostPort, ActorRef])
 
   val conf = system.settings.config
 
@@ -103,7 +103,7 @@ class Express(val system: ExtendedActorSystem) extends Extension with ActorLooku
   /** Send message to remote task */
   def transport(taskMessage: TaskMessage, remote: HostPort): Unit = {
 
-    val remoteClient = remoteClientMap.get.get(remote)
+    val remoteClient = remoteClientMap.get().get(remote)
     if (remoteClient.isDefined) {
       remoteClient.get.tell(taskMessage, Actor.noSender)
     } else {
@@ -115,9 +115,30 @@ class Express(val system: ExtendedActorSystem) extends Extension with ActorLooku
   }
 }
 
-/** A customized transport layer by using Akka extension */
+/** A customized transport layer implemented as a Pekko extension. */
 object Express extends ExtensionId[Express] with ExtensionIdProvider {
   val LOG: Logger = LogUtil.getLogger(getClass)
+
+  private final case class StateRef[A](initial: A)(implicit ec: ExecutionContext) {
+    private val ref = new AtomicReference[A](initial)
+
+    def get(): A = ref.get()
+
+    def sendOff(update: A => A): Future[A] = Future(alterNow(update))
+
+    def alter(update: A => A): Future[A] = Future(alterNow(update))
+
+    private def alterNow(update: A => A): A = {
+      var updated = false
+      var next = ref.get()
+      while (!updated) {
+        val current = ref.get()
+        next = update(current)
+        updated = ref.compareAndSet(current, next)
+      }
+      next
+    }
+  }
 
   override def get(system: ActorSystem): Express = super.get(system)
 

--- a/core/src/main/scala/io/gearpump/transport/netty/Client.scala
+++ b/core/src/main/scala/io/gearpump/transport/netty/Client.scala
@@ -14,7 +14,7 @@
 
 package io.gearpump.transport.netty
 
-import akka.actor.Actor
+import org.apache.pekko.actor.Actor
 import io.gearpump.transport.HostPort
 import io.gearpump.util.LogUtil
 import java.net.{ConnectException, InetSocketAddress}

--- a/core/src/main/scala/io/gearpump/transport/netty/Context.scala
+++ b/core/src/main/scala/io/gearpump/transport/netty/Context.scala
@@ -14,7 +14,7 @@
 
 package io.gearpump.transport.netty
 
-import akka.actor.{ActorRef, ActorSystem, Props}
+import org.apache.pekko.actor.{ActorRef, ActorSystem, Props}
 import com.typesafe.config.Config
 import io.gearpump.transport.{ActorLookupById, HostPort}
 import io.gearpump.transport.netty.Server.ServerPipelineFactory

--- a/core/src/main/scala/io/gearpump/transport/netty/Server.scala
+++ b/core/src/main/scala/io/gearpump/transport/netty/Server.scala
@@ -14,9 +14,9 @@
 
 package io.gearpump.transport.netty
 
-import akka.actor.{Actor, ActorContext, ActorRef, ExtendedActorSystem}
+import org.apache.pekko.actor.{Actor, ActorContext, ActorRef, ExtendedActorSystem}
 import io.gearpump.transport.ActorLookupById
-import io.gearpump.util.{AkkaHelper, LogUtil}
+import io.gearpump.util.{PekkoHelper, LogUtil}
 import java.util
 import org.jboss.netty.channel._
 import org.jboss.netty.channel.group.{ChannelGroup, DefaultChannelGroup}
@@ -111,7 +111,7 @@ object Server {
       if (!taskIdtoActorRef.contains(sessionId)) {
 
         // A fake ActorRef for performance optimization.
-        val actorRef = AkkaHelper.actorFor(context.system, s"/session#$sessionId")
+        val actorRef = PekkoHelper.actorFor(context.system, s"/session#$sessionId")
         taskIdtoActorRef += sessionId -> actorRef
       }
       taskIdtoActorRef.get(sessionId).get

--- a/core/src/main/scala/io/gearpump/util/ActorSystemBooter.scala
+++ b/core/src/main/scala/io/gearpump/util/ActorSystemBooter.scala
@@ -14,7 +14,7 @@
 
 package io.gearpump.util
 
-import akka.actor._
+import org.apache.pekko.actor._
 import com.typesafe.config.Config
 import io.gearpump.cluster.ClusterConfig
 import io.gearpump.util.LogUtil.ProcessType

--- a/core/src/main/scala/io/gearpump/util/ActorUtil.scala
+++ b/core/src/main/scala/io/gearpump/util/ActorUtil.scala
@@ -14,10 +14,10 @@
 
 package io.gearpump.util
 
-import akka.actor._
-import akka.actor.Actor.Receive
-import akka.pattern.ask
-import akka.util.Timeout
+import org.apache.pekko.actor._
+import org.apache.pekko.actor.Actor.Receive
+import org.apache.pekko.pattern.ask
+import org.apache.pekko.util.Timeout
 import io.gearpump.cluster.{ApplicationStatus, AppMasterContext}
 import io.gearpump.cluster.AppMasterToMaster.{ApplicationStatusChanged, GetAllWorkers}
 import io.gearpump.cluster.ClientToMaster.{ResolveAppId, ResolveWorkerId}
@@ -81,10 +81,10 @@ object ActorUtil {
     executorId
 
   // TODO: Currently we explicitly require the master contacts to be started with this path pattern
-  // akka.tcp://$MASTER@${master.host}:${master.port}/user/$MASTER
+  // pekko.tcp://$MASTER@${master.host}:${master.port}/user/$MASTER
   def getMasterActorPath(master: HostPort): ActorPath = {
     import Constants.MASTER
-    ActorPath.fromString(s"akka.tcp://$MASTER@${master.host}:${master.port}/user/$MASTER")
+    ActorPath.fromString(s"pekko.tcp://$MASTER@${master.host}:${master.port}/user/$MASTER")
   }
 
   def launchExecutorOnEachWorker(master: ActorRef, executorJvmConfig: ExecutorSystemJvmConfig,

--- a/core/src/main/scala/io/gearpump/util/AkkaApp.scala
+++ b/core/src/main/scala/io/gearpump/util/AkkaApp.scala
@@ -14,27 +14,5 @@
 
 package io.gearpump.util
 
-import io.gearpump.cluster.ClusterConfig
-import scala.util.Try
-
-/**
- * A Main class helper to load Akka configuration automatically.
- */
-trait AkkaApp {
-
-  type Config = com.typesafe.config.Config
-
-  def main(akkaConf: Config, args: Array[String]): Unit
-
-  def help(): Unit
-
-  protected def akkaConfig: Config = {
-    ClusterConfig.default()
-  }
-
-  def main(args: Array[String]): Unit = {
-    Try {
-      main(akkaConfig, args)
-    }.failed.foreach { ex => help(); throw ex }
-  }
-}
+/** Compatibility shim for code that still imports AkkaApp. */
+trait AkkaApp extends PekkoApp

--- a/core/src/main/scala/io/gearpump/util/Constants.scala
+++ b/core/src/main/scala/io/gearpump/util/Constants.scala
@@ -74,7 +74,7 @@ object Constants {
   // responsive time if set to too big. Please make sure you have
   // enough justification to change this global setting, otherwise
   // please use your local timeout setting instead.
-  val FUTURE_TIMEOUT = akka.util.Timeout(15, TimeUnit.SECONDS)
+  val FUTURE_TIMEOUT = org.apache.pekko.util.Timeout(15, TimeUnit.SECONDS)
 
   val GEARPUMP_START_EXECUTOR_SYSTEM_TIMEOUT_MS = "gearpump.start-executor-system-timeout-ms"
 
@@ -86,7 +86,7 @@ object Constants {
   val NETTY_MAX_SLEEP_MS = "gearpump.netty.max-sleep-ms"
   val NETTY_MESSAGE_BATCH_SIZE = "gearpump.netty.message-batch-size"
   val NETTY_FLUSH_CHECK_INTERVAL = "gearpump.netty.flush-check-interval"
-  val NETTY_TCP_HOSTNAME = "akka.remote.netty.tcp.hostname"
+  val NETTY_TCP_HOSTNAME = "pekko.remote.classic.netty.tcp.hostname"
   val NETTY_DISPATCHER = "gearpump.netty.dispatcher"
 
   val GEARPUMP_USERNAME = "gearpump.username"
@@ -138,8 +138,8 @@ object Constants {
   val GEARPUMP_KEYTAB_FILE = "gearpump.keytab.file"
   val GEARPUMP_KERBEROS_PRINCIPAL = "gearpump.kerberos.principal"
 
-  val GEARPUMP_METRICS_MAX_LIMIT = "gearpump.metrics.akka.max-limit-on-query"
-  val GEARPUMP_METRICS_AGGREGATORS = "gearpump.metrics.akka.metrics-aggregator-class"
+  val GEARPUMP_METRICS_MAX_LIMIT = "gearpump.metrics.pekko.max-limit-on-query"
+  val GEARPUMP_METRICS_AGGREGATORS = "gearpump.metrics.pekko.metrics-aggregator-class"
 
   val GEARPUMP_UI_SECURITY = "gearpump.ui-security"
   val GEARPUMP_UI_SECURITY_AUTHENTICATION_ENABLED = "gearpump.ui-security.authentication-enabled"
@@ -161,5 +161,5 @@ object Constants {
 
   val APPLICATION_TOTAL_RETRIES = "gearpump.application.total-retries"
 
-  val AKKA_SCHEDULER_TICK_DURATION = "akka.scheduler.tick-duration"
+  val PEKKO_SCHEDULER_TICK_DURATION = "pekko.scheduler.tick-duration"
 }

--- a/core/src/main/scala/io/gearpump/util/HistoryMetricsService.scala
+++ b/core/src/main/scala/io/gearpump/util/HistoryMetricsService.scala
@@ -14,7 +14,7 @@
 
 package io.gearpump.util
 
-import akka.actor.Actor
+import org.apache.pekko.actor.Actor
 import com.typesafe.config.Config
 import io.gearpump.Time.MilliSeconds
 import io.gearpump.cluster.ClientToMaster.{QueryHistoryMetrics, ReadOption}

--- a/core/src/main/scala/io/gearpump/util/MasterClientCommand.scala
+++ b/core/src/main/scala/io/gearpump/util/MasterClientCommand.scala
@@ -18,14 +18,14 @@ import io.gearpump.cluster.client.ClientContext
 import io.gearpump.util.LogUtil.ProcessType
 import scala.util.Try
 
-trait MasterClientCommand extends AkkaApp {
+trait MasterClientCommand extends PekkoApp {
 
   override def main(args: Array[String]): Unit = {
     ClientContext.setRemote()
-    LogUtil.loadConfiguration(akkaConfig, ProcessType.CLIENT)
+    LogUtil.loadConfiguration(pekkoConfig, ProcessType.CLIENT)
 
     Try {
-      main(akkaConfig, args)
+      main(pekkoConfig, args)
     }.failed.foreach { ex => help(); throw ex }
   }
 

--- a/core/src/main/scala/io/gearpump/util/PekkoApp.scala
+++ b/core/src/main/scala/io/gearpump/util/PekkoApp.scala
@@ -12,25 +12,29 @@
  * limitations under the License.
  */
 
-package io.gearpump.transport.netty
+package io.gearpump.util
 
-import org.apache.pekko.actor.ActorRef
-import io.gearpump.transport.{ActorLookupById, HostPort}
+import io.gearpump.cluster.ClusterConfig
+import scala.util.Try
 
-trait IContext {
+/**
+ * A main class helper to load Pekko configuration automatically.
+ */
+trait PekkoApp {
 
-  /**
-   * Create a Netty server connection.
-   */
-  def bind(name: String, lookupActor: ActorLookupById, deserializeFlag: Boolean, port: Int): Int
+  type Config = com.typesafe.config.Config
 
-  /**
-   * Create a Netty client actor
-   */
-  def connect(hostPort: HostPort): ActorRef
+  def main(pekkoConf: Config, args: Array[String]): Unit
 
-  /**
-   * Close resource for this context
-   */
-  def close()
+  def help(): Unit
+
+  protected def pekkoConfig: Config = {
+    ClusterConfig.default()
+  }
+
+  def main(args: Array[String]): Unit = {
+    Try {
+      main(pekkoConfig, args)
+    }.failed.foreach { ex => help(); throw ex }
+  }
 }

--- a/core/src/main/scala/io/gearpump/util/TimeOutScheduler.scala
+++ b/core/src/main/scala/io/gearpump/util/TimeOutScheduler.scala
@@ -14,8 +14,8 @@
 
 package io.gearpump.util
 
-import akka.actor.{Actor, ActorRef}
-import akka.pattern.ask
+import org.apache.pekko.actor.{Actor, ActorRef}
+import org.apache.pekko.pattern.ask
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}

--- a/core/src/test/resources/test.conf
+++ b/core/src/test/resources/test.conf
@@ -34,40 +34,38 @@ gearpump {
 gearpump-linux {
   ### On windows, the value must be larger than 10ms, check
   ### https://github.com/akka/akka/blob/master/akka-actor/src/main/scala/akka/actor/Scheduler.scala#L204
-  akka.scheduler.tick-duration = 1
+  pekko.scheduler.tick-duration = 1
 }
 
 ### Configuration only visible to worker nodes...
 gearpump-worker {
   ## Add worker overrided config
-  akka {
+  pekko {
     loglevel = "INFO"
     log-dead-letters = off
     log-dead-letters-during-shutdown = off
     actor {
-      provider = "akka.remote.RemoteActorRefProvider"
+      provider = "remote"
     }
     cluster {
       roles = ["worker"]
     }
     remote {
-      log-remote-lifecycle-events = off
+      artery.enabled = off
+      classic.log-remote-lifecycle-events = off
     }
   }
 }
 
 ### Configuration only visible to master nodes..
 gearpump-master {
-  extensions = [
-    "akka.contrib.datareplication.DataReplication$"
-  ]
-  akka {
+  pekko {
     loglevel = "INFO"
     log-dead-letters = off
     log-dead-letters-during-shutdown = off
     actor {
-      ## Master forms a akka cluster
-      provider = "akka.cluster.ClusterActorRefProvider"
+      ## Master forms a pekko cluster
+      provider = "cluster"
     }
     cluster {
       roles = ["master"]
@@ -77,7 +75,8 @@ gearpump-master {
       auto-down-unreachable-after = 15s
     }
     remote {
-      log-remote-lifecycle-events = off
+      artery.enabled = off
+      classic.log-remote-lifecycle-events = off
     }
   }
 }
@@ -100,7 +99,7 @@ gearpump-ui {
   }
 }
 
-akka {
+pekko {
   logger-startup-timeout = 30s
 
   log-dead-letters = on
@@ -108,9 +107,9 @@ akka {
   loglevel = "INFO"
   actor {
     creation-timeout = 60s
-    provider = "akka.remote.RemoteActorRefProvider"
+    provider = "remote"
     default-mailbox {
-      mailbox-type = "akka.dispatch.SingleConsumerOnlyUnboundedMailbox"
+      mailbox-type = "org.apache.pekko.dispatch.SingleConsumerOnlyUnboundedMailbox"
     }
     default-dispatcher {
       throughput = 10
@@ -126,23 +125,8 @@ akka {
     }
   }
   remote {
+    artery.enabled = off
 
-    log-remote-lifecycle-events = on
-    #    use-dispatcher = ""
-    use-dispatcher = "akka.remote.default-remote-dispatcher"
-    enabled-transports = ["akka.remote.netty.tcp"]
-    netty.tcp {
-      port = 0
-      hostname = "127.0.0.1"
-      server-socket-worker-pool {
-        pool-size-min = 1
-        pool-size-max = 2
-      }
-      client-socket-worker-pool {
-        pool-size-min = 1
-        pool-size-max = 2
-      }
-    }
     default-remote-dispatcher {
       throughput = 5
       type = Dispatcher
@@ -152,27 +136,44 @@ akka {
         parallelism-max = 2
       }
     }
-    startup-timeout = 600 s
-    shutdown-timeout = 600 s
-    flush-wait-on-shutdown = 2 s
-    command-ack-timeout = 600 s
+    classic {
+      log-remote-lifecycle-events = on
+      #    use-dispatcher = ""
+      use-dispatcher = "pekko.remote.default-remote-dispatcher"
+      enabled-transports = ["pekko.remote.classic.netty.tcp"]
+      netty.tcp {
+        port = 0
+        hostname = "127.0.0.1"
+        connection-timeout = 600 s
+        server-socket-worker-pool {
+          pool-size-min = 1
+          pool-size-max = 2
+        }
+        client-socket-worker-pool {
+          pool-size-min = 1
+          pool-size-max = 2
+        }
+      }
+      startup-timeout = 600 s
+      shutdown-timeout = 600 s
+      flush-wait-on-shutdown = 2 s
+      command-ack-timeout = 600 s
 
-    transport-failure-detector {
-      heartbeat-interval = 600 s
-      acceptable-heartbeat-pause = 2000 s
+      transport-failure-detector {
+        heartbeat-interval = 600 s
+        acceptable-heartbeat-pause = 2000 s
+      }
+      watch-failure-detector {
+        heartbeat-interval = 600 s
+        acceptable-heartbeat-pause = 10 s
+        unreachable-nodes-reaper-interval = 600s
+        expected-response-after = 3 s
+      }
+      retry-gate-closed-for = 5 s
+      prune-quarantine-marker-after = 5 d
+      system-message-ack-piggyback-timeout = 600 s
+      resend-interval = 600 s
+      initial-system-message-delivery-timeout = 3 m
     }
-    watch-failure-detector {
-      heartbeat-interval = 600 s
-      acceptable-heartbeat-pause = 10 s
-      unreachable-nodes-reaper-interval = 600s
-      expected-response-after = 3 s
-    }
-    retry-gate-closed-for = 5 s
-    prune-quarantine-marker-after = 5 d
-    system-message-ack-piggyback-timeout = 600 s
-    resend-interval = 600 s
-    initial-system-message-delivery-timeout = 3 m
-    enabled-transports = ["akka.remote.netty.tcp"]
-    netty.tcp.connection-timeout = 600 s
   }
 }

--- a/core/src/test/scala/io/gearpump/TestProbeUtil.scala
+++ b/core/src/test/scala/io/gearpump/TestProbeUtil.scala
@@ -14,8 +14,8 @@
 
 package io.gearpump
 
-import akka.actor.{Actor, Props, Terminated}
-import akka.testkit.TestProbe
+import org.apache.pekko.actor.{Actor, Props, Terminated}
+import org.apache.pekko.testkit.TestProbe
 import scala.language.implicitConversions
 
 object TestProbeUtil {

--- a/core/src/test/scala/io/gearpump/cluster/MasterHarness.scala
+++ b/core/src/test/scala/io/gearpump/cluster/MasterHarness.scala
@@ -14,8 +14,8 @@
 
 package io.gearpump.cluster
 
-import akka.actor.{Actor, ActorSystem, Address, Props}
-import akka.testkit.TestProbe
+import org.apache.pekko.actor.{Actor, ActorSystem, Address, Props}
+import org.apache.pekko.testkit.TestProbe
 import com.typesafe.config.{Config, ConfigFactory, ConfigParseOptions, ConfigValueFactory}
 import io.gearpump.cluster.MasterHarness._
 import io.gearpump.cluster.client.ClientContext

--- a/core/src/test/scala/io/gearpump/cluster/MiniCluster.scala
+++ b/core/src/test/scala/io/gearpump/cluster/MiniCluster.scala
@@ -13,9 +13,9 @@
  */
 package io.gearpump.cluster
 
-import akka.actor.{Actor, ActorRef, ActorSystem, Props}
-import akka.pattern.ask
-import akka.testkit.TestActorRef
+import org.apache.pekko.actor.{Actor, ActorRef, ActorSystem, Props}
+import org.apache.pekko.pattern.ask
+import org.apache.pekko.testkit.TestActorRef
 import com.typesafe.config.ConfigValueFactory
 import io.gearpump.cluster.AppMasterToMaster.GetAllWorkers
 import io.gearpump.cluster.MasterToAppMaster.WorkerList

--- a/core/src/test/scala/io/gearpump/cluster/appmaster/AppManagerSpec.scala
+++ b/core/src/test/scala/io/gearpump/cluster/appmaster/AppManagerSpec.scala
@@ -14,8 +14,8 @@
 
 package io.gearpump.cluster.appmaster
 
-import akka.actor.{Actor, ActorRef, Props}
-import akka.testkit.TestProbe
+import org.apache.pekko.actor.{Actor, ActorRef, Props}
+import org.apache.pekko.testkit.TestProbe
 import com.typesafe.config.Config
 import io.gearpump.cluster.{MasterHarness, TestUtil, _}
 import io.gearpump.cluster.AppMasterToMaster.{AppDataSaved, RegisterAppMaster, _}

--- a/core/src/test/scala/io/gearpump/cluster/appmaster/AppMasterRuntimeEnvironmentSpec.scala
+++ b/core/src/test/scala/io/gearpump/cluster/appmaster/AppMasterRuntimeEnvironmentSpec.scala
@@ -14,8 +14,8 @@
 
 package io.gearpump.cluster.appmaster
 
-import akka.actor._
-import akka.testkit.TestProbe
+import org.apache.pekko.actor._
+import org.apache.pekko.testkit.TestProbe
 import io.gearpump.TestProbeUtil._
 import io.gearpump.cluster.{TestUtil, _}
 import io.gearpump.cluster.AppMasterToMaster.RegisterAppMaster

--- a/core/src/test/scala/io/gearpump/cluster/appmaster/ExecutorSystemLauncherSpec.scala
+++ b/core/src/test/scala/io/gearpump/cluster/appmaster/ExecutorSystemLauncherSpec.scala
@@ -14,8 +14,8 @@
 
 package io.gearpump.cluster.appmaster
 
-import akka.actor.{ActorSystem, Props}
-import akka.testkit.TestProbe
+import org.apache.pekko.actor.{ActorSystem, Props}
+import org.apache.pekko.testkit.TestProbe
 import com.typesafe.config.ConfigValueFactory
 import io.gearpump.cluster.AppMasterToWorker.LaunchExecutor
 import io.gearpump.cluster.TestUtil
@@ -35,7 +35,7 @@ class ExecutorSystemLauncherSpec extends FlatSpec with Matchers with BeforeAndAf
   val workerId: WorkerId = WorkerId(0, 0L)
   val appId = 0
   val executorId = 0
-  val url = "akka.tcp://worker@127.0.0.1:3000"
+  val url = "pekko.tcp://worker@127.0.0.1:3000"
   val session = Session(null, null)
   val launchExecutorSystemTimeout = 3000
   val activeConfig = TestUtil.DEFAULT_CONFIG.

--- a/core/src/test/scala/io/gearpump/cluster/appmaster/ExecutorSystemSchedulerSpec.scala
+++ b/core/src/test/scala/io/gearpump/cluster/appmaster/ExecutorSystemSchedulerSpec.scala
@@ -14,8 +14,8 @@
 
 package io.gearpump.cluster.appmaster
 
-import akka.actor.{Actor, ActorSystem, Props}
-import akka.testkit.TestProbe
+import org.apache.pekko.actor.{Actor, ActorSystem, Props}
+import org.apache.pekko.testkit.TestProbe
 import io.gearpump.cluster.{AppJar, TestUtil}
 import io.gearpump.cluster.AppMasterToMaster.RequestResource
 import io.gearpump.cluster.MasterToAppMaster.ResourceAllocated

--- a/core/src/test/scala/io/gearpump/cluster/appmaster/InMemoryKVServiceSpec.scala
+++ b/core/src/test/scala/io/gearpump/cluster/appmaster/InMemoryKVServiceSpec.scala
@@ -14,8 +14,8 @@
 
 package io.gearpump.cluster.appmaster
 
-import akka.actor.Props
-import akka.testkit.TestProbe
+import org.apache.pekko.actor.Props
+import org.apache.pekko.testkit.TestProbe
 import com.typesafe.config.Config
 import io.gearpump.cluster.{MasterHarness, TestUtil}
 import io.gearpump.cluster.master.InMemoryKVService

--- a/core/src/test/scala/io/gearpump/cluster/appmaster/MasterConnectionKeeperSpec.scala
+++ b/core/src/test/scala/io/gearpump/cluster/appmaster/MasterConnectionKeeperSpec.scala
@@ -14,8 +14,8 @@
 
 package io.gearpump.cluster.appmaster
 
-import akka.actor.{ActorRef, ActorSystem, Props}
-import akka.testkit.TestProbe
+import org.apache.pekko.actor.{ActorRef, ActorSystem, Props}
+import org.apache.pekko.testkit.TestProbe
 import io.gearpump.cluster.AppMasterToMaster.RegisterAppMaster
 import io.gearpump.cluster.MasterToAppMaster.AppMasterRegistered
 import io.gearpump.cluster.TestUtil

--- a/core/src/test/scala/io/gearpump/cluster/client/RunningApplicationSpec.scala
+++ b/core/src/test/scala/io/gearpump/cluster/client/RunningApplicationSpec.scala
@@ -14,9 +14,9 @@
 
 package io.gearpump.cluster.client
 
-import akka.actor.ActorSystem
-import akka.testkit.TestProbe
-import akka.util.Timeout
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.testkit.TestProbe
+import org.apache.pekko.util.Timeout
 import io.gearpump.cluster.ClientToMaster.{ResolveAppId, ShutdownApplication}
 import io.gearpump.cluster.MasterToClient.{ResolveAppIdResult, ShutdownApplicationResult}
 import io.gearpump.cluster.TestUtil

--- a/core/src/test/scala/io/gearpump/cluster/main/MainSpec.scala
+++ b/core/src/test/scala/io/gearpump/cluster/main/MainSpec.scala
@@ -14,7 +14,7 @@
 
 package io.gearpump.cluster.main
 
-import akka.testkit.TestProbe
+import org.apache.pekko.testkit.TestProbe
 import com.typesafe.config.{Config, ConfigFactory}
 import io.gearpump.cluster.{ApplicationStatus, MasterHarness, TestUtil}
 import io.gearpump.cluster.ClientToMaster.{ResolveAppId, ShutdownApplication}

--- a/core/src/test/scala/io/gearpump/cluster/main/MasterWatcherSpec.scala
+++ b/core/src/test/scala/io/gearpump/cluster/main/MasterWatcherSpec.scala
@@ -13,8 +13,8 @@
  */
 package io.gearpump.cluster.main
 
-import akka.actor.{ActorSystem, Props}
-import akka.testkit.TestProbe
+import org.apache.pekko.actor.{ActorSystem, Props}
+import org.apache.pekko.testkit.TestProbe
 import com.typesafe.config.Config
 import io.gearpump.cluster.TestUtil
 import org.scalatest.{FlatSpec, Matchers}

--- a/core/src/test/scala/io/gearpump/cluster/master/AppMasterLauncherSpec.scala
+++ b/core/src/test/scala/io/gearpump/cluster/master/AppMasterLauncherSpec.scala
@@ -14,8 +14,8 @@
 
 package io.gearpump.cluster.master
 
-import akka.actor._
-import akka.testkit.TestProbe
+import org.apache.pekko.actor._
+import org.apache.pekko.testkit.TestProbe
 import com.typesafe.config.Config
 import io.gearpump.cluster.{MasterHarness, TestUtil}
 import io.gearpump.cluster.AppMasterToMaster.RequestResource

--- a/core/src/test/scala/io/gearpump/cluster/scheduler/PrioritySchedulerSpec.scala
+++ b/core/src/test/scala/io/gearpump/cluster/scheduler/PrioritySchedulerSpec.scala
@@ -13,8 +13,8 @@
  */
 package io.gearpump.cluster.scheduler
 
-import akka.actor.{ActorSystem, Props}
-import akka.testkit.{ImplicitSender, TestKit, TestProbe}
+import org.apache.pekko.actor.{ActorSystem, Props}
+import org.apache.pekko.testkit.{ImplicitSender, TestKit, TestProbe}
 import io.gearpump.cluster.AppMasterToMaster.RequestResource
 import io.gearpump.cluster.MasterToAppMaster.ResourceAllocated
 import io.gearpump.cluster.MasterToWorker.{UpdateResourceFailed, WorkerRegistered}

--- a/core/src/test/scala/io/gearpump/cluster/worker/WorkerSpec.scala
+++ b/core/src/test/scala/io/gearpump/cluster/worker/WorkerSpec.scala
@@ -13,8 +13,8 @@
  */
 package io.gearpump.cluster.worker
 
-import akka.actor.{ActorSystem, PoisonPill, Props}
-import akka.testkit.TestProbe
+import org.apache.pekko.actor.{ActorSystem, PoisonPill, Props}
+import org.apache.pekko.testkit.TestProbe
 import com.typesafe.config.{Config, ConfigFactory}
 import io.gearpump.cluster.{ExecutorJVMConfig, MasterHarness, TestUtil}
 import io.gearpump.cluster.AppMasterToWorker.{ChangeExecutorResource, LaunchExecutor, ShutdownExecutor}

--- a/core/src/test/scala/io/gearpump/jarstore/FileServerSpec.scala
+++ b/core/src/test/scala/io/gearpump/jarstore/FileServerSpec.scala
@@ -14,7 +14,7 @@
 
 package io.gearpump.jarstore
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import com.google.common.io.Files
 import com.typesafe.config.ConfigValueFactory
 import io.gearpump.cluster.TestUtil
@@ -29,7 +29,7 @@ import scala.concurrent.duration.Duration
 
 class FileServerSpec extends WordSpecLike with Matchers with BeforeAndAfterAll {
 
-  implicit val timeout = akka.util.Timeout(25, TimeUnit.SECONDS)
+  implicit val timeout = org.apache.pekko.util.Timeout(25, TimeUnit.SECONDS)
   val host = "localhost"
   private val LOG = LogUtil.getLogger(getClass)
 

--- a/core/src/test/scala/io/gearpump/security/ConfigFileBasedAuthenticatorSpec.scala
+++ b/core/src/test/scala/io/gearpump/security/ConfigFileBasedAuthenticatorSpec.scala
@@ -14,7 +14,7 @@
 
 package io.gearpump.security
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import io.gearpump.cluster.TestUtil
 import org.scalatest.{FlatSpec, Matchers}
 import scala.concurrent.Await

--- a/core/src/test/scala/io/gearpump/serializer/SerializerSpec.scala
+++ b/core/src/test/scala/io/gearpump/serializer/SerializerSpec.scala
@@ -14,7 +14,7 @@
 
 package io.gearpump.serializer
 
-import akka.actor.{ActorSystem, ExtendedActorSystem}
+import org.apache.pekko.actor.{ActorSystem, ExtendedActorSystem}
 import com.esotericsoftware.kryo.{Kryo, Serializer => KryoSerializer}
 import com.esotericsoftware.kryo.io.{Input, Output}
 import com.typesafe.config.{ConfigFactory, ConfigValueFactory}

--- a/core/src/test/scala/io/gearpump/transport/NettySpec.scala
+++ b/core/src/test/scala/io/gearpump/transport/NettySpec.scala
@@ -14,8 +14,8 @@
 
 package io.gearpump.transport
 
-import akka.actor.{ActorRef, ActorSystem}
-import akka.testkit.TestProbe
+import org.apache.pekko.actor.{ActorRef, ActorSystem}
+import org.apache.pekko.testkit.TestProbe
 import io.gearpump.cluster.TestUtil
 import io.gearpump.transport.MockTransportSerializer.NettyMessage
 import io.gearpump.transport.netty.{Context, TaskMessage}

--- a/core/src/test/scala/io/gearpump/util/ActorSystemBooterSpec.scala
+++ b/core/src/test/scala/io/gearpump/util/ActorSystemBooterSpec.scala
@@ -14,8 +14,8 @@
 
 package io.gearpump.util
 
-import akka.actor.{Actor, ActorSystem, Props}
-import akka.testkit.TestProbe
+import org.apache.pekko.actor.{Actor, ActorSystem, Props}
+import org.apache.pekko.testkit.TestProbe
 import com.github.ghik.silencer.silent
 import io.gearpump.cluster.TestUtil
 import io.gearpump.util.ActorSystemBooter.{ActorCreated, RegisterActorSystem, _}

--- a/core/src/test/scala/io/gearpump/util/ActorUtilSpec.scala
+++ b/core/src/test/scala/io/gearpump/util/ActorUtilSpec.scala
@@ -28,8 +28,7 @@ class ActorUtilSpec extends FlatSpec {
     assert(masterPath.address.port == Some(port))
     assert(masterPath.address.system == MASTER)
     assert(masterPath.address.host == Some(host))
-    assert(masterPath.address.protocol == "akka.tcp")
+    assert(masterPath.address.protocol == "pekko.tcp")
     assert(masterPath.toStringWithoutAddress == s"/user/$MASTER")
   }
 }
-

--- a/core/src/test/scala/io/gearpump/util/ConfigsSpec.scala
+++ b/core/src/test/scala/io/gearpump/util/ConfigsSpec.scala
@@ -14,7 +14,7 @@
 
 package io.gearpump.util
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import io.gearpump.cluster.{ClusterConfig, ClusterConfigSource, UserConfig}
 import java.io.File
 import org.scalatest.{FlatSpec, Matchers}

--- a/core/src/test/scala/io/gearpump/util/TimeOutSchedulerSpec.scala
+++ b/core/src/test/scala/io/gearpump/util/TimeOutSchedulerSpec.scala
@@ -14,8 +14,8 @@
 
 package io.gearpump.util
 
-import akka.actor._
-import akka.testkit.{ImplicitSender, TestActorRef, TestKit, TestProbe}
+import org.apache.pekko.actor._
+import org.apache.pekko.testkit.{ImplicitSender, TestActorRef, TestKit, TestProbe}
 import com.github.ghik.silencer.silent
 import io.gearpump.cluster.TestUtil
 import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}

--- a/docs/contents/deployment/deployment-configuration.md
+++ b/docs/contents/deployment/deployment-configuration.md
@@ -36,11 +36,11 @@ To change the log level, you need to change both `gear.conf`, and `log4j.propert
 
 ### To change the log level for master and worker daemon
 
-Please change `log4j.rootLevel` in `log4j.properties`, `gearpump-master.akka.loglevel` and `gearpump-worker.akka.loglevel` in `gear.conf`.
+Please change `log4j.rootLevel` in `log4j.properties`, `gearpump-master.pekko.loglevel` and `gearpump-worker.pekko.loglevel` in `gear.conf`.
 
 ### To change the log level for application job
 
-Please change `log4j.rootLevel` in `log4j.properties`, and `akka.loglevel` in `gear.conf` or `application.conf`.
+Please change `log4j.rootLevel` in `log4j.properties`, and `pekko.loglevel` in `gear.conf` or `application.conf`.
 
 ## Gearpump Default Configuration
 
@@ -54,7 +54,7 @@ This is the default configuration for `gear.conf`.
 | gearpump.metrics.enabled | true | flag to enable the metrics system |
 | gearpump.metrics.sample-rate | 1 | We will take one sample every `gearpump.metrics.sample-rate` data points. Note it may have impact that the statistics on UI portal is not accurate. Change it to 1 if you want accurate metrics in UI |
 | gearpump.metrics.report-interval-ms | 15000 | we will report once every 15 seconds |
-| gearpump.metrics.reporter  | "akka" | available value: "graphite", "akka", "logfile" which write the metrics data to different places. |
+| gearpump.metrics.reporter  | "pekko" | available value: "graphite", "pekko", "logfile" which write the metrics data to different places. |
 | gearpump.retainHistoryData.hours | 72 | max hours of history data to retain, Note: Due to implementation limitation(we store all history in memory), please don't set this to too big which may exhaust memory. |
 | gearpump.retainHistoryData.intervalMs | 3600000 |  time interval between two data points for history data (unit: ms). Usually this is set to a big value so that we only store coarse-grain data |
 | gearpump.retainRecentData.seconds | 300 | max seconds of recent data to retain. This is for the fine-grain data |

--- a/docs/contents/deployment/deployment-ha.md
+++ b/docs/contents/deployment/deployment-ha.md
@@ -72,4 +72,4 @@ On node1, node2, node3, Start Master
 
 Now you have a highly available HA cluster. You can kill any node, the master HA will take effect.
 
-**NOTE**: It can take up to 15 seconds for master node to fail-over. You can change the fail-over timeout time by adding config in `gear.conf` `gearpump-master.akka.cluster.auto-down-unreachable-after=10s` or set it to a smaller value
+**NOTE**: It can take up to 15 seconds for master node to fail-over. You can change the fail-over timeout time by adding config in `gear.conf` `gearpump-master.pekko.cluster.auto-down-unreachable-after=10s` or set it to a smaller value

--- a/docs/contents/dev/dev-rest-api.md
+++ b/docs/contents/dev/dev-rest-api.md
@@ -136,8 +136,8 @@ Sample Response:
 	      "status": "active",
 	      "appId": 1,
 	      "appName": "wordCount",
-	      "appMasterPath": "akka.tcp://app1-executor-1@127.0.0.1:52212/user/daemon/appdaemon1/$c",
-	      "workerPath": "akka.tcp://master@127.0.0.1:3000/user/Worker0",
+	      "appMasterPath": "pekko.tcp://app1-executor-1@127.0.0.1:52212/user/daemon/appdaemon1/$c",
+	      "workerPath": "pekko.tcp://master@127.0.0.1:3000/user/Worker0",
 	      "submissionTime": "1450758114766",
 	      "startTime": "1450758117294",
 	      "user": "lisa"
@@ -160,7 +160,7 @@ Sample Response:
 	  {
 	    "workerId": "1",
 	    "state": "active",
-	    "actorPath": "akka.tcp://master@127.0.0.1:3000/user/Worker0",
+	    "actorPath": "pekko.tcp://master@127.0.0.1:3000/user/Worker0",
 	    "aliveFor": "431565",
 	    "logFile": "logs/",
 	    "executors": [
@@ -183,7 +183,7 @@ Sample Response:
 	  {
 	    "workerId": "0",
 	    "state": "active",
-	    "actorPath": "akka.tcp://master@127.0.0.1:3000/user/Worker1",
+	    "actorPath": "pekko.tcp://master@127.0.0.1:3000/user/Worker1",
 	    "aliveFor": "431546",
 	    "logFile": "logs/",
 	    "executors": [
@@ -213,15 +213,15 @@ Sample Response:
 	:::json
 	{
 	  "extensions": [
-	    "akka.contrib.datareplication.DataReplication$"
+	    "org.apache.pekko.cluster.ddata.DistributedData$"
 	  ]
-	  "akka": {
+	  "pekko" : {
 	    "loglevel": "INFO"
 	    "log-dead-letters": "off"
 	    "log-dead-letters-during-shutdown": "off"
 	    "actor": {
-	      ## Master forms a akka cluster
-	      "provider": "akka.cluster.ClusterActorRefProvider"
+	      ## Master forms a pekko cluster
+	      "provider": "cluster"
 	    }
 	    "cluster": {
 	      "roles": ["master"]
@@ -388,7 +388,7 @@ Sample Response:
 	{
 	  "workerId": "0",
 	  "state": "active",
-	  "actorPath": "akka.tcp://master@127.0.0.1:3000/user/Worker1",
+	  "actorPath": "pekko.tcp://master@127.0.0.1:3000/user/Worker1",
 	  "aliveFor": "831069",
 	  "logFile": "logs/",
 	  "executors": [
@@ -418,15 +418,15 @@ Sample Response:
 	:::json
 	{
 	  "extensions": [
-	    "akka.contrib.datareplication.DataReplication$"
+	    "org.apache.pekko.cluster.ddata.DistributedData$"
 	  ]
-	  "akka": {
+	  "pekko" : {
 	    "loglevel": "INFO"
 	    "log-dead-letters": "off"
 	    "log-dead-letters-during-shutdown": "off"
 	    "actor": {
-	      ## Master forms a akka cluster
-	      "provider": "akka.cluster.ClusterActorRefProvider"
+	      ## Master forms a pekko cluster
+	      "provider": "cluster"
 	    }
 	    "cluster": {
 	      "roles": ["master"]
@@ -709,24 +709,24 @@ Sample Response:
 	      ]
 	    ]
 	  },
-	  "actorPath": "akka.tcp://app1-executor-1@127.0.0.1:52212/user/daemon/appdaemon1/$c/appmaster",
+	  "actorPath": "pekko.tcp://app1-executor-1@127.0.0.1:52212/user/daemon/appdaemon1/$c/appmaster",
 	  "clock": "1450759382430",
 	  "executors": [
 	    {
 	      "executorId": 0,
-	      "executor": "akka.tcp://app1system0@127.0.0.1:52240/remote/akka.tcp/app1-executor-1@127.0.0.1:52212/user/daemon/appdaemon1/$c/appmaster/executors/0#-1554950276",
+	      "executor": "pekko.tcp://app1system0@127.0.0.1:52240/remote/pekko.tcp/app1-executor-1@127.0.0.1:52212/user/daemon/appdaemon1/$c/appmaster/executors/0#-1554950276",
 	      "workerId": "1",
 	      "status": "active"
 	    },
 	    {
 	      "executorId": 1,
-	      "executor": "akka.tcp://app1system1@127.0.0.1:52241/remote/akka.tcp/app1-executor-1@127.0.0.1:52212/user/daemon/appdaemon1/$c/appmaster/executors/1#928082134",
+	      "executor": "pekko.tcp://app1system1@127.0.0.1:52241/remote/pekko.tcp/app1-executor-1@127.0.0.1:52212/user/daemon/appdaemon1/$c/appmaster/executors/1#928082134",
 	      "workerId": "0",
 	      "status": "active"
 	    },
 	    {
 	      "executorId": -1,
-	      "executor": "akka://app1-executor-1/user/daemon/appdaemon1/$c/appmaster",
+	      "executor": "pekko://app1-executor-1/user/daemon/appdaemon1/$c/appmaster",
 	      "workerId": "1",
 	      "status": "active"
 	    }
@@ -816,7 +816,7 @@ Sample Response:
 	            },
 	            "logfile" : {},
 	            "report-interval-ms" : 15000,
-	            "reporter" : "akka",
+	            "reporter" : "pekko",
 	            "retainHistoryData" : {
 	                "hours" : 72,
 	                "intervalMs" : 3600000
@@ -835,7 +835,7 @@ Sample Response:
 	            "max-sleep-ms" : 1000,
 	            "message-batch-size" : 262144
 	        },
-	        "netty-dispatcher" : "akka.actor.default-dispatcher",
+	        "netty-dispatcher" : "pekko.actor.default-dispatcher",
 	        "scheduling" : {
 	            "scheduler-class" : "io.gearpump.cluster.scheduler.PriorityScheduler"
 	        },
@@ -871,7 +871,7 @@ Sample Response:
 	            # gear.conf: 114
 	            "ws" : 8091
 	        },
-	        "task-dispatcher" : "akka.actor.pined-dispatcher",
+	        "task-dispatcher" : "pekko.actor.pinned-dispatcher",
 	        "worker" : {
 	            # reference.conf: 100
 	            # # How many slots each worker contains
@@ -1027,15 +1027,15 @@ Sample Response:
 	:::json
 	{
 	  "extensions": [
-	    "akka.contrib.datareplication.DataReplication$"
+	    "org.apache.pekko.cluster.ddata.DistributedData$"
 	  ]
-	  "akka": {
+	  "pekko" : {
 	    "loglevel": "INFO"
 	    "log-dead-letters": "off"
 	    "log-dead-letters-during-shutdown": "off"
 	    "actor": {
-	      ## Master forms a akka cluster
-	      "provider": "akka.cluster.ClusterActorRefProvider"
+	      ## Master forms a pekko cluster
+	      "provider": "cluster"
 	    }
 	    "cluster": {
 	      "roles": ["master"]
@@ -1063,7 +1063,7 @@ Sample Response:
 	{
 	  "id": 1,
 	  "workerId": "0",
-	  "actorPath": "akka.tcp://app1system1@127.0.0.1:52241/remote/akka.tcp/app1-executor-1@127.0.0.1:52212/user/daemon/appdaemon1/$c/appmaster/executors/1",
+	  "actorPath": "pekko.tcp://app1system1@127.0.0.1:52241/remote/pekko.tcp/app1-executor-1@127.0.0.1:52212/user/daemon/appdaemon1/$c/appmaster/executors/1",
 	  "logFile": "logs/",
 	  "status": "active",
 	  "taskCount": 1,

--- a/docs/contents/dev/dev-write-1st-app.md
+++ b/docs/contents/dev/dev-write-1st-app.md
@@ -4,12 +4,12 @@ We'll use the classical [wordcount](https://github.com/apache/incubator-gearpump
 
 	:::scala     
 	/** WordCount with High level DSL */
-	object WordCount extends AkkaApp with ArgumentsParser {
+	object WordCount extends PekkoApp with ArgumentsParser {
 	
 	  override val options: Array[(String, CLIOption[Any])] = Array.empty
 	
-	  override def main(akkaConf: Config, args: Array[String]): Unit = {
-	    val context = ClientContext(akkaConf)
+	  override def main(pekkoConf: Config, args: Array[String]): Unit = {
+	    val context = ClientContext(pekkoConf)
 	    val app = StreamApp("dsl", context)
 	    val data = "This is a good start, bingo!! bingo!!"
 	

--- a/docs/contents/index.md
+++ b/docs/contents/index.md
@@ -6,7 +6,7 @@ description: Gearpump GEARPUMP_VERSION documentation homepage
 ---
 
 Gearpump is a real-time big data streaming engine.
-It is inspired by recent advances in the [Akka](http://akka.io/) framework and a desire to improve on existing streaming frameworks.
+It is inspired by recent advances in the [Apache Pekko](https://pekko.apache.org/) framework and a desire to improve on existing streaming frameworks.
 Gearpump is event/message based and featured as low latency handling, high performance, exactly once semantics,
 dynamic topology update, [Apache Storm](https://storm.apache.org/) compatibility, etc.
 

--- a/docs/contents/internals/gearpump-internals.md
+++ b/docs/contents/internals/gearpump-internals.md
@@ -18,7 +18,7 @@ Everything in the diagram is an actor; they fall into two categories, Cluster Ac
 
   **Task**: Child of Executor, does the real job. Every task actor has a global unique address. One task actor can send data to any other task actors. This gives us great flexibility of how the computation DAG is distributed.
 
-  All actors in the graph are weaved together with actor supervision, and actor watching and every error is handled properly via supervisors. In a master, a risky job is isolated and delegated to child actors, so it's more robust. In the application, an extra intermediate layer "Executor" is created so that we can do fine-grained and fast recovery in case of task failure. A master watches the lifecycle of AppMaster and worker to handle the failures, but the life cycle of Worker and AppMaster are not bound to a Master Actor by supervision, so that Master node can fail independently.  Several Master Actors form an Akka cluster, the Master state is exchanged using the Gossip protocol in a conflict-free consistent way so that there is no single point of failure. With this hierarchy design, we are able to achieve high availability.
+  All actors in the graph are weaved together with actor supervision, and actor watching and every error is handled properly via supervisors. In a master, a risky job is isolated and delegated to child actors, so it's more robust. In the application, an extra intermediate layer "Executor" is created so that we can do fine-grained and fast recovery in case of task failure. A master watches the lifecycle of AppMaster and worker to handle the failures, but the life cycle of Worker and AppMaster are not bound to a Master Actor by supervision, so that Master node can fail independently.  Several Master Actors form an Pekko cluster, the Master state is exchanged using the Gossip protocol in a conflict-free consistent way so that there is no single point of failure. With this hierarchy design, we are able to achieve high availability.
 
 ### Application Clock and Global Clock Service
 
@@ -47,12 +47,12 @@ In streaming, typical message size is very small, usually less than 100 bytes pe
 For each message sent between two actors, it contains sender and receiver actor path. When sending over the wire, the overhead of this ActorPath is not trivial. For example, the below actor path takes more than 200 bytes.
 
 	:::bash
-	akka.tcp://system1@192.168.1.53:51582/remote/akka.tcp/2120193a-e10b-474e-bccb-8ebc4b3a0247@192.168.1.53:48948/remote/akka.tcp/system2@192.168.1.54:43676/user/master/Worker1/app_0_executor_0/group_1_task_0#-768886794
+	pekko.tcp://system1@192.168.1.53:51582/remote/pekko.tcp/2120193a-e10b-474e-bccb-8ebc4b3a0247@192.168.1.53:48948/remote/pekko.tcp/system2@192.168.1.54:43676/user/master/Worker1/app_0_executor_0/group_1_task_0#-768886794
 
 
 #### How do we solve this?
 
-We implement a custom Netty transportation layer with Akka extension. In the below diagram, Netty Client will translate ActorPath to TaskId, and Netty Server will translate it back. Only TaskId will be passed on wire, it is only about 10 bytes, the overhead is minimized. Different Netty Client Actors are isolated; they will not block each other.
+We implement a custom Netty transportation layer with Pekko extension. In the below diagram, Netty Client will translate ActorPath to TaskId, and Netty Server will translate it back. Only TaskId will be passed on wire, it is only about 10 bytes, the overhead is minimized. Different Netty Client Actors are isolated; they will not block each other.
 
 ![Netty Transport](../img/netty_transport.png)
 
@@ -96,11 +96,11 @@ In a distributed streaming system, any part can fail. The system must stay respo
 ![HA](../img/ha.png)
 Figure: Master High Availability
 
-We use Akka clustering to implement the Master high availability. The cluster consists of several master nodes, but no worker nodes. With clustering facilities, we can easily detect and handle the failure of master node crash. The master state is replicated on all master nodes with the Typesafe akka-data-replication  library, when one master node crashes, another standby master will read the master state and take over. The master state contains the submission data of all applications. If one application dies, a master can use that state to recover that application. CRDT LwwMap  is used to represent the state; it is a hash map that can converge on distributed nodes without conflict. To have strong data consistency, the state read and write must happen on a quorum of master nodes.
+We use Pekko clustering to implement the Master high availability. The cluster consists of several master nodes, but no worker nodes. With clustering facilities, we can easily detect and handle the failure of master node crash. The master state is replicated on all master nodes with the Apache Pekko distributed data  library, when one master node crashes, another standby master will read the master state and take over. The master state contains the submission data of all applications. If one application dies, a master can use that state to recover that application. CRDT LwwMap  is used to represent the state; it is a hash map that can converge on distributed nodes without conflict. To have strong data consistency, the state read and write must happen on a quorum of master nodes.
 
 ### How we do handle failures?
 
-With Akka's powerful actor supervision, we can implement a resilient system relatively easy. In Gearpump, different applications have a different AppMaster instance, they are totally isolated from each other. For each application, there is a supervision tree, AppMaster->Executor->Task. With this supervision hierarchy, we can free ourselves from the headache of zombie process, for example if AppMaster is down, Akka supervisor will ensure the whole tree is shutting down.
+With Pekko's powerful actor supervision, we can implement a resilient system relatively easy. In Gearpump, different applications have a different AppMaster instance, they are totally isolated from each other. For each application, there is a supervision tree, AppMaster->Executor->Task. With this supervision hierarchy, we can free ourselves from the headache of zombie process, for example if AppMaster is down, Pekko supervisor will ensure the whole tree is shutting down.
 
 There are multiple possible failure scenarios
 

--- a/docs/contents/introduction/features.md
+++ b/docs/contents/introduction/features.md
@@ -36,7 +36,7 @@ By implementing smart batching strategies, Gearpump is extremely effective in tr
 
 #### High availability, No single point of failure
 
-Gearpump has a careful design for high availability. We have considered message loss, worker machine crash, application crash, master crash, brain-split, and have made sure Gearpump recovers when these errors may occur. When there is message loss, the lost message will be replayed; when there is a worker machine crash or application crash, the related computation tasks will be rescheduled on new machines. For master high availability, several master nodes will form a Akka cluster, and CRDTs (conflict free data types) are used to exchange the state, so as long as there is still a quorum, the master will stay functional. When one master node fails, other master nodes in the cluster will take over and state will be recovered.
+Gearpump has a careful design for high availability. We have considered message loss, worker machine crash, application crash, master crash, brain-split, and have made sure Gearpump recovers when these errors may occur. When there is message loss, the lost message will be replayed; when there is a worker machine crash or application crash, the related computation tasks will be rescheduled on new machines. For master high availability, several master nodes will form a Pekko cluster, and CRDTs (conflict free data types) are used to exchange the state, so as long as there is still a quorum, the master will stay functional. When one master node fails, other master nodes in the cluster will take over and state will be recovered.
 
 ![HA](../img/ha.png)
 

--- a/examples/distributedshell/src/main/scala/io/gearpump/examples/distributedshell/DistShellAppMaster.scala
+++ b/examples/distributedshell/src/main/scala/io/gearpump/examples/distributedshell/DistShellAppMaster.scala
@@ -13,9 +13,9 @@
  */
 package io.gearpump.examples.distributedshell
 
-import akka.actor.{Deploy, Props}
-import akka.pattern.{ask, pipe}
-import akka.remote.RemoteScope
+import org.apache.pekko.actor.{Deploy, Props}
+import org.apache.pekko.pattern.{ask, pipe}
+import org.apache.pekko.remote.RemoteScope
 import com.typesafe.config.Config
 import io.gearpump.cluster._
 import io.gearpump.cluster.ClientToMaster.ShutdownApplication

--- a/examples/distributedshell/src/main/scala/io/gearpump/examples/distributedshell/DistributedShell.scala
+++ b/examples/distributedshell/src/main/scala/io/gearpump/examples/distributedshell/DistributedShell.scala
@@ -16,18 +16,18 @@ package io.gearpump.examples.distributedshell
 import io.gearpump.cluster.{Application, UserConfig}
 import io.gearpump.cluster.client.ClientContext
 import io.gearpump.cluster.main.{ArgumentsParser, CLIOption}
-import io.gearpump.util.{AkkaApp, LogUtil}
+import io.gearpump.util.{PekkoApp, LogUtil}
 import org.slf4j.Logger
 
 /** Demo application to distribute and execute shell command on all machines of the cluster */
-object DistributedShell extends AkkaApp with ArgumentsParser {
+object DistributedShell extends PekkoApp with ArgumentsParser {
   private val LOG: Logger = LogUtil.getLogger(getClass)
 
   override val options: Array[(String, CLIOption[Any])] = Array.empty
 
-  override def main(akkaConf: Config, args: Array[String]): Unit = {
+  override def main(pekkoConf: Config, args: Array[String]): Unit = {
     LOG.info(s"Distributed shell submitting application...")
-    val context = ClientContext(akkaConf)
+    val context = ClientContext(pekkoConf)
     val app = context.submit(Application[DistShellAppMaster]("DistributedShell",
     UserConfig.empty))
     context.close()

--- a/examples/distributedshell/src/main/scala/io/gearpump/examples/distributedshell/DistributedShellClient.scala
+++ b/examples/distributedshell/src/main/scala/io/gearpump/examples/distributedshell/DistributedShellClient.scala
@@ -13,18 +13,18 @@
  */
 package io.gearpump.examples.distributedshell
 
-import akka.pattern.ask
+import org.apache.pekko.pattern.ask
 import io.gearpump.cluster.client.ClientContext
 import io.gearpump.cluster.main.{ArgumentsParser, CLIOption}
 import io.gearpump.examples.distributedshell.DistShellAppMaster.ShellCommand
-import io.gearpump.util.{AkkaApp, Constants}
+import io.gearpump.util.{PekkoApp, Constants}
 import java.util.concurrent.TimeUnit
 import org.slf4j.{Logger, LoggerFactory}
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
 /** Client to DistributedShell to input "shell command" */
-object DistributedShellClient extends AkkaApp with ArgumentsParser {
+object DistributedShellClient extends PekkoApp with ArgumentsParser {
   implicit val timeout = Constants.FUTURE_TIMEOUT
   private val LOG: Logger = LoggerFactory.getLogger(getClass)
 
@@ -33,9 +33,9 @@ object DistributedShellClient extends AkkaApp with ArgumentsParser {
     "command" -> CLIOption[String]("<shell command>", required = true)
   )
 
-  override def main(akkaConf: Config, args: Array[String]): Unit = {
+  override def main(pekkoConf: Config, args: Array[String]): Unit = {
     val config = parse(args)
-    val context = ClientContext(akkaConf)
+    val context = ClientContext(pekkoConf)
     implicit val system = context.system
     implicit val dispatcher = system.dispatcher
     val appid = config.getInt("appid")

--- a/examples/distributedshell/src/main/scala/io/gearpump/examples/distributedshell/ShellExecutor.scala
+++ b/examples/distributedshell/src/main/scala/io/gearpump/examples/distributedshell/ShellExecutor.scala
@@ -14,7 +14,7 @@
 
 package io.gearpump.examples.distributedshell
 
-import akka.actor.Actor
+import org.apache.pekko.actor.Actor
 import io.gearpump.cluster.ExecutorContext
 import io.gearpump.examples.distributedshell.DistShellAppMaster.{ShellCommand, ShellCommandResult}
 import io.gearpump.util.LogUtil

--- a/examples/distributedshell/src/test/scala/io/gearpump/examples/distributedshell/DistShellAppMasterSpec.scala
+++ b/examples/distributedshell/src/test/scala/io/gearpump/examples/distributedshell/DistShellAppMasterSpec.scala
@@ -13,8 +13,8 @@
  */
 package io.gearpump.examples.distributedshell
 
-import akka.actor.ActorSystem
-import akka.testkit.{TestActorRef, TestProbe}
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.testkit.{TestActorRef, TestProbe}
 import io.gearpump.cluster.{TestUtil, _}
 import io.gearpump.cluster.AppMasterToMaster.{GetAllWorkers, RegisterAppMaster, RequestResource}
 import io.gearpump.cluster.AppMasterToWorker.LaunchExecutor

--- a/examples/distributedshell/src/test/scala/io/gearpump/examples/distributedshell/DistributedShellClientSpec.scala
+++ b/examples/distributedshell/src/test/scala/io/gearpump/examples/distributedshell/DistributedShellClientSpec.scala
@@ -13,7 +13,7 @@
  */
 package io.gearpump.examples.distributedshell
 
-import akka.testkit.TestProbe
+import org.apache.pekko.testkit.TestProbe
 import io.gearpump.cluster.{MasterHarness, TestUtil}
 import io.gearpump.cluster.ClientToMaster.ResolveAppId
 import io.gearpump.cluster.MasterToClient.ResolveAppIdResult

--- a/examples/distributedshell/src/test/scala/io/gearpump/examples/distributedshell/ShellExecutorSpec.scala
+++ b/examples/distributedshell/src/test/scala/io/gearpump/examples/distributedshell/ShellExecutorSpec.scala
@@ -13,8 +13,8 @@
  */
 package io.gearpump.examples.distributedshell
 
-import akka.actor.{ActorSystem, Props}
-import akka.testkit.TestProbe
+import org.apache.pekko.actor.{ActorSystem, Props}
+import org.apache.pekko.testkit.TestProbe
 import io.gearpump.cluster.{ExecutorContext, TestUtil}
 import io.gearpump.cluster.appmaster.WorkerInfo
 import io.gearpump.cluster.scheduler.Resource

--- a/examples/pagerank/src/main/scala/io/gearpump/examples/pagerank/PageRankApplication.scala
+++ b/examples/pagerank/src/main/scala/io/gearpump/examples/pagerank/PageRankApplication.scala
@@ -13,7 +13,7 @@
  */
 package io.gearpump.examples.pagerank
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import io.gearpump.cluster.{Application, ApplicationMaster, UserConfig}
 import io.gearpump.examples.pagerank.PageRankApplication.NodeWithTaskId
 import io.gearpump.streaming.{Processor, StreamApplication}

--- a/examples/pagerank/src/main/scala/io/gearpump/examples/pagerank/PageRankController.scala
+++ b/examples/pagerank/src/main/scala/io/gearpump/examples/pagerank/PageRankController.scala
@@ -13,7 +13,7 @@
  */
 package io.gearpump.examples.pagerank
 
-import akka.actor.Actor.Receive
+import org.apache.pekko.actor.Actor.Receive
 import io.gearpump.cluster.UserConfig
 import io.gearpump.examples.pagerank.PageRankController.Tick
 import io.gearpump.examples.pagerank.PageRankWorker.LatestWeight

--- a/examples/pagerank/src/main/scala/io/gearpump/examples/pagerank/PageRankExample.scala
+++ b/examples/pagerank/src/main/scala/io/gearpump/examples/pagerank/PageRankExample.scala
@@ -14,11 +14,11 @@
 package io.gearpump.examples.pagerank
 
 import io.gearpump.cluster.client.ClientContext
-import io.gearpump.util.{AkkaApp, Graph}
+import io.gearpump.util.{PekkoApp, Graph}
 import io.gearpump.util.Graph.Node
 
 /** A very simple PageRank example, Cyclic graph is not supported */
-object PageRankExample extends AkkaApp {
+object PageRankExample extends PekkoApp {
 
   val a = "a"
   val b = "b"
@@ -27,10 +27,10 @@ object PageRankExample extends AkkaApp {
 
   def help(): Unit = Unit
 
-  def main(akkaConf: Config, args: Array[String]): Unit = {
+  def main(pekkoConf: Config, args: Array[String]): Unit = {
     val pageRankGraph = Graph(a ~> b, a ~> c, a ~> d, b ~> a, b ~> d, d ~> b, d ~> c, c ~> b)
     val app = new PageRankApplication("pagerank", iteration = 100, delta = 0.001, pageRankGraph)
-    val context = ClientContext(akkaConf)
+    val context = ClientContext(pekkoConf)
     context.submit(app)
     context.close()
   }

--- a/examples/pagerank/src/main/scala/io/gearpump/examples/pagerank/PageRankWorker.scala
+++ b/examples/pagerank/src/main/scala/io/gearpump/examples/pagerank/PageRankWorker.scala
@@ -13,7 +13,7 @@
  */
 package io.gearpump.examples.pagerank
 
-import akka.actor.Actor.Receive
+import org.apache.pekko.actor.Actor.Receive
 import io.gearpump.cluster.UserConfig
 import io.gearpump.examples.pagerank.PageRankApplication.NodeWithTaskId
 import io.gearpump.examples.pagerank.PageRankController.Tick

--- a/examples/streaming/complexdag/src/main/scala/io/gearpump/streaming/examples/complexdag/Dag.scala
+++ b/examples/streaming/complexdag/src/main/scala/io/gearpump/streaming/examples/complexdag/Dag.scala
@@ -20,7 +20,7 @@ import io.gearpump.cluster.main.{ArgumentsParser, CLIOption}
 import io.gearpump.streaming.{Processor, StreamApplication}
 import io.gearpump.streaming.partitioner.HashPartitioner
 import io.gearpump.streaming.task.TaskContext
-import io.gearpump.util.{AkkaApp, Graph}
+import io.gearpump.util.{PekkoApp, Graph}
 import io.gearpump.util.Graph.{Node => GraphNode}
 
 case class Source_0(_context: TaskContext, _conf: UserConfig) extends Source(_context, _conf)
@@ -56,7 +56,7 @@ case class Sink_4(_context: TaskContext, _conf: UserConfig) extends Sink(_contex
  *   Source_1 -> Sink_4;
  * }
  */
-object Dag extends AkkaApp with ArgumentsParser {
+object Dag extends PekkoApp with ArgumentsParser {
   override val options: Array[(String, CLIOption[Any])] = Array.empty
 
   def application(): StreamApplication = {
@@ -94,8 +94,8 @@ object Dag extends AkkaApp with ArgumentsParser {
     app
   }
 
-  override def main(akkaConf: Config, args: Array[String]): Unit = {
-    val context = ClientContext(akkaConf)
+  override def main(pekkoConf: Config, args: Array[String]): Unit = {
+    val context = ClientContext(pekkoConf)
     context.submit(application())
     context.close()
   }

--- a/examples/streaming/complexdag/src/test/scala/io/gearpump/streaming/examples/complexdag/SourceSpec.scala
+++ b/examples/streaming/complexdag/src/test/scala/io/gearpump/streaming/examples/complexdag/SourceSpec.scala
@@ -13,7 +13,7 @@
  */
 package io.gearpump.streaming.examples.complexdag
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import io.gearpump.Message
 import io.gearpump.cluster.{TestUtil, UserConfig}
 import io.gearpump.streaming.MockUtil

--- a/examples/streaming/sol/src/main/scala/io/gearpump/streaming/examples/sol/SOL.scala
+++ b/examples/streaming/sol/src/main/scala/io/gearpump/streaming/examples/sol/SOL.scala
@@ -19,10 +19,10 @@ import io.gearpump.cluster.client.ClientContext
 import io.gearpump.cluster.main.{ArgumentsParser, CLIOption, ParseResult}
 import io.gearpump.streaming.{Processor, StreamApplication}
 import io.gearpump.streaming.partitioner.ShufflePartitioner
-import io.gearpump.util.{AkkaApp, Graph}
+import io.gearpump.util.{PekkoApp, Graph}
 import io.gearpump.util.Graph._
 
-object SOL extends AkkaApp with ArgumentsParser {
+object SOL extends PekkoApp with ArgumentsParser {
 
   override val options: Array[(String, CLIOption[Any])] = Array(
     "streamProducer" -> CLIOption[Int]("<stream producer number>", required = false,
@@ -52,9 +52,9 @@ object SOL extends AkkaApp with ArgumentsParser {
     app
   }
 
-  override def main(akkaConf: Config, args: Array[String]): Unit = {
+  override def main(pekkoConf: Config, args: Array[String]): Unit = {
     val config = parse(args)
-    val context = ClientContext(akkaConf)
+    val context = ClientContext(pekkoConf)
     context.submit(application(config))
     context.close()
   }

--- a/examples/streaming/sol/src/main/scala/io/gearpump/streaming/examples/sol/SOLStreamProcessor.scala
+++ b/examples/streaming/sol/src/main/scala/io/gearpump/streaming/examples/sol/SOLStreamProcessor.scala
@@ -14,7 +14,7 @@
 
 package io.gearpump.streaming.examples.sol
 
-import akka.actor.Cancellable
+import org.apache.pekko.actor.Cancellable
 import io.gearpump.Message
 import io.gearpump.cluster.UserConfig
 import io.gearpump.streaming.task.{Task, TaskContext}

--- a/examples/streaming/wordcount-java/src/main/java/io/gearpump/streaming/examples/wordcountjava/WordCount.java
+++ b/examples/streaming/wordcount-java/src/main/java/io/gearpump/streaming/examples/wordcountjava/WordCount.java
@@ -31,7 +31,7 @@ public class WordCount {
     main(ClusterConfig.defaultConfig(), args);
   }
 
-  public static void main(Config akkaConf, String[] args) throws InterruptedException {
+  public static void main(Config pekkoConf, String[] args) throws InterruptedException {
     // For split task, we config to create two tasks
     int splitTaskNumber = 2;
     Processor split = new Processor(Split.class).withParallelism(splitTaskNumber);
@@ -50,7 +50,7 @@ public class WordCount {
 
     UserConfig conf = UserConfig.empty();
     StreamApplication app = new StreamApplication("wordcountJava", conf, graph);
-    ClientContext masterClient = ClientContext.apply(akkaConf);
+    ClientContext masterClient = ClientContext.apply(pekkoConf);
     masterClient.submit(app);
 
     masterClient.close();

--- a/examples/streaming/wordcount-java/src/main/java/io/gearpump/streaming/examples/wordcountjava/dsl/WordCount.java
+++ b/examples/streaming/wordcount-java/src/main/java/io/gearpump/streaming/examples/wordcountjava/dsl/WordCount.java
@@ -42,8 +42,8 @@ public class WordCount {
     main(ClusterConfig.defaultConfig(), args);
   }
 
-  public static void main(Config akkaConf, String[] args) throws InterruptedException {
-    ClientContext context = ClientContext.apply(akkaConf);
+  public static void main(Config pekkoConf, String[] args) throws InterruptedException {
+    ClientContext context = ClientContext.apply(pekkoConf);
     JavaStreamApp app = new JavaStreamApp("JavaDSL", context, UserConfig.empty());
 
     JavaStream<String> sentence = app.source(new StringSource("This is a good start, bingo!! bingo!!"),

--- a/examples/streaming/wordcount/src/main/scala/io/gearpump/streaming/examples/wordcount/Sum.scala
+++ b/examples/streaming/wordcount/src/main/scala/io/gearpump/streaming/examples/wordcount/Sum.scala
@@ -14,7 +14,7 @@
 
 package io.gearpump.streaming.examples.wordcount
 
-import akka.actor.Cancellable
+import org.apache.pekko.actor.Cancellable
 import io.gearpump.Message
 import io.gearpump.cluster.UserConfig
 import io.gearpump.streaming.task.{Task, TaskContext}

--- a/examples/streaming/wordcount/src/main/scala/io/gearpump/streaming/examples/wordcount/WordCount.scala
+++ b/examples/streaming/wordcount/src/main/scala/io/gearpump/streaming/examples/wordcount/WordCount.scala
@@ -14,18 +14,18 @@
 
 package io.gearpump.streaming.examples.wordcount
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import io.gearpump.cluster.UserConfig
 import io.gearpump.cluster.client.ClientContext
 import io.gearpump.cluster.main.{ArgumentsParser, CLIOption, ParseResult}
 import io.gearpump.streaming.{Processor, StreamApplication}
 import io.gearpump.streaming.partitioner.HashPartitioner
 import io.gearpump.streaming.source.DataSourceProcessor
-import io.gearpump.util.{AkkaApp, Graph}
+import io.gearpump.util.{PekkoApp, Graph}
 import io.gearpump.util.Graph.Node
 
 /** Same WordCount with low level Processor Graph syntax */
-object WordCount extends AkkaApp with ArgumentsParser {
+object WordCount extends PekkoApp with ArgumentsParser {
 
   override val options: Array[(String, CLIOption[Any])] = Array(
     "split" -> CLIOption[Int]("<how many source tasks>", required = false,
@@ -47,9 +47,9 @@ object WordCount extends AkkaApp with ArgumentsParser {
     app
   }
 
-  override def main(akkaConf: Config, args: Array[String]): Unit = {
+  override def main(pekkoConf: Config, args: Array[String]): Unit = {
     val config = parse(args)
-    val context: ClientContext = ClientContext(akkaConf)
+    val context: ClientContext = ClientContext(pekkoConf)
     val app = application(config, context.system)
     context.submit(app)
     context.close()

--- a/examples/streaming/wordcount/src/main/scala/io/gearpump/streaming/examples/wordcount/dsl/WindowedWordCount.scala
+++ b/examples/streaming/wordcount/src/main/scala/io/gearpump/streaming/examples/wordcount/dsl/WindowedWordCount.scala
@@ -20,15 +20,15 @@ import io.gearpump.streaming.dsl.scalaapi.{LoggerSink, StreamApp}
 import io.gearpump.streaming.dsl.window.api.{EventTimeTrigger, FixedWindows}
 import io.gearpump.streaming.source.{DataSource, Watermark}
 import io.gearpump.streaming.task.TaskContext
-import io.gearpump.util.AkkaApp
+import io.gearpump.util.PekkoApp
 import java.time.{Duration, Instant}
 
-object WindowedWordCount extends AkkaApp with ArgumentsParser {
+object WindowedWordCount extends PekkoApp with ArgumentsParser {
 
   override val options: Array[(String, CLIOption[Any])] = Array.empty
 
-  override def main(akkaConf: Config, args: Array[String]): Unit = {
-    val context = ClientContext(akkaConf)
+  override def main(pekkoConf: Config, args: Array[String]): Unit = {
+    val context = ClientContext(pekkoConf)
     val app = StreamApp("dsl", context)
     app.source[String](new TimedDataSource).
       // word => (word, count)

--- a/examples/streaming/wordcount/src/main/scala/io/gearpump/streaming/examples/wordcount/dsl/WordCount.scala
+++ b/examples/streaming/wordcount/src/main/scala/io/gearpump/streaming/examples/wordcount/dsl/WordCount.scala
@@ -18,15 +18,15 @@ import io.gearpump.cluster.client.ClientContext
 import io.gearpump.cluster.main.{ArgumentsParser, CLIOption}
 import io.gearpump.streaming.dsl.scalaapi.StreamApp
 import io.gearpump.streaming.dsl.scalaapi.StreamApp._
-import io.gearpump.util.AkkaApp
+import io.gearpump.util.PekkoApp
 
 /** Same WordCount with High level DSL syntax */
-object WordCount extends AkkaApp with ArgumentsParser {
+object WordCount extends PekkoApp with ArgumentsParser {
 
   override val options: Array[(String, CLIOption[Any])] = Array.empty
 
-  override def main(akkaConf: Config, args: Array[String]): Unit = {
-    val context: ClientContext = ClientContext(akkaConf)
+  override def main(pekkoConf: Config, args: Array[String]): Unit = {
+    val context: ClientContext = ClientContext(pekkoConf)
     val app = StreamApp("dsl", context)
     val data = "This is a good start, bingo!! bingo!!"
     app.source(data.lines.toList, 1, "source").

--- a/examples/streaming/wordcount/src/test/scala/io/gearpump/streaming/examples/wordcount/SplitSpec.scala
+++ b/examples/streaming/wordcount/src/test/scala/io/gearpump/streaming/examples/wordcount/SplitSpec.scala
@@ -13,8 +13,8 @@
  */
 package io.gearpump.streaming.examples.wordcount
 
-import akka.actor.ActorSystem
-import akka.testkit.TestProbe
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.testkit.TestProbe
 import io.gearpump.Message
 import io.gearpump.cluster.TestUtil
 import io.gearpump.streaming.MockUtil

--- a/project/BuildDashboard.scala
+++ b/project/BuildDashboard.scala
@@ -23,11 +23,12 @@ object BuildDashboard {
   lazy val serviceJvmSettings = commonSettings ++ noPublish ++ myAssemblySettings ++
     javadocSettings ++ Seq(
       libraryDependencies ++= Seq(
-        "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpVersion % "test",
+        "org.apache.pekko" %% "pekko-http-testkit" % pekkoHttpVersion % "test",
+        "org.apache.pekko" %% "pekko-stream-testkit" % pekkoVersion % "test",
         "org.scalatest" %% "scalatest" % scalaTestVersion % "test",
         "com.lihaoyi" %% "upickle" % upickleVersion,
-        "com.softwaremill.akka-http-session" %% "core" % "0.3.0",
-        "com.typesafe.akka" %% "akka-http-spray-json" % akkaHttpVersion,
+        "com.softwaremill.pekko-http-session" %% "core" % pekkoHttpSessionVersion,
+        "org.apache.pekko" %% "pekko-http-spray-json" % pekkoHttpVersion,
         "com.github.scribejava" % "scribejava-apis" % "2.4.0",
         "com.ning" % "async-http-client" % "1.9.33",
         "org.webjars" % "angularjs" % "1.4.9",

--- a/project/BuildGearpump.scala
+++ b/project/BuildGearpump.scala
@@ -152,7 +152,6 @@ object BuildGearpump {
       s"${name.value}_${scalaBinaryVersion.value}-${version.value}-assembly.jar"
     },
     assemblyShadeRules in assembly := Seq(
-      ShadeRule.rename("com.romix.**" -> "io.gearpump.@0").inAll,
       ShadeRule.rename("com.esotericsoftware.**" ->
         "io.gearpump.@0").inAll,
       ShadeRule.rename("org.objenesis.**" -> "io.gearpump.@0").inAll,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,8 +19,9 @@ object Dependencies {
 
   val crossScalaVersionNumbers = Seq("2.12.7")
   val scalaVersionNumber = crossScalaVersionNumbers.last
-  val akkaVersion = "2.5.18"
-  val akkaHttpVersion = "10.1.3"
+  val pekkoVersion = "1.4.0"
+  val pekkoHttpVersion = "1.3.0"
+  val pekkoHttpSessionVersion = "0.7.1"
   val hadoopVersion = "3.1.1"
   val commonsHttpVersion = "3.1"
   val commonsLoggingVersion = "1.1.3"
@@ -33,7 +34,7 @@ object Dependencies {
   val slf4jVersion = "1.7.16"
   val guavaVersion = "16.0.1"
   val codahaleVersion = "3.0.2"
-  val kryoVersion = "0.5.2"
+  val pekkoKryoVersion = "1.4.0"
   val gsCollectionsVersion = "6.2.0"
   val sprayVersion = "1.3.2"
   val sprayJsonVersion = "1.3.1"
@@ -69,38 +70,40 @@ object Dependencies {
       "commons-lang" % "commons-lang" % commonsLangVersion,
 
       /**
-       * Overrides Netty version 3.10.3.Final used by Akka 2.4.2 to work-around netty hang issue
+       * Overrides Netty version 3.10.3.Final used by the original Akka 2.4.2 stack to
+       * work around a Netty hang issue
        * (https://github.com/gearpump/gearpump/issues/2020)
        *
-       * Akka 2.4.2 by default use Netty 3.10.3.Final, which has a serious issue which can hang
+       * Akka 2.4.2 used Netty 3.10.3.Final by default, which has a serious issue that can hang
        * the network. The same issue also happens in version range (3.10.0.Final, 3.10.5.Final)
        * Netty 3.10.6.Final have this issue fixed, however, we find there is a 20% performance
-       * drop. So we decided to downgrade netty to 3.8.0.Final (Same version used in akka 2.3.12).
+       * drop. So we decided to downgrade netty to 3.8.0.Final (the same version used in
+       * Akka 2.3.12).
        *
        * @see https://github.com/gearpump/gearpump/pull/2017 for more discussions.
        */
       "io.netty" % "netty" % "3.8.0.Final",
-      "com.typesafe.akka" %% "akka-remote" % akkaVersion
+      "org.apache.pekko" %% "pekko-remote" % pekkoVersion
         exclude("io.netty", "netty"),
 
-      "com.typesafe.akka" %% "akka-cluster" % akkaVersion,
-      "com.typesafe.akka" %% "akka-cluster-tools" % akkaVersion,
+      "org.apache.pekko" %% "pekko-cluster" % pekkoVersion,
+      "org.apache.pekko" %% "pekko-cluster-tools" % pekkoVersion,
       "commons-logging" % "commons-logging" % commonsLoggingVersion,
-      "com.typesafe.akka" %% "akka-distributed-data" % akkaVersion,
-      "com.typesafe.akka" %% "akka-actor" % akkaVersion,
-      "com.typesafe.akka" %% "akka-agent" % akkaVersion,
-      "com.typesafe.akka" %% "akka-slf4j" % akkaVersion,
-      "com.typesafe.akka" %% "akka-http" % akkaHttpVersion,
-      "com.typesafe.akka" %% "akka-http-spray-json" % akkaHttpVersion,
+      "org.apache.pekko" %% "pekko-distributed-data" % pekkoVersion,
+      "org.apache.pekko" %% "pekko-actor" % pekkoVersion,
+      "org.apache.pekko" %% "pekko-slf4j" % pekkoVersion,
+      "org.apache.pekko" %% "pekko-stream" % pekkoVersion,
+      "org.apache.pekko" %% "pekko-http" % pekkoHttpVersion,
+      "org.apache.pekko" %% "pekko-http-spray-json" % pekkoHttpVersion,
       "org.scala-lang" % "scala-reflect" % scalaVersionNumber,
-      "com.github.romix.akka" %% "akka-kryo-serialization" % kryoVersion,
+      "io.altoo" %% "pekko-kryo-serialization" % pekkoKryoVersion,
       "com.google.guava" % "guava" % guavaVersion,
       "com.codahale.metrics" % "metrics-graphite" % codahaleVersion
         exclude("org.slf4j", "slf4j-api"),
       "com.codahale.metrics" % "metrics-jvm" % codahaleVersion
         exclude("org.slf4j", "slf4j-api"),
 
-      "com.typesafe.akka" %% "akka-testkit" % akkaVersion % "test",
+      "org.apache.pekko" %% "pekko-testkit" % pekkoVersion % "test",
       "org.scalatest" %% "scalatest" % scalaTestVersion % "test",
       "org.scalacheck" %% "scalacheck" % scalaCheckVersion % "test",
       "org.mockito" % "mockito-core" % mockitoVersion % "test",

--- a/project/Docs.scala
+++ b/project/Docs.scala
@@ -45,6 +45,6 @@ object Docs {
   private def ignoreUndocumentedPackages(packages: Seq[Seq[File]]): Seq[Seq[File]] = {
     packages
       .map(_.filterNot(_.getName.contains("$")))
-      .map(_.filterNot(_.getCanonicalPath.contains("akka")))
+      .map(_.filterNot(_.getCanonicalPath.contains("pekko")))
   }
 }

--- a/services/jvm/src/main/scala/io/gearpump/services/AdminService.scala
+++ b/services/jvm/src/main/scala/io/gearpump/services/AdminService.scala
@@ -14,10 +14,10 @@
 
 package io.gearpump.services
 
-import akka.actor.ActorSystem
-import akka.http.scaladsl.model._
-import akka.http.scaladsl.server.Directives._
-import akka.stream.Materializer
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.model._
+import org.apache.pekko.http.scaladsl.server.Directives._
+import org.apache.pekko.stream.Materializer
 
 /**
  * AdminService is for cluster-wide managements. it is not related with

--- a/services/jvm/src/main/scala/io/gearpump/services/AppMasterService.scala
+++ b/services/jvm/src/main/scala/io/gearpump/services/AppMasterService.scala
@@ -14,12 +14,12 @@
 
 package io.gearpump.services
 
-import akka.actor.{ActorRef, ActorSystem}
-import akka.http.scaladsl.model.{FormData, Multipart}
-import akka.http.scaladsl.server.Directives._
-import akka.http.scaladsl.server.Route
-import akka.http.scaladsl.server.directives.ParameterDirectives.ParamMagnet
-import akka.stream.Materializer
+import org.apache.pekko.actor.{ActorRef, ActorSystem}
+import org.apache.pekko.http.scaladsl.model.{FormData, Multipart}
+import org.apache.pekko.http.scaladsl.server.Directives._
+import org.apache.pekko.http.scaladsl.server.Route
+import org.apache.pekko.http.scaladsl.server.directives.ParameterDirectives.ParamMagnet
+import org.apache.pekko.stream.Materializer
 import io.gearpump.cluster.AppMasterToMaster.{AppMasterSummary, GeneralAppMasterSummary}
 import io.gearpump.cluster.ClientToMaster._
 import io.gearpump.cluster.ClusterConfig

--- a/services/jvm/src/main/scala/io/gearpump/services/BasicService.scala
+++ b/services/jvm/src/main/scala/io/gearpump/services/BasicService.scala
@@ -14,12 +14,12 @@
 
 package io.gearpump.services
 
-import akka.actor.ActorSystem
-import akka.http.scaladsl.model.headers.CacheDirectives.{`max-age`, `no-cache`}
-import akka.http.scaladsl.model.headers.`Cache-Control`
-import akka.http.scaladsl.server.Directives._
-import akka.http.scaladsl.server.Route
-import akka.stream.Materializer
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.model.headers.CacheDirectives.{`max-age`, `no-cache`}
+import org.apache.pekko.http.scaladsl.model.headers.`Cache-Control`
+import org.apache.pekko.http.scaladsl.server.Directives._
+import org.apache.pekko.http.scaladsl.server.Route
+import org.apache.pekko.stream.Materializer
 import io.gearpump.util.Constants
 import scala.concurrent.ExecutionContext
 
@@ -34,7 +34,7 @@ trait BasicService extends RouteService {
 
   implicit def system: ActorSystem
 
-  implicit def timeout: akka.util.Timeout = Constants.FUTURE_TIMEOUT
+  implicit def timeout: org.apache.pekko.util.Timeout = Constants.FUTURE_TIMEOUT
 
   implicit def ec: ExecutionContext = system.dispatcher
 

--- a/services/jvm/src/main/scala/io/gearpump/services/MasterService.scala
+++ b/services/jvm/src/main/scala/io/gearpump/services/MasterService.scala
@@ -14,12 +14,12 @@
 
 package io.gearpump.services
 
-import akka.actor.{ActorRef, ActorSystem}
-import akka.http.scaladsl.server.Directives._
-import akka.http.scaladsl.server.Route
-import akka.http.scaladsl.server.directives.ParameterDirectives.ParamMagnet
-import akka.http.scaladsl.unmarshalling.Unmarshaller._
-import akka.stream.Materializer
+import org.apache.pekko.actor.{ActorRef, ActorSystem}
+import org.apache.pekko.http.scaladsl.server.Directives._
+import org.apache.pekko.http.scaladsl.server.Route
+import org.apache.pekko.http.scaladsl.server.directives.ParameterDirectives.ParamMagnet
+import org.apache.pekko.http.scaladsl.unmarshalling.Unmarshaller._
+import org.apache.pekko.stream.Materializer
 import com.typesafe.config.Config
 import io.gearpump.cluster.{ClusterConfig, UserConfig}
 import io.gearpump.cluster.AppMasterToMaster.{GetAllWorkers, GetMasterData, GetWorkerData, MasterData, WorkerData}

--- a/services/jvm/src/main/scala/io/gearpump/services/RestServices.scala
+++ b/services/jvm/src/main/scala/io/gearpump/services/RestServices.scala
@@ -14,12 +14,12 @@
 
 package io.gearpump.services
 
-import akka.actor.{ActorRef, ActorSystem}
-import akka.http.scaladsl.model.HttpResponse
-import akka.http.scaladsl.model.StatusCodes._
-import akka.http.scaladsl.server.{Route, _}
-import akka.http.scaladsl.server.Directives._
-import akka.util.Timeout
+import org.apache.pekko.actor.{ActorRef, ActorSystem}
+import org.apache.pekko.http.scaladsl.model.HttpResponse
+import org.apache.pekko.http.scaladsl.model.StatusCodes._
+import org.apache.pekko.http.scaladsl.server.{Route, _}
+import org.apache.pekko.http.scaladsl.server.Directives._
+import org.apache.pekko.util.Timeout
 import io.gearpump.jarstore.JarStoreClient
 import io.gearpump.util.{Constants, LogUtil}
 import org.apache.commons.lang.exception.ExceptionUtils

--- a/services/jvm/src/main/scala/io/gearpump/services/SecurityService.scala
+++ b/services/jvm/src/main/scala/io/gearpump/services/SecurityService.scala
@@ -14,14 +14,14 @@
 
 package io.gearpump.services
 
-import akka.actor.ActorSystem
-import akka.http.scaladsl.model.{RemoteAddress, StatusCodes, Uri}
-import akka.http.scaladsl.model.headers.{HttpChallenge, HttpCookie, HttpCookiePair}
-import akka.http.scaladsl.server._
-import akka.http.scaladsl.server.AuthenticationFailedRejection.{CredentialsMissing, CredentialsRejected}
-import akka.http.scaladsl.server.Directives._
-import akka.http.scaladsl.server.directives.FormFieldDirectives.FieldMagnet
-import akka.stream.Materializer
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.model.{RemoteAddress, StatusCodes, Uri}
+import org.apache.pekko.http.scaladsl.model.headers.{HttpChallenge, HttpCookie, HttpCookiePair}
+import org.apache.pekko.http.scaladsl.server._
+import org.apache.pekko.http.scaladsl.server.AuthenticationFailedRejection.{CredentialsMissing, CredentialsRejected}
+import org.apache.pekko.http.scaladsl.server.Directives._
+import org.apache.pekko.http.scaladsl.server.directives.FormFieldDirectives.FieldMagnet
+import org.apache.pekko.stream.Materializer
 import com.github.ghik.silencer.silent
 import com.softwaremill.session.{MultiValueSessionSerializer, SessionConfig, SessionManager}
 import com.softwaremill.session.SessionDirectives._
@@ -252,6 +252,7 @@ class SecurityService(inner: RouteService, implicit val system: ActorSystem) ext
 
 object SecurityService {
 
+  // The pekko-http-session library still reads akka.http.session.* keys.
   val SESSION_MANAGER_KEY = "akka.http.session.server-secret"
 
   case class UserSession(user: String, permissionLevel: Int)

--- a/services/jvm/src/main/scala/io/gearpump/services/StaticService.scala
+++ b/services/jvm/src/main/scala/io/gearpump/services/StaticService.scala
@@ -14,12 +14,12 @@
 
 package io.gearpump.services
 
-import akka.actor.ActorSystem
-import akka.http.scaladsl.marshalling.ToResponseMarshallable
-import akka.http.scaladsl.marshalling.ToResponseMarshallable._
-import akka.http.scaladsl.model._
-import akka.http.scaladsl.server.Directives._
-import akka.stream.Materializer
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.marshalling.ToResponseMarshallable
+import org.apache.pekko.http.scaladsl.marshalling.ToResponseMarshallable._
+import org.apache.pekko.http.scaladsl.model._
+import org.apache.pekko.http.scaladsl.server.Directives._
+import org.apache.pekko.stream.Materializer
 import io.gearpump.util.Util
 
 /**

--- a/services/jvm/src/main/scala/io/gearpump/services/SupervisorService.scala
+++ b/services/jvm/src/main/scala/io/gearpump/services/SupervisorService.scala
@@ -14,10 +14,10 @@
 
 package io.gearpump.services
 
-import akka.actor.{ActorRef, ActorSystem}
-import akka.http.scaladsl.server.Directives._
-import akka.http.scaladsl.server.Route
-import akka.stream.Materializer
+import org.apache.pekko.actor.{ActorRef, ActorSystem}
+import org.apache.pekko.http.scaladsl.server.Directives._
+import org.apache.pekko.http.scaladsl.server.Route
+import org.apache.pekko.stream.Materializer
 import io.gearpump.cluster.AppMasterToMaster.{GetWorkerData, WorkerData}
 import io.gearpump.cluster.ClientToMaster._
 import io.gearpump.cluster.worker.WorkerId

--- a/services/jvm/src/main/scala/io/gearpump/services/WorkerService.scala
+++ b/services/jvm/src/main/scala/io/gearpump/services/WorkerService.scala
@@ -14,9 +14,9 @@
 
 package io.gearpump.services
 
-import akka.actor.{ActorRef, ActorSystem}
-import akka.http.scaladsl.server.Directives._
-import akka.stream.Materializer
+import org.apache.pekko.actor.{ActorRef, ActorSystem}
+import org.apache.pekko.http.scaladsl.server.Directives._
+import org.apache.pekko.stream.Materializer
 import io.gearpump.cluster.AppMasterToMaster.{GetWorkerData, WorkerData}
 import io.gearpump.cluster.ClientToMaster.{QueryHistoryMetrics, QueryWorkerConfig, ReadOption}
 import io.gearpump.cluster.ClusterConfig

--- a/services/jvm/src/main/scala/io/gearpump/services/main/Services.scala
+++ b/services/jvm/src/main/scala/io/gearpump/services/main/Services.scala
@@ -14,25 +14,26 @@
 
 package io.gearpump.services.main
 
-import akka.actor.ActorSystem
-import akka.http.scaladsl.Http
-import akka.http.scaladsl.server.Route
-import akka.stream.ActorMaterializer
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.Http
+import org.apache.pekko.http.scaladsl.server.Route
+import org.apache.pekko.stream.Materializer
 import com.typesafe.config.ConfigValueFactory
 import io.gearpump.cluster.ClusterConfig
 import io.gearpump.cluster.main.{ArgumentsParser, CLIOption, Gear}
 import io.gearpump.cluster.master.MasterProxy
 import io.gearpump.services.{RestServices, SecurityService}
-import io.gearpump.util.{AkkaApp, Constants, LogUtil, Util}
+import io.gearpump.util.{PekkoApp, Constants, LogUtil, Util}
 import io.gearpump.util.LogUtil.ProcessType
 import java.util.Random
 import org.slf4j.Logger
 import scala.collection.JavaConverters._
 import scala.concurrent.Await
+import scala.concurrent.Future
 import sun.misc.BASE64Encoder
 
 /** Command line to start UI server */
-object Services extends AkkaApp with ArgumentsParser {
+object Services extends PekkoApp with ArgumentsParser {
 
   override val options: Array[(String, CLIOption[Any])] = Array(
     "master" -> CLIOption("<host:port>", required = false),
@@ -41,7 +42,7 @@ object Services extends AkkaApp with ArgumentsParser {
 
   override val description = "UI Server"
 
-  override def akkaConfig: Config = {
+  override def pekkoConfig: Config = {
     ClusterConfig.ui()
   }
 
@@ -53,28 +54,28 @@ object Services extends AkkaApp with ArgumentsParser {
 
   private var killFunction: Option[() => Unit] = None
 
-  override def main(inputAkkaConf: Config, args: Array[String]): Unit = {
+  override def main(inputPekkoConf: Config, args: Array[String]): Unit = {
 
     val argConfig = parse(args)
-    var akkaConf =
+    var pekkoConf =
       if (argConfig.exists(Gear.OPTION_CONFIG)) {
         ClusterConfig.ui(argConfig.getString(Gear.OPTION_CONFIG))
       } else {
-        inputAkkaConf
+        inputPekkoConf
       }
 
     val LOG: Logger = {
-      LogUtil.loadConfiguration(akkaConf, ProcessType.UI)
+      LogUtil.loadConfiguration(pekkoConf, ProcessType.UI)
       LogUtil.getLogger(getClass)
     }
 
     if (argConfig.exists("master")) {
       val master = argConfig.getString("master")
-      akkaConf = akkaConf.withValue(Constants.GEARPUMP_CLUSTER_MASTERS,
+      pekkoConf = pekkoConf.withValue(Constants.GEARPUMP_CLUSTER_MASTERS,
         ConfigValueFactory.fromIterable(List(master).asJava))
     }
 
-    akkaConf = akkaConf.withValue(Constants.GEARPUMP_SERVICE_SUPERVISOR_PATH,
+    pekkoConf = pekkoConf.withValue(Constants.GEARPUMP_SERVICE_SUPERVISOR_PATH,
       ConfigValueFactory.fromAnyRef(argConfig.getString("supervisor")))
       // Creates a random unique secret key for session manager.
       // All previous stored session token cookies will be invalidated when UI
@@ -82,10 +83,10 @@ object Services extends AkkaApp with ArgumentsParser {
       .withValue(SecurityService.SESSION_MANAGER_KEY,
         ConfigValueFactory.fromAnyRef(randomSeverSecret()))
 
-    val masterCluster = akkaConf.getStringList(Constants.GEARPUMP_CLUSTER_MASTERS).asScala
+    val masterCluster = pekkoConf.getStringList(Constants.GEARPUMP_CLUSTER_MASTERS).asScala
       .flatMap(Util.parseHostList)
 
-    implicit val system = ActorSystem("services", akkaConf)
+    implicit val system = ActorSystem("services", pekkoConf)
     implicit val executionContext = system.dispatcher
 
     import scala.concurrent.duration._
@@ -95,8 +96,8 @@ object Services extends AkkaApp with ArgumentsParser {
 
     val services = new RestServices(master, system)
 
-    implicit val mat = ActorMaterializer()
-    val bindFuture = Http().bindAndHandle(Route.handlerFlow(services.route), host, port)
+    implicit val mat: Materializer = Materializer(system)
+    val bindFuture: Future[Http.ServerBinding] = Http().newServerAt(host, port).bind(services.route)
     Await.result(bindFuture, 15.seconds)
 
     val displayHost = if (host == "0.0.0.0") "127.0.0.1" else host

--- a/services/jvm/src/test/scala/io/gearpump/services/AdminServiceSpec.scala
+++ b/services/jvm/src/test/scala/io/gearpump/services/AdminServiceSpec.scala
@@ -14,8 +14,8 @@
 
 package io.gearpump.services
 
-import akka.actor.ActorSystem
-import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
 import com.typesafe.config.Config
 import io.gearpump.cluster.TestUtil
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}

--- a/services/jvm/src/test/scala/io/gearpump/services/AppMasterServiceSpec.scala
+++ b/services/jvm/src/test/scala/io/gearpump/services/AppMasterServiceSpec.scala
@@ -14,11 +14,11 @@
 
 package io.gearpump.services
 
-import akka.actor.ActorRef
-import akka.http.scaladsl.model.headers.`Cache-Control`
-import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
-import akka.testkit.{TestKit, TestProbe}
-import akka.testkit.TestActor.{AutoPilot, KeepRunning}
+import org.apache.pekko.actor.ActorRef
+import org.apache.pekko.http.scaladsl.model.headers.`Cache-Control`
+import org.apache.pekko.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
+import org.apache.pekko.testkit.{TestKit, TestProbe}
+import org.apache.pekko.testkit.TestActor.{AutoPilot, KeepRunning}
 import com.typesafe.config.{Config, ConfigFactory}
 import io.gearpump.cluster.{ApplicationStatus, TestUtil}
 import io.gearpump.cluster.AppMasterToMaster.GeneralAppMasterSummary

--- a/services/jvm/src/test/scala/io/gearpump/services/MasterServiceSpec.scala
+++ b/services/jvm/src/test/scala/io/gearpump/services/MasterServiceSpec.scala
@@ -14,14 +14,14 @@
 
 package io.gearpump.services
 
-import akka.actor.ActorRef
-import akka.http.scaladsl.marshalling.Marshal
-import akka.http.scaladsl.model._
-import akka.http.scaladsl.model.headers.`Cache-Control`
-import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
-import akka.stream.scaladsl.{FileIO, Source}
-import akka.testkit.TestActor.{AutoPilot, KeepRunning}
-import akka.testkit.TestProbe
+import org.apache.pekko.actor.ActorRef
+import org.apache.pekko.http.scaladsl.marshalling.Marshal
+import org.apache.pekko.http.scaladsl.model._
+import org.apache.pekko.http.scaladsl.model.headers.`Cache-Control`
+import org.apache.pekko.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
+import org.apache.pekko.stream.scaladsl.{FileIO, Source}
+import org.apache.pekko.testkit.TestActor.{AutoPilot, KeepRunning}
+import org.apache.pekko.testkit.TestProbe
 import com.typesafe.config.{Config, ConfigFactory}
 import io.gearpump.cluster.AppMasterToMaster.{GetAllWorkers, GetMasterData, GetWorkerData, MasterData, WorkerData}
 import io.gearpump.cluster.ClientToMaster.{QueryHistoryMetrics, QueryMasterConfig, ResolveWorkerId, SubmitApplication}

--- a/services/jvm/src/test/scala/io/gearpump/services/SecurityServiceSpec.scala
+++ b/services/jvm/src/test/scala/io/gearpump/services/SecurityServiceSpec.scala
@@ -14,12 +14,12 @@
 
 package io.gearpump.services
 
-import akka.actor.ActorSystem
-import akka.http.scaladsl.model.FormData
-import akka.http.scaladsl.model.headers.{`Set-Cookie`, Cookie, _}
-import akka.http.scaladsl.server.{AuthorizationFailedRejection, _}
-import akka.http.scaladsl.server.Directives._
-import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.model.FormData
+import org.apache.pekko.http.scaladsl.model.headers.{`Set-Cookie`, Cookie, _}
+import org.apache.pekko.http.scaladsl.server.{AuthorizationFailedRejection, _}
+import org.apache.pekko.http.scaladsl.server.Directives._
+import org.apache.pekko.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
 import com.typesafe.config.Config
 import io.gearpump.cluster.TestUtil
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}

--- a/services/jvm/src/test/scala/io/gearpump/services/StaticServiceSpec.scala
+++ b/services/jvm/src/test/scala/io/gearpump/services/StaticServiceSpec.scala
@@ -14,8 +14,8 @@
 
 package io.gearpump.services
 
-import akka.http.scaladsl.model.headers.`Cache-Control`
-import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
+import org.apache.pekko.http.scaladsl.model.headers.`Cache-Control`
+import org.apache.pekko.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
 import com.typesafe.config.Config
 import io.gearpump.cluster.TestUtil
 import io.gearpump.util.Constants

--- a/services/jvm/src/test/scala/io/gearpump/services/SupervisorServiceSpec.scala
+++ b/services/jvm/src/test/scala/io/gearpump/services/SupervisorServiceSpec.scala
@@ -14,11 +14,11 @@
 
 package io.gearpump.services
 
-import akka.actor.ActorRef
-import akka.http.scaladsl.model.StatusCodes
-import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
-import akka.testkit.{TestKit, TestProbe}
-import akka.testkit.TestActor.{AutoPilot, KeepRunning}
+import org.apache.pekko.actor.ActorRef
+import org.apache.pekko.http.scaladsl.model.StatusCodes
+import org.apache.pekko.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
+import org.apache.pekko.testkit.{TestKit, TestProbe}
+import org.apache.pekko.testkit.TestActor.{AutoPilot, KeepRunning}
 import com.typesafe.config.{Config, ConfigFactory}
 import io.gearpump.cluster.AppMasterToMaster.{GetWorkerData, WorkerData}
 import io.gearpump.cluster.ClientToMaster._

--- a/services/jvm/src/test/scala/io/gearpump/services/WorkerServiceSpec.scala
+++ b/services/jvm/src/test/scala/io/gearpump/services/WorkerServiceSpec.scala
@@ -14,11 +14,11 @@
 
 package io.gearpump.services
 
-import akka.actor.ActorRef
-import akka.http.scaladsl.model.headers.`Cache-Control`
-import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
-import akka.testkit.{TestKit, TestProbe}
-import akka.testkit.TestActor.{AutoPilot, KeepRunning}
+import org.apache.pekko.actor.ActorRef
+import org.apache.pekko.http.scaladsl.model.headers.`Cache-Control`
+import org.apache.pekko.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
+import org.apache.pekko.testkit.{TestKit, TestProbe}
+import org.apache.pekko.testkit.TestActor.{AutoPilot, KeepRunning}
 import com.typesafe.config.{Config, ConfigFactory}
 import io.gearpump.cluster.AppMasterToMaster.{GetWorkerData, WorkerData}
 import io.gearpump.cluster.ClientToMaster.{QueryHistoryMetrics, QueryWorkerConfig, ResolveWorkerId}

--- a/services/jvm/src/test/scala/io/gearpump/services/security/oauth2/CloudFoundryUAAOAuth2AuthenticatorSpec.scala
+++ b/services/jvm/src/test/scala/io/gearpump/services/security/oauth2/CloudFoundryUAAOAuth2AuthenticatorSpec.scala
@@ -14,12 +14,12 @@
 
 package io.gearpump.services.security.oauth2
 
-import akka.actor.ActorSystem
-import akka.http.scaladsl.model._
-import akka.http.scaladsl.model.HttpEntity.Strict
-import akka.http.scaladsl.model.MediaTypes._
-import akka.http.scaladsl.model.Uri.{Path, Query}
-import akka.http.scaladsl.testkit.ScalatestRouteTest
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.model._
+import org.apache.pekko.http.scaladsl.model.HttpEntity.Strict
+import org.apache.pekko.http.scaladsl.model.MediaTypes._
+import org.apache.pekko.http.scaladsl.model.Uri.{Path, Query}
+import org.apache.pekko.http.scaladsl.testkit.ScalatestRouteTest
 import com.typesafe.config.ConfigFactory
 import io.gearpump.security.Authenticator
 import io.gearpump.services.security.oauth2.impl.CloudFoundryUAAOAuth2Authenticator

--- a/services/jvm/src/test/scala/io/gearpump/services/security/oauth2/GoogleOAuth2AuthenticatorSpec.scala
+++ b/services/jvm/src/test/scala/io/gearpump/services/security/oauth2/GoogleOAuth2AuthenticatorSpec.scala
@@ -14,12 +14,12 @@
 
 package io.gearpump.services.security.oauth2
 
-import akka.actor.ActorSystem
-import akka.http.scaladsl.model._
-import akka.http.scaladsl.model.HttpEntity.Strict
-import akka.http.scaladsl.model.MediaTypes._
-import akka.http.scaladsl.model.Uri.{Path, Query}
-import akka.http.scaladsl.testkit.ScalatestRouteTest
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.model._
+import org.apache.pekko.http.scaladsl.model.HttpEntity.Strict
+import org.apache.pekko.http.scaladsl.model.MediaTypes._
+import org.apache.pekko.http.scaladsl.model.Uri.{Path, Query}
+import org.apache.pekko.http.scaladsl.testkit.ScalatestRouteTest
 import com.typesafe.config.ConfigFactory
 import io.gearpump.security.Authenticator
 import io.gearpump.services.security.oauth2.GoogleOAuth2AuthenticatorSpec.MockGoogleAuthenticator

--- a/services/jvm/src/test/scala/io/gearpump/services/security/oauth2/MockOAuth2Server.scala
+++ b/services/jvm/src/test/scala/io/gearpump/services/security/oauth2/MockOAuth2Server.scala
@@ -14,12 +14,11 @@
 
 package io.gearpump.services.security.oauth2
 
-import akka.actor.ActorSystem
-import akka.http.scaladsl.Http
-import akka.http.scaladsl.Http.ServerBinding
-import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
-import akka.stream.ActorMaterializer
-import akka.stream.scaladsl.Sink
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.Http
+import org.apache.pekko.http.scaladsl.Http.ServerBinding
+import org.apache.pekko.http.scaladsl.model.{HttpRequest, HttpResponse}
+import org.apache.pekko.stream.Materializer
 import io.gearpump.util.Util
 import scala.concurrent.{Await, Future}
 
@@ -31,7 +30,7 @@ class MockOAuth2Server(
     var requestHandler: HttpRequest => HttpResponse) {
 
   implicit val system: ActorSystem = actorSystem
-  implicit val materializer = ActorMaterializer()
+  implicit val materializer: Materializer = Materializer(system)
   implicit val ec = system.dispatcher
 
   private var _port: Int = 0
@@ -41,13 +40,7 @@ class MockOAuth2Server(
 
   def start(): Unit = {
     _port = Util.findFreePort().get
-
-    val serverSource = Http().bind(interface = "127.0.0.1", port = _port)
-    bindingFuture = {
-      serverSource.to(Sink.foreach { connection =>
-        connection handleWithSyncHandler requestHandler
-      }).run()
-    }
+    bindingFuture = Http().newServerAt("127.0.0.1", _port).bindSync(requestHandler)
   }
 
   def stop(): Unit = {

--- a/streaming/src/main/java/io/gearpump/streaming/javaapi/Processor.java
+++ b/streaming/src/main/java/io/gearpump/streaming/javaapi/Processor.java
@@ -14,7 +14,7 @@
 
 package io.gearpump.streaming.javaapi;
 
-import akka.actor.ActorSystem;
+import org.apache.pekko.actor.ActorSystem;
 import io.gearpump.cluster.UserConfig;
 import io.gearpump.streaming.sink.DataSink;
 import io.gearpump.streaming.sink.DataSinkProcessor;

--- a/streaming/src/main/java/io/gearpump/streaming/javaapi/StreamApplication.java
+++ b/streaming/src/main/java/io/gearpump/streaming/javaapi/StreamApplication.java
@@ -14,7 +14,7 @@
 
 package io.gearpump.streaming.javaapi;
 
-import akka.actor.ActorSystem;
+import org.apache.pekko.actor.ActorSystem;
 import io.gearpump.cluster.Application;
 import io.gearpump.cluster.ApplicationMaster;
 import io.gearpump.cluster.UserConfig;

--- a/streaming/src/main/java/io/gearpump/streaming/javaapi/Task.java
+++ b/streaming/src/main/java/io/gearpump/streaming/javaapi/Task.java
@@ -14,7 +14,7 @@
 
 package io.gearpump.streaming.javaapi;
 
-import akka.actor.ActorRef;
+import org.apache.pekko.actor.ActorRef;
 import io.gearpump.Message;
 import io.gearpump.cluster.UserConfig;
 import io.gearpump.streaming.task.TaskContext;

--- a/streaming/src/main/resources/geardefault.conf
+++ b/streaming/src/main/resources/geardefault.conf
@@ -16,7 +16,7 @@ gearpump {
 
   ### Flag to enable metrics
   metrics {
-    akka {
+    pekko {
 
       ### Whitelist for Metrics Aggregator class.
       ### See class [[MetricsAggregator]] for more information.

--- a/streaming/src/main/scala/io/gearpump/streaming/ExecutorToAppMaster.scala
+++ b/streaming/src/main/scala/io/gearpump/streaming/ExecutorToAppMaster.scala
@@ -14,7 +14,7 @@
 
 package io.gearpump.streaming
 
-import akka.actor.ActorRef
+import org.apache.pekko.actor.ActorRef
 import io.gearpump.cluster.appmaster.WorkerInfo
 import io.gearpump.cluster.scheduler.Resource
 import io.gearpump.streaming.task.TaskId

--- a/streaming/src/main/scala/io/gearpump/streaming/StreamApplication.scala
+++ b/streaming/src/main/scala/io/gearpump/streaming/StreamApplication.scala
@@ -14,7 +14,7 @@
 
 package io.gearpump.streaming
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import io.gearpump.cluster.{AppJar, Application, ApplicationMaster, UserConfig}
 import io.gearpump.streaming.appmaster.AppMaster
 import io.gearpump.streaming.partitioner.{HashPartitioner, Partitioner, PartitionerDescription, PartitionerObject}

--- a/streaming/src/main/scala/io/gearpump/streaming/appmaster/AppMaster.scala
+++ b/streaming/src/main/scala/io/gearpump/streaming/appmaster/AppMaster.scala
@@ -14,7 +14,7 @@
 
 package io.gearpump.streaming.appmaster
 
-import akka.actor._
+import org.apache.pekko.actor._
 import io.gearpump.Time.MilliSeconds
 import io.gearpump.cluster._
 import io.gearpump.cluster.AppMasterToMaster.ApplicationStatusChanged
@@ -58,7 +58,7 @@ class AppMaster(appContext: AppMasterContext, app: AppDescription) extends Appli
   private implicit val actorSystem = context.system
   private implicit val timeOut = FUTURE_TIMEOUT
 
-  import akka.pattern.ask
+  import org.apache.pekko.pattern.ask
   private implicit val dispatcher = context.dispatcher
 
   private val startTime: MilliSeconds = System.currentTimeMillis()

--- a/streaming/src/main/scala/io/gearpump/streaming/appmaster/ClockService.scala
+++ b/streaming/src/main/scala/io/gearpump/streaming/appmaster/ClockService.scala
@@ -14,7 +14,7 @@
 
 package io.gearpump.streaming.appmaster
 
-import akka.actor.{Actor, ActorRef, Cancellable, Stash}
+import org.apache.pekko.actor.{Actor, ActorRef, Cancellable, Stash}
 import com.google.common.primitives.Longs
 import io.gearpump.Time
 import io.gearpump.Time.MilliSeconds

--- a/streaming/src/main/scala/io/gearpump/streaming/appmaster/DagManager.scala
+++ b/streaming/src/main/scala/io/gearpump/streaming/appmaster/DagManager.scala
@@ -14,8 +14,8 @@
 
 package io.gearpump.streaming.appmaster
 
-import akka.actor.{Actor, ActorRef, ExtendedActorSystem, Stash}
-import akka.serialization.JavaSerializer
+import org.apache.pekko.actor.{Actor, ActorRef, ExtendedActorSystem, Stash}
+import org.apache.pekko.serialization.JavaSerializer
 import io.gearpump.cluster.UserConfig
 import io.gearpump.streaming._
 import io.gearpump.streaming.appmaster.DagManager.{DagInitiated, DAGOperationFailed, DAGOperationSuccess, GetLatestDAG, GetTaskLaunchData, LatestDAG, NewDAGDeployed, ReplaceProcessor, TaskLaunchData, WatchChange}

--- a/streaming/src/main/scala/io/gearpump/streaming/appmaster/ExecutorManager.scala
+++ b/streaming/src/main/scala/io/gearpump/streaming/appmaster/ExecutorManager.scala
@@ -14,9 +14,9 @@
 
 package io.gearpump.streaming.appmaster
 
-import akka.actor._
-import akka.actor.SupervisorStrategy.Stop
-import akka.remote.RemoteScope
+import org.apache.pekko.actor._
+import org.apache.pekko.actor.SupervisorStrategy.Stop
+import org.apache.pekko.remote.RemoteScope
 import com.typesafe.config.Config
 import io.gearpump.cluster.{AppJar, AppMasterContext, ExecutorContext, UserConfig}
 import io.gearpump.cluster.AppMasterToWorker.ChangeExecutorResource
@@ -174,11 +174,11 @@ private[appmaster] class ExecutorManager(
   }
 
   private def getExecutorJvmConfig(jar: Option[AppJar]): ExecutorSystemJvmConfig = {
-    val executorAkkaConfig = clusterConfig
-    val jvmSetting = Util.resolveJvmSetting(executorAkkaConfig.withFallback(systemConfig)).executor
+    val executorPekkoConfig = clusterConfig
+    val jvmSetting = Util.resolveJvmSetting(executorPekkoConfig.withFallback(systemConfig)).executor
 
     ExecutorSystemJvmConfig(jvmSetting.classPath, jvmSetting.vmargs, jar,
-      username, executorAkkaConfig)
+      username, executorPekkoConfig)
   }
 }
 

--- a/streaming/src/main/scala/io/gearpump/streaming/appmaster/JarScheduler.scala
+++ b/streaming/src/main/scala/io/gearpump/streaming/appmaster/JarScheduler.scala
@@ -13,8 +13,8 @@
  */
 package io.gearpump.streaming.appmaster
 
-import akka.actor._
-import akka.pattern.ask
+import org.apache.pekko.actor._
+import org.apache.pekko.pattern.ask
 import com.typesafe.config.Config
 import io.gearpump.Time.MilliSeconds
 import io.gearpump.cluster.AppJar

--- a/streaming/src/main/scala/io/gearpump/streaming/appmaster/TaskManager.scala
+++ b/streaming/src/main/scala/io/gearpump/streaming/appmaster/TaskManager.scala
@@ -14,8 +14,8 @@
 
 package io.gearpump.streaming.appmaster
 
-import akka.actor._
-import akka.pattern.ask
+import org.apache.pekko.actor._
+import org.apache.pekko.pattern.ask
 import io.gearpump.Time.MilliSeconds
 import io.gearpump.cluster.MasterToAppMaster.ReplayFromTimestampWindowTrailingEdge
 import io.gearpump.streaming._

--- a/streaming/src/main/scala/io/gearpump/streaming/appmaster/TaskRegistry.scala
+++ b/streaming/src/main/scala/io/gearpump/streaming/appmaster/TaskRegistry.scala
@@ -40,7 +40,7 @@ class TaskRegistry(val expectedTasks: List[TaskId],
    *
    * @param taskId   Task that register itself to TaskRegistry.
    * @param location The host and port where this task is running on. NOTE: The host and port
-   *                 is NOT the same host and port of Akka remoting. Instead, it is host and port
+   *                 is NOT the same host and port of Pekko remoting. Instead, it is host and port
    *                 of custom netty layer, see [[io.gearpump.transport.netty.Context]].
    */
   def registerTask(taskId: TaskId, location: TaskLocation): RegisterTaskStatus = {

--- a/streaming/src/main/scala/io/gearpump/streaming/dsl/plan/OP.scala
+++ b/streaming/src/main/scala/io/gearpump/streaming/dsl/plan/OP.scala
@@ -14,7 +14,7 @@
 
 package io.gearpump.streaming.dsl.plan
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import com.github.ghik.silencer.silent
 import io.gearpump.cluster.UserConfig
 import io.gearpump.streaming.{Constants, Processor}

--- a/streaming/src/main/scala/io/gearpump/streaming/dsl/plan/Planner.scala
+++ b/streaming/src/main/scala/io/gearpump/streaming/dsl/plan/Planner.scala
@@ -14,7 +14,7 @@
 
 package io.gearpump.streaming.dsl.plan
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import io.gearpump.streaming.Processor
 import io.gearpump.streaming.partitioner.{CoLocationPartitioner, GroupByPartitioner, HashPartitioner, Partitioner}
 import io.gearpump.streaming.task.Task

--- a/streaming/src/main/scala/io/gearpump/streaming/dsl/scalaapi/StreamApp.scala
+++ b/streaming/src/main/scala/io/gearpump/streaming/dsl/scalaapi/StreamApp.scala
@@ -14,7 +14,7 @@
 
 package io.gearpump.streaming.dsl.scalaapi
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import io.gearpump.Message
 import io.gearpump.cluster.UserConfig
 import io.gearpump.cluster.client.ClientContext

--- a/streaming/src/main/scala/io/gearpump/streaming/executor/Executor.scala
+++ b/streaming/src/main/scala/io/gearpump/streaming/executor/Executor.scala
@@ -14,8 +14,8 @@
 
 package io.gearpump.streaming.executor
 
-import akka.actor._
-import akka.actor.SupervisorStrategy.Resume
+import org.apache.pekko.actor._
+import org.apache.pekko.actor.SupervisorStrategy.Resume
 import com.typesafe.config.Config
 import io.gearpump.cluster.{ClusterConfig, ExecutorContext, UserConfig}
 import io.gearpump.cluster.worker.WorkerId

--- a/streaming/src/main/scala/io/gearpump/streaming/executor/TaskLauncher.scala
+++ b/streaming/src/main/scala/io/gearpump/streaming/executor/TaskLauncher.scala
@@ -14,7 +14,7 @@
 
 package io.gearpump.streaming.executor
 
-import akka.actor.{Actor, ActorRef, ActorRefFactory, Props}
+import org.apache.pekko.actor.{Actor, ActorRef, ActorRefFactory, Props}
 import io.gearpump.cluster.{ExecutorContext, UserConfig}
 import io.gearpump.serializer.SerializationFramework
 import io.gearpump.streaming.ProcessorDescription

--- a/streaming/src/main/scala/io/gearpump/streaming/sink/DataSinkProcessor.scala
+++ b/streaming/src/main/scala/io/gearpump/streaming/sink/DataSinkProcessor.scala
@@ -14,7 +14,7 @@
 
 package io.gearpump.streaming.sink
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import io.gearpump.cluster.UserConfig
 import io.gearpump.streaming.Processor
 

--- a/streaming/src/main/scala/io/gearpump/streaming/source/DataSourceProcessor.scala
+++ b/streaming/src/main/scala/io/gearpump/streaming/source/DataSourceProcessor.scala
@@ -14,7 +14,7 @@
 
 package io.gearpump.streaming.source
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import io.gearpump.cluster.UserConfig
 import io.gearpump.streaming.{Constants, Processor}
 import io.gearpump.streaming.dsl.plan.functions.DummyRunner

--- a/streaming/src/main/scala/io/gearpump/streaming/storage/InMemoryAppStoreOnMaster.scala
+++ b/streaming/src/main/scala/io/gearpump/streaming/storage/InMemoryAppStoreOnMaster.scala
@@ -13,8 +13,8 @@
  */
 package io.gearpump.streaming.storage
 
-import akka.actor.ActorRef
-import akka.pattern.ask
+import org.apache.pekko.actor.ActorRef
+import org.apache.pekko.pattern.ask
 import io.gearpump.cluster.AppMasterToMaster.{GetAppData, GetAppDataResult, SaveAppData}
 import io.gearpump.util.Constants
 import scala.concurrent.Future

--- a/streaming/src/main/scala/io/gearpump/streaming/task/ExpressTransport.scala
+++ b/streaming/src/main/scala/io/gearpump/streaming/task/ExpressTransport.scala
@@ -14,13 +14,13 @@
 
 package io.gearpump.streaming.task
 
-import akka.actor.{ActorRef, ExtendedActorSystem}
+import org.apache.pekko.actor.{ActorRef, ExtendedActorSystem}
 import io.gearpump.Message
 import io.gearpump.transport.{Express, HostPort}
 import io.gearpump.transport.netty.TaskMessage
-import io.gearpump.util.AkkaHelper
+import io.gearpump.util.PekkoHelper
 /**
- * ExpressTransport wire the networking function from default akka
+ * ExpressTransport wires the networking function from default Pekko
  * networking to customized implementation [[io.gearpump.transport.Express]].
  *
  * See [[io.gearpump.transport.Express]] for more information.
@@ -35,7 +35,7 @@ trait ExpressTransport {
   lazy val sourceId = TaskId.toLong(taskId)
 
   lazy val sessionRef: ActorRef = {
-    AkkaHelper.actorFor(system, s"/session#$sessionId")
+    PekkoHelper.actorFor(system, s"/session#$sessionId")
   }
 
   def transport(msg: AnyRef, remotes: TaskId*): Unit = {

--- a/streaming/src/main/scala/io/gearpump/streaming/task/Task.scala
+++ b/streaming/src/main/scala/io/gearpump/streaming/task/Task.scala
@@ -14,8 +14,8 @@
 
 package io.gearpump.streaming.task
 
-import akka.actor.{ActorRef, ActorSystem, Cancellable, Props}
-import akka.actor.Actor.Receive
+import org.apache.pekko.actor.{ActorRef, ActorSystem, Cancellable, Props}
+import org.apache.pekko.actor.Actor.Receive
 import io.gearpump.Message
 import io.gearpump.Time.MilliSeconds
 import io.gearpump.cluster.UserConfig
@@ -87,7 +87,7 @@ trait TaskContext {
   def schedule(initialDelay: FiniteDuration, interval: FiniteDuration)(f: => Unit): Cancellable
 
   /**
-   * akka.actor.ActorRefProvider.scheduleOnce
+   * org.apache.pekko.actor.ActorRefProvider.scheduleOnce
    *
    * @param initialDelay  the initial delay
    * @param f  the function to execute after initial delay

--- a/streaming/src/main/scala/io/gearpump/streaming/task/TaskActor.scala
+++ b/streaming/src/main/scala/io/gearpump/streaming/task/TaskActor.scala
@@ -14,7 +14,7 @@
 
 package io.gearpump.streaming.task
 
-import akka.actor._
+import org.apache.pekko.actor._
 import com.gs.collections.impl.map.mutable.primitive.IntShortHashMap
 import io.gearpump.Message
 import io.gearpump.Time.MilliSeconds
@@ -423,7 +423,7 @@ object TaskActor {
     // We store the session Id in the uid of ActorPath
     // ActorPath.hashCode is same as uid.
     private def getSessionId(actor: ActorRef): Int = {
-      // TODO: As method uid is protected in [akka] package. We
+      // TODO: As method uid is protected in the Pekko package, we
       // are using hashCode instead of uid.
       actor.hashCode()
     }

--- a/streaming/src/main/scala/io/gearpump/streaming/task/TaskContextData.scala
+++ b/streaming/src/main/scala/io/gearpump/streaming/task/TaskContextData.scala
@@ -14,7 +14,7 @@
 
 package io.gearpump.streaming.task
 
-import akka.actor.ActorRef
+import org.apache.pekko.actor.ActorRef
 import io.gearpump.streaming.LifeTime
 
 case class TaskContextData(

--- a/streaming/src/main/scala/io/gearpump/streaming/task/TaskWrapper.scala
+++ b/streaming/src/main/scala/io/gearpump/streaming/task/TaskWrapper.scala
@@ -14,8 +14,8 @@
 
 package io.gearpump.streaming.task
 
-import akka.actor.{ActorRef, ActorSystem, Cancellable, Props}
-import akka.actor.Actor._
+import org.apache.pekko.actor.{ActorRef, ActorSystem, Cancellable, Props}
+import org.apache.pekko.actor.Actor._
 import io.gearpump.Message
 import io.gearpump.Time.MilliSeconds
 import io.gearpump.cluster.UserConfig

--- a/streaming/src/main/scala/io/gearpump/streaming/util/ActorPathUtil.scala
+++ b/streaming/src/main/scala/io/gearpump/streaming/util/ActorPathUtil.scala
@@ -14,7 +14,7 @@
 
 package io.gearpump.streaming.util
 
-import akka.actor.{ActorPath, ActorRef}
+import org.apache.pekko.actor.{ActorPath, ActorRef}
 import io.gearpump.streaming.task.TaskId
 
 object ActorPathUtil {

--- a/streaming/src/test/scala/io/gearpump/streaming/MockUtil.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/MockUtil.scala
@@ -14,8 +14,8 @@
 
 package io.gearpump.streaming
 
-import akka.actor.{Actor, ActorSystem}
-import akka.testkit.TestActorRef
+import org.apache.pekko.actor.{Actor, ActorSystem}
+import org.apache.pekko.testkit.TestActorRef
 import io.gearpump.cluster.TestUtil
 import io.gearpump.streaming.task.{TaskContext, TaskId}
 import org.mockito.{ArgumentMatcher, Matchers, Mockito}

--- a/streaming/src/test/scala/io/gearpump/streaming/StreamingTestUtil.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/StreamingTestUtil.scala
@@ -14,8 +14,8 @@
 
 package io.gearpump.streaming
 
-import akka.actor.{ActorRef, Props}
-import akka.testkit.TestActorRef
+import org.apache.pekko.actor.{ActorRef, Props}
+import org.apache.pekko.testkit.TestActorRef
 import io.gearpump.cluster.{AppDescription, AppMasterContext, MiniCluster, UserConfig}
 import io.gearpump.cluster.AppMasterToMaster.RegisterAppMaster
 import io.gearpump.cluster.scheduler.Resource

--- a/streaming/src/test/scala/io/gearpump/streaming/appmaster/AppMasterSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/appmaster/AppMasterSpec.scala
@@ -13,8 +13,8 @@
  */
 package io.gearpump.streaming.appmaster
 
-import akka.actor.{ActorRef, ActorSystem, Props}
-import akka.testkit.{TestActorRef, TestProbe}
+import org.apache.pekko.actor.{ActorRef, ActorSystem, Props}
+import org.apache.pekko.testkit.{TestActorRef, TestProbe}
 import io.gearpump.cluster.{MasterHarness, TestUtil, UserConfig, _}
 import io.gearpump.cluster.AppMasterToMaster._
 import io.gearpump.cluster.AppMasterToWorker.LaunchExecutor

--- a/streaming/src/test/scala/io/gearpump/streaming/appmaster/ClockServiceSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/appmaster/ClockServiceSpec.scala
@@ -13,8 +13,8 @@
  */
 package io.gearpump.streaming.appmaster
 
-import akka.actor.{ActorSystem, Props}
-import akka.testkit.{ImplicitSender, TestKit, TestProbe}
+import org.apache.pekko.actor.{ActorSystem, Props}
+import org.apache.pekko.testkit.{ImplicitSender, TestKit, TestProbe}
 import io.gearpump.cluster.{TestUtil, UserConfig}
 import io.gearpump.streaming.{DAG, LifeTime, ProcessorDescription}
 import io.gearpump.streaming.appmaster.ClockService.{ChangeToNewDAG, ChangeToNewDAGSuccess, HealthChecker, ProcessorClock}

--- a/streaming/src/test/scala/io/gearpump/streaming/appmaster/DagManagerSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/appmaster/DagManagerSpec.scala
@@ -14,8 +14,8 @@
 
 package io.gearpump.streaming.appmaster
 
-import akka.actor.{ActorSystem, Props}
-import akka.testkit.TestProbe
+import org.apache.pekko.actor.{ActorSystem, Props}
+import org.apache.pekko.testkit.TestProbe
 import io.gearpump.cluster.{TestUtil, UserConfig}
 import io.gearpump.streaming._
 import io.gearpump.streaming.appmaster.DagManager.{DAGOperationFailed, DAGOperationSuccess, GetLatestDAG, GetTaskLaunchData, LatestDAG, NewDAGDeployed, ReplaceProcessor, TaskLaunchData, WatchChange}

--- a/streaming/src/test/scala/io/gearpump/streaming/appmaster/ExecutorManagerSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/appmaster/ExecutorManagerSpec.scala
@@ -14,8 +14,8 @@
 
 package io.gearpump.streaming.appmaster
 
-import akka.actor._
-import akka.testkit.TestProbe
+import org.apache.pekko.actor._
+import org.apache.pekko.testkit.TestProbe
 import com.typesafe.config.ConfigFactory
 import io.gearpump.TestProbeUtil
 import io.gearpump.cluster.{TestUtil, UserConfig, _}
@@ -80,14 +80,14 @@ class ExecutorManagerSpec extends FlatSpec with Matchers with BeforeAndAfterAll 
     import scala.concurrent.duration._
     val startExecutorSystem = master.receiveOne(5.seconds).asInstanceOf[StartExecutorSystems]
     assert(startExecutorSystem.resources == resourceRequest)
-    import startExecutorSystem.executorSystemConfig.{classPath, executorAkkaConfig, jar, jvmArguments, username => returnedUserName}
+    import startExecutorSystem.executorSystemConfig.{classPath, executorPekkoConfig, jar, jvmArguments, username => returnedUserName}
     assert(startExecutorSystem.resources == resourceRequest)
 
     assert(classPath.length == 0)
     assert(jvmArguments.length == 0)
     assert(jar == appJar)
     assert(returnedUserName == username)
-    assert(executorAkkaConfig.isEmpty)
+    assert(executorPekkoConfig.isEmpty)
 
     (master, executor, taskManager, executorManager)
   }

--- a/streaming/src/test/scala/io/gearpump/streaming/appmaster/HistoryMetricsServiceSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/appmaster/HistoryMetricsServiceSpec.scala
@@ -14,8 +14,8 @@
 
 package io.gearpump.streaming.appmaster
 
-import akka.actor.{ActorSystem, Props}
-import akka.testkit.TestProbe
+import org.apache.pekko.actor.{ActorSystem, Props}
+import org.apache.pekko.testkit.TestProbe
 import io.gearpump.cluster.ClientToMaster.QueryHistoryMetrics
 import io.gearpump.cluster.MasterToClient.HistoryMetrics
 import io.gearpump.cluster.TestUtil

--- a/streaming/src/test/scala/io/gearpump/streaming/appmaster/JarSchedulerSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/appmaster/JarSchedulerSpec.scala
@@ -13,7 +13,7 @@
  */
 package io.gearpump.streaming.appmaster
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import io.gearpump.cluster.{AppJar, TestUtil}
 import io.gearpump.cluster.scheduler.{Resource, ResourceRequest}
 import io.gearpump.cluster.worker.WorkerId

--- a/streaming/src/test/scala/io/gearpump/streaming/appmaster/TaskManagerSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/appmaster/TaskManagerSpec.scala
@@ -14,8 +14,8 @@
 
 package io.gearpump.streaming.appmaster
 
-import akka.actor.{ActorRef, ActorSystem, Props}
-import akka.testkit.TestProbe
+import org.apache.pekko.actor.{ActorRef, ActorSystem, Props}
+import org.apache.pekko.testkit.TestProbe
 import io.gearpump.Time.MilliSeconds
 import io.gearpump.cluster.{AppJar, TestUtil, UserConfig}
 import io.gearpump.cluster.MasterToAppMaster.ReplayFromTimestampWindowTrailingEdge

--- a/streaming/src/test/scala/io/gearpump/streaming/dsl/plan/OpSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/dsl/plan/OpSpec.scala
@@ -13,7 +13,7 @@
  */
 package io.gearpump.streaming.dsl.plan
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import io.gearpump.Message
 import io.gearpump.cluster.{TestUtil, UserConfig}
 import io.gearpump.streaming.Processor

--- a/streaming/src/test/scala/io/gearpump/streaming/dsl/plan/PlannerSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/dsl/plan/PlannerSpec.scala
@@ -14,7 +14,7 @@
 
 package io.gearpump.streaming.dsl.plan
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import io.gearpump.Message
 import io.gearpump.cluster.{TestUtil, UserConfig}
 import io.gearpump.streaming.MockUtil

--- a/streaming/src/test/scala/io/gearpump/streaming/dsl/scalaapi/StreamAppSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/dsl/scalaapi/StreamAppSpec.scala
@@ -14,7 +14,7 @@
 
 package io.gearpump.streaming.dsl.scalaapi
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import io.gearpump.cluster.TestUtil
 import io.gearpump.cluster.client.ClientContext
 import io.gearpump.streaming.{ProcessorDescription, StreamApplication}

--- a/streaming/src/test/scala/io/gearpump/streaming/dsl/scalaapi/StreamSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/dsl/scalaapi/StreamSpec.scala
@@ -14,7 +14,7 @@
 
 package io.gearpump.streaming.dsl.scalaapi
 
-import akka.actor._
+import org.apache.pekko.actor._
 import io.gearpump.Message
 import io.gearpump.cluster.{TestUtil, UserConfig}
 import io.gearpump.cluster.client.ClientContext

--- a/streaming/src/test/scala/io/gearpump/streaming/executor/ExecutorSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/executor/ExecutorSpec.scala
@@ -13,8 +13,8 @@
  */
 package io.gearpump.streaming.executor
 
-import akka.actor.{ActorRefFactory, ActorSystem, Props}
-import akka.testkit.TestProbe
+import org.apache.pekko.actor.{ActorRefFactory, ActorSystem, Props}
+import org.apache.pekko.testkit.TestProbe
 import io.gearpump.cluster.{ExecutorContext, TestUtil, UserConfig}
 import io.gearpump.cluster.appmaster.WorkerInfo
 import io.gearpump.cluster.scheduler.Resource

--- a/streaming/src/test/scala/io/gearpump/streaming/executor/TaskLauncherSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/executor/TaskLauncherSpec.scala
@@ -13,8 +13,8 @@
  */
 package io.gearpump.streaming.executor
 
-import akka.actor.{Actor, ActorSystem}
-import akka.testkit.TestProbe
+import org.apache.pekko.actor.{Actor, ActorSystem}
+import org.apache.pekko.testkit.TestProbe
 import io.gearpump.cluster.{TestUtil, UserConfig}
 import io.gearpump.serializer.SerializationFramework
 import io.gearpump.streaming.ProcessorDescription

--- a/streaming/src/test/scala/io/gearpump/streaming/task/TaskActorSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/task/TaskActorSpec.scala
@@ -13,8 +13,8 @@
  */
 package io.gearpump.streaming.task
 
-import akka.actor.{ExtendedActorSystem, Props}
-import akka.testkit._
+import org.apache.pekko.actor.{ExtendedActorSystem, Props}
+import org.apache.pekko.testkit._
 import com.typesafe.config.{Config, ConfigFactory}
 import io.gearpump.Message
 import io.gearpump.cluster.{MasterHarness, TestUtil}
@@ -31,8 +31,8 @@ import org.scalatest.{BeforeAndAfterEach, Matchers, WordSpec}
 class TaskActorSpec extends WordSpec with Matchers with BeforeAndAfterEach with MasterHarness {
   protected override def config: Config = {
     ConfigFactory.parseString(
-      """ akka.loggers = ["akka.testkit.TestEventListener"]
-        | akka.test.filter-leeway = 20000
+      """ pekko.loggers = ["org.apache.pekko.testkit.TestEventListener"]
+        | pekko.test.filter-leeway = 20000
       """.stripMargin).
       withFallback(TestUtil.DEFAULT_CONFIG)
   }


### PR DESCRIPTION
## Summary
- replace Akka usage with Apache Pekko while keeping thin compatibility shims for legacy helper and reporter entry points
- upgrade the build to sbt 1.9.9 and Scala 2.13.18 so the project compiles on JDK 17
- fix the main-source and test-compile fallout from the migration, including scheduler APIs, collection updates, Base64 changes, Kryo wiring, and warning cleanup
- remove Travis CI and add a GitHub Actions workflow that runs `sbt -Dsbt.log.noformat=true clean compile test:compile`

## Why
The repository was still tied to an older Akka, Scala 2.12, sbt, and Travis toolchain that no longer matches the current JDK 17 target. This change brings the dependency stack, compiler settings, and CI path forward together so the branch is buildable again on modern infrastructure.

## Impact
- developers can build and iterate on the repo with JDK 17
- CI no longer depends on Travis
- the branch now has a passing GitHub Actions-friendly compile and test-compile path

## Validation
- `git diff --check`
- `sbt -Dsbt.log.noformat=true clean compile test:compile`
- `sbt -Dsbt.log.noformat=true clean test:compile`

## Known Gaps
- `sbt test` is not fully green yet due legacy runtime/test issues exposed by the migration
- `scalastyle` still reports import-order and related style violations in migrated sources
