### PR TITLE
docs: remove incubating project references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,9 +47,8 @@ This section explains how to make a contribution.
 
 ## Report a bug
 
-To report a bug you should [open an issue](https://issues.apache.org/jira/browse/GEARPUMP) in our issue tracker that
-summarizes the bug.  Set the form field "Issue type" to "Bug".  If you have not used the issue tracker before you will
-need to register an account (free), log in, and then click on the red "Create Issue" button in the top navigation bar.
+To report a bug you should [open an issue](https://github.com/gearpump/gearpump/issues) in our issue tracker that
+summarizes the bug.
 
 In order to help us understand and fix the bug it would be great if you could provide us with:
 
@@ -70,10 +69,8 @@ with.
 
 ## Request a new feature
 
-To request a new feature you should [open an issue](https://issues.apache.org/jira/browse/GEARPUMP) in our issue tracker
-and summarize the desired functionality.  Set the form field "Issue type" to "New feature".  If you have not used the
-issue tracker before you will need to register an account (free), log in, and then click on the red "Create Issue"
-button in the top navigation bar.
+To request a new feature you should [open an issue](https://github.com/gearpump/gearpump/issues) in our issue tracker
+and summarize the desired functionality.
 
 
 <a name="contribute-code"></a>
@@ -83,7 +80,7 @@ Before you set out to contribute code we recommend that you familiarize yourself
 
 _If you are interested in contributing code to Gearpump but do not know where to begin:_
 In this case you should
-[browse our issue tracker for open issues and tasks](https://issues.apache.org/jira/browse/GEARPUMP/?selectedTab=com.atlassian.jira.jira-projects-plugin:issues-panel).
+[browse our issue tracker for open issues and tasks](https://github.com/gearpump/gearpump/issues).
 
 Contributions to the Gearpump codebase should be sent as GitHub pull requests.  See section [Create a pull request](#create-pr) below
 for details.  If there is any problem with the pull request we can iterate on it using the commenting features of
@@ -93,7 +90,7 @@ GitHub.
 * For _larger code contributions_, please use the following process. The idea behind this process is to prevent any
   wasted work and catch design issues early on.
 
-    1. [Open an issue](https://issues.apache.org/jira/browse/GEARPUMP) on our issue tracker if a similar issue does not
+    1. [Open an issue](https://github.com/gearpump/gearpump/issues) on our issue tracker if a similar issue does not
        exist already.  If a similar issue does exist, then you may consider participating in the work on the existing
        issue.
     2. Comment on the issue with your plan for implementing the issue.  Explain what pieces of the codebase you are
@@ -313,23 +310,13 @@ _This section applies to committers only._
 It's committer's duty to review pull requests from contributors. 
 
 Any PR ready to merge shall have at least one +1(s) and no -1(s) from other than the one who authored this PR. And any merge shall wait another 24 hours after the first +1 received to wait for potential comments.
-Only committer has the right to perform PR merge to Apache upstream.
+Only maintainers have the right to merge pull requests into the upstream repository.
 
 
 <a name="merge-pull-request"></a>
 ## Merge pull request
 
-All merges should be done using the `dev-tools/merge_gearpump_pr.py` script. To use this script, you will need to add a git remote called "apache" at `https://git-wip-us.apache.org/repos/asf/incubator-gearpump.git`, as well as one called "apache-github" at `git://github.com/apache/incubator-gearpump`. For the "apache" repo, you can authenticate using your ASF username and password. 
-
-The script is fairly self explanatory and walks you through following steps and options interactively.
-
-1. squashes the pull request's changes into one commit and merge into master
-2. push to "apache" repo (automitically close GitHub pull request)
-3. optionally cherry-pick the commit on to another branch
-5. clean up and resolve the related JIRA issue
-
-If you want to amend a commit before merging – which should be used for trivial touch-ups – then simply let the script wait at the point where it asks you if you want to push to Apache. Then, in a separate window, modify the code and push a commit. Run "git rebase -i HEAD~2" and "squash" your new commit. Edit the commit message just after to remove your commit message. You can verify the result is one change with "git log". Then resume the script in the other window.
-Also, please remember to set Assignee on JIRAs where applicable when they are resolved. The script can't do this automatically.
+Use the normal GitHub pull request merge flow for this repository. Prefer squash or rebase merges so the history stays clean, and make sure any linked GitHub issue is updated or closed when the pull request lands.
 
 <a name="release"></a>
 ## How to make a release

--- a/DISCLAIMER
+++ b/DISCLAIMER
@@ -1,8 +1,0 @@
-Apache Gearpump (Incubating) is an effort undergoing incubation at The Apache
-Software Foundation (ASF), sponsored by the Apache Incubator PMC. Incubation is
-required of all newly accepted projects until a further review indicates that
-the infrastructure, communications, and decision making process have stabilized
-in a manner consistent with other successful ASF projects. While incubation
-status is not necessarily a reflection of the completeness or stability of the
-code, it does indicate that the project has yet to be fully endorsed by the ASF.
-

--- a/KEYS
+++ b/KEYS
@@ -26,7 +26,7 @@ Developers:
   Releases will be signed using one of these keys in this file. This file will
   be available with the distributed Apache Gearpump releases at:
 
-      https://dist.apache.org/repos/dist/release/incubator/gearpump/KEYS
+      https://dist.apache.org/repos/dist/release/gearpump/KEYS
 
 ********************************************************************************
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ For steps to reproduce the performance test, please check [Performance benchmark
 * How to [Submit your first application](http://gearpump.apache.org/releases/latest/introduction/submit-your-1st-application/index.html)
 * Explore the [Maven dependencies](http://gearpump.apache.org/downloads.html#maven-dependencies)
 * Explore the [Document site](http://gearpump.apache.org)
-* Explore the [User Mailing List](http://mail-archives.apache.org/mod_mbox/incubator-gearpump-user/)
 * Report an [issue](https://github.com/gearpump/gearpump/issues)
 
 ## How to Build

--- a/ReleaseProcess.md
+++ b/ReleaseProcess.md
@@ -24,16 +24,16 @@ Step1: Pre-release
 5. Run dev-tools/create_apache_source_release.sh $GPG_KEY $GPG_PASSPHRASE
    This will provide the source artifacts that need to be uploaded in step 6. below
 6. Upload to svn 
-   Run 'svn checkout https://dist.apache.org/repos/dist/dev/incubator/gearpump'
-   Run 'svn mkdir RELEASE_VERSION-incubating'
-   Run 'svn mkdir RELEASE_VERSION-incubating/RC[0-9]'
-   cp the gearpump* files generated from 5. to RELEASE_VERSION-incubating/RC[0-9]
-   Run 'svn add RELEASE_VERSION-incubating/RC[0-9]/gearpump*'
+   Run 'svn checkout https://dist.apache.org/repos/dist/dev/gearpump'
+   Run 'svn mkdir RELEASE_VERSION'
+   Run 'svn mkdir RELEASE_VERSION/RC[0-9]'
+   cp the gearpump* files generated from 5. to RELEASE_VERSION/RC[0-9]
+   Run 'svn add RELEASE_VERSION/RC[0-9]/gearpump*'
    Run 'svn commit'
 7. Run dev-tools/create_apache_bin_release.sh $GPG_KEY $GPG_PASSPHRASE
    This will provide the binary artifacts that need to be uploaded in step 8. below
-8. svn add gearpump-* to https://dist.apache.org/repos/dist/dev/incubator/gearpump/RELEASE_VERSION-incubating/RC[0-9]
-9. svn add KEYS to https://dist.apache.org/repos/dist/dev/incubator/gearpump/
+8. svn add gearpump-* to https://dist.apache.org/repos/dist/dev/gearpump/RELEASE_VERSION/RC[0-9]
+9. svn add KEYS to https://dist.apache.org/repos/dist/dev/gearpump/
    This only needs to be done if we are adding new committers for this release
 10.Create a tag for the RC release by ```git tag RELEASE_VERION-RC[0-9]```
 11.Push this tag upstream and merge
@@ -41,7 +41,7 @@ Step1: Pre-release
 Step2: Release
 ==================
 1. Create a tag by ```git tag RELEASE_VERSION```
-2. ```git remote add upstream https://github.com/apache/incubator-gearpump```
+2. ```git remote add upstream https://github.com/gearpump/gearpump.git```
 3. ```git push upstream RELEASE_VERSION```
 
 Step3: Post-Release
@@ -54,4 +54,3 @@ Step3: Post-Release
    where NEXT_SNAPSHOT_VERSION must end with "-SNAPSHOT". For example, 0.2.3-SNAPSHOT is a good snapshot version, 0.2.3 is NOT
 2. Create JIRA for new release
 3. Make PR with new release
-

--- a/ReleaseProcess.md
+++ b/ReleaseProcess.md
@@ -11,38 +11,34 @@ Step0: Function verification Checklist
 
 Step1: Pre-release
 ===================
-1. Review release notes in JIRA
+1. Review release notes in the issue tracker
 2. Update version in docs/version.yml
 3. Bump the gearpump version in version.sbt 
    ```scala
    version in ThisBuild := "RELEASE_VERSION"
    ```
-4. Run dev-tools/dependencies.sh
-   This will generate a LICENSE.dependencies file that lists all dependencies including Apache.
-   Make sure this agrees with the LICENSE and license/* files.
-   Eventually we'll have something like a verify option so the inspection isn't manual.
-5. Run dev-tools/create_apache_source_release.sh $GPG_KEY $GPG_PASSPHRASE
-   This will provide the source artifacts that need to be uploaded in step 6. below
-6. Upload to svn 
-   Run 'svn checkout https://dist.apache.org/repos/dist/dev/gearpump'
-   Run 'svn mkdir RELEASE_VERSION'
-   Run 'svn mkdir RELEASE_VERSION/RC[0-9]'
-   cp the gearpump* files generated from 5. to RELEASE_VERSION/RC[0-9]
-   Run 'svn add RELEASE_VERSION/RC[0-9]/gearpump*'
-   Run 'svn commit'
-7. Run dev-tools/create_apache_bin_release.sh $GPG_KEY $GPG_PASSPHRASE
-   This will provide the binary artifacts that need to be uploaded in step 8. below
-8. svn add gearpump-* to https://dist.apache.org/repos/dist/dev/gearpump/RELEASE_VERSION/RC[0-9]
-9. svn add KEYS to https://dist.apache.org/repos/dist/dev/gearpump/
-   This only needs to be done if we are adding new committers for this release
-10.Create a tag for the RC release by ```git tag RELEASE_VERION-RC[0-9]```
-11.Push this tag upstream and merge
+4. Run the license report tasks:
+   ```bash
+   sbt dumpLicenseReport dependencyLicenseInfo
+   ```
+   Make sure the generated dependency/license reports agree with the LICENSE and license/* files.
+5. Build the release artifacts:
+   ```bash
+   sbt clean +assembly +packArchiveZip
+   ```
+6. Sign the release artifacts and generate checksums for the files you plan to publish.
+7. Upload the signed source/binary artifacts to the project's current release channel.
+   Do not upload release artifacts to Apache dist SVN.
+8. Update KEYS if new signing keys are being used for the release, and publish it alongside the signed artifacts.
+9. Create a tag for the RC release by ```git tag RELEASE_VERSION-RC[0-9]```
+10. Push this tag upstream and announce the release candidate for validation.
 
 Step2: Release
 ==================
 1. Create a tag by ```git tag RELEASE_VERSION```
 2. ```git remote add upstream https://github.com/gearpump/gearpump.git```
 3. ```git push upstream RELEASE_VERSION```
+4. Publish the final release artifacts in the project's current release channel.
 
 Step3: Post-Release
 ==================
@@ -52,5 +48,5 @@ Step3: Post-Release
    version in ThisBuild := "NEXT_SNAPSHOT_VERSION"
    ```
    where NEXT_SNAPSHOT_VERSION must end with "-SNAPSHOT". For example, 0.2.3-SNAPSHOT is a good snapshot version, 0.2.3 is NOT
-2. Create JIRA for new release
+2. Create a tracking issue for the next release
 3. Make PR with new release

--- a/docs/contents/deployment/get-gearpump-distribution.md
+++ b/docs/contents/deployment/get-gearpump-distribution.md
@@ -5,7 +5,7 @@ You can either download pre-build release package or choose to build from source
 
 If you choose to use pre-build package, then you don't need to build from source code. The release package can be downloaded from:
 
-##### [Download page](http://gearpump.incubator.apache.org/downloads.html)
+##### [Download page](http://gearpump.apache.org/downloads.html)
 
 #### Build from Source code
 
@@ -14,7 +14,7 @@ If you choose to build the package from source code yourself, you can follow the
 1). Clone the Gearpump repository
 
 	:::bash
-  	git clone https://github.com/apache/incubator-gearpump.git
+  git clone https://github.com/gearpump/gearpump.git
   cd gearpump
 
 

--- a/docs/contents/dev/dev-non-streaming-example.md
+++ b/docs/contents/dev/dev-non-streaming-example.md
@@ -1,10 +1,10 @@
-We'll use [Distributed Shell](https://github.com/apache/incubator-gearpump/blob/master/examples/distributedshell) as an example to illustrate how to do that.
+We'll use [Distributed Shell](https://github.com/gearpump/gearpump/tree/master/examples/distributedshell) as an example to illustrate how to do that.
 
 What Distributed Shell do is that user send a shell command to the cluster and the command will the executed on each node, then the result will be return to user.
 
 ### Maven/Sbt Settings
 
-Repository and library dependencies can be found at [Maven Setting](http://gearpump.incubator.apache.org/downloads.html#maven-dependencies)
+Repository and library dependencies can be found at [Maven Setting](http://gearpump.apache.org/downloads.html#maven-dependencies)
 
 ### Define Executor Class
 

--- a/docs/contents/dev/dev-write-1st-app.md
+++ b/docs/contents/dev/dev-write-1st-app.md
@@ -1,6 +1,6 @@
 ## Write your first Gearpump Application
 
-We'll use the classical [wordcount](https://github.com/apache/incubator-gearpump/tree/master/examples/streaming/wordcount/src/main/scala/org/apache/gearpump/streaming/examples/wordcount) example to illustrate how to write Gearpump applications.
+We'll use the classical [wordcount](https://github.com/gearpump/gearpump/tree/master/examples/streaming/wordcount/src/main/scala/io/gearpump/streaming/examples/wordcount) example to illustrate how to write Gearpump applications.
 
 	:::scala     
 	/** WordCount with the low-level Processor graph API */
@@ -36,6 +36,5 @@ You can get your preferred IDE ready for Gearpump by following [this guide](dev-
 ### Submit application
 
 Finally, you need to package everything into a uber jar with [proper dependencies](http://gearpump.apache.org/downloads.html#maven-dependencies) and submit it to a Gearpump cluster. Please check out the [application submission tool](../introduction/commandline).
-
 
 

--- a/docs/contents/internals/gearpump-internals.md
+++ b/docs/contents/internals/gearpump-internals.md
@@ -195,13 +195,12 @@ Figure: Dynamic Graph, Attach, Replace, and Remove
 
 ## At least once message delivery and Kafka
 
-The Kafka source example project and tutorials can be found at:
-- [Kafka connector example project](https://github.com/apache/incubator-gearpump/tree/master/examples/streaming/kafka)
+The Kafka source tutorial can be found at:
 - [Connect with Kafka source](../dev/dev-connectors)
 
 In this doc, we will talk about how the at least once message delivery works.
 
-We will use the WordCount example of [source tree](https://github.com/apache/incubator-gearpump/tree/master/examples/streaming/kafka)  to illustrate.
+We will use the Kafka WordCount DAG below to illustrate.
 
 ### How the kafka WordCount DAG looks like:
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,6 +1,6 @@
-site_name: Apache Gearpump(incubating)
+site_name: Gearpump
 
-repo_url: 'https://github.com/apache/incubator-gearpump'
+repo_url: 'https://github.com/gearpump/gearpump'
 
 edit_uri: 'edit/master/docs/contents'
 

--- a/services/dashboard/views/landing/header.js
+++ b/services/dashboard/views/landing/header.js
@@ -32,7 +32,7 @@ angular.module('dashboard')
           {text: 'Sign Out', href: conf.loginUrl, icon: 'glyphicon glyphicon-off'},
           {isDivider: true},
           {text: 'Documents', href: '//gearpump.apache.org', icon: 'fa fa-book'},
-          {text: 'GitHub', href: '//github.com/apache/incubator-gearpump', icon: 'fa fa-github'}
+          {text: 'GitHub', href: '//github.com/gearpump/gearpump', icon: 'fa fa-github'}
         ];
 
         $scope.version = 'beta';


### PR DESCRIPTION
## Summary
- remove the standalone incubating disclaimer file
- update docs and metadata that still pointed at the old incubator repo and URLs
- rewrite contributor guidance away from Apache JIRA and ASF-specific merge instructions

## Testing
- git diff --check
- rg -n "apache/incubator-gearpump|incubator-gearpump|gearpump\.incubator\.apache\.org|\(incubating\)|RELEASE_VERSION-incubating|dist/dev/incubator/gearpump|dist/release/incubator/gearpump|issues\.apache\.org/jira|git-wip-us\.apache\.org" -S README.md CONTRIBUTING.md ReleaseProcess.md KEYS docs services/dashboard/views