### PR TITLE
Remove sbteclipse plugin

### DIFF
--- a/docs/contents/dev/dev-ide-setup.md
+++ b/docs/contents/dev/dev-ide-setup.md
@@ -16,14 +16,4 @@
 
 ### Eclipse IDE Setup
 
-I will show how to do this in eclipse LUNA.
-
-There is a sbt-eclipse plugin to generate eclipse project files, but seems there are some bugs, and some manual fix is still required. Here is the steps that works for me:
-
-1. Install latest version eclipse luna
-2. Install latest scala-IDE http://scala-ide.org/download/current.html   I use update site address: http://download.scala-ide.org/sdk/lithium/e44/scala211/stable/site
-3. Open a sbt shell under the root folder of Gearpump. enter "eclipse", then we get all eclipse project file generated.
-4. Use eclipse import wizard. File->Import->Existing projects into Workspace, make sure to tick the option "Search for nested projects"
-5. Then it may starts to complain about encoding error, like "IO error while decoding". You need to fix the eclipse default text encoding by changing configuration at "Window->Preference->General->Workspace->Text file encoding" to UTF-8.
-6. Then the project gearpump-external-kafka may still cannot compile. The reason is that there is some dependencies missing in generated .classpath file by sbt-eclipse. We need to do some manual fix. Right click on project icon of gearpump-external-kafka in eclipse, then choose menu "Build Path->Configure Build Path". A window will popup. Under the tab "projects", click add, choose "gearpump-streaming"
-7. All set. Now the project should compile OK in eclipse.
+Eclipse project generation through sbteclipse is no longer supported by the Gearpump build. Use the Intellij setup above for sbt-based development.

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,8 +14,6 @@ addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")
 
-addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "5.2.4")
-
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.3")
 
 addSbtPlugin("org.scalastyle" % "scalastyle-sbt-plugin" % "1.0.0")


### PR DESCRIPTION
### Motivation
- The sbteclipse SBT plugin is no longer used by the project and Eclipse project generation via sbteclipse is not supported, so the build should stop declaring the plugin and the docs should direct developers to the recommended IDE workflow.

### Description
- Removed the `addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "5.2.4")` entry from `project/plugins.sbt`.
- Replaced the detailed Eclipse setup steps in `docs/contents/dev/dev-ide-setup.md` with a short note that sbteclipse-based Eclipse project generation is no longer supported and to use the IntelliJ setup instead.

### Testing
- Ran `rg -n "sbteclipse-plugin|sbt-eclipse" . -g '!target' -g '!**/.git/**'` which returned no remaining references to sbteclipse, indicating the removal is complete and consistent.
- Ran `git diff --check` which reported no whitespace or patch errors.
- Attempted `sbt --version` to validate SBT locally but `sbt` is not installed in the environment, so the SBT binary could not be executed for validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a054a8f8f608330a29bf45a48a5aa7e)