### PR TITLE
ci: add weekly schedule and pin sbt-dependency-submission to v3.2.1

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+  schedule:
+    - cron: "0 7 * * 1"
   workflow_dispatch:
 
 permissions:
@@ -30,4 +32,4 @@ jobs:
         uses: sbt/setup-sbt@v1
 
       - name: Submit sbt dependency graph
-        uses: scalacenter/sbt-dependency-submission@v3
+        uses: scalacenter/sbt-dependency-submission@v3.2.1


### PR DESCRIPTION
### Motivation
- Ensure the sbt dependency submission runs on a regular weekly cadence in addition to `master` pushes and manual runs, and pin the action for stability.

### Description
- Updated `.github/workflows/dependency-graph.yml` to add a weekly `schedule` (`cron: "0 7 * * 1"`) and pin the submission step to `scalacenter/sbt-dependency-submission@v3.2.1`.

### Testing
- Verified the workflow YAML parses successfully with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/dependency-graph.yml"); puts "YAML OK"'`, which returned "YAML OK".

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05447c52908330a0a0412358e5a920)