### PR TITLE
Use GITHUB_TOKEN for Scala Steward

### DIFF
--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -13,15 +13,8 @@ jobs:
   update-dependencies:
     runs-on: ubuntu-24.04
     timeout-minutes: 45
-    env:
-      SCALA_STEWARD_GITHUB_TOKEN: ${{ secrets.SCALA_STEWARD_GITHUB_TOKEN }}
     steps:
-      - name: Skip when Scala Steward token is not configured
-        if: ${{ env.SCALA_STEWARD_GITHUB_TOKEN == '' }}
-        run: echo "SCALA_STEWARD_GITHUB_TOKEN is not configured; skipping dependency updates."
-
       - name: Run Scala Steward
-        if: ${{ env.SCALA_STEWARD_GITHUB_TOKEN != '' }}
         uses: scala-steward-org/scala-steward-action@v2
         with:
-          github-token: ${{ env.SCALA_STEWARD_GITHUB_TOKEN }}
+          github-token: ${{ github.token }}


### PR DESCRIPTION
## Summary
- switch the Scala Steward workflow to use the built-in GITHUB_TOKEN
- remove the custom SCALA_STEWARD_GITHUB_TOKEN gating logic

## Testing
- git diff --check -- .github/workflows/scala-steward.yml

## Notes
- PRs opened by Scala Steward with GITHUB_TOKEN may not trigger follow-on workflows automatically