### PR TITLE
feat(beam): support windowing and grouped combines

### DIFF
--- a/experiments/beam/README.md
+++ b/experiments/beam/README.md
@@ -5,17 +5,20 @@ graph API.
 
 Current scope:
 
-- `Create` and other `Read.Bounded` sources
-- `ParDo`
+- `Create`, `Impulse`, and other `Read.Bounded` sources
+- `ParDo`, including multi-output `ParDo` without side inputs
 - `Flatten.pCollections()`
-- `GroupByKey` in the default global window
+- `Window.into(...)` for non-merging windows
+- `GroupByKey` in non-merging windows with a single final pane
+- `Combine.GroupedValues` and common keyed combines such as `Sum.integersPerKey()`
 
 Current limitations:
 
 - No side inputs
-- No custom window assignment or merging windows
+- No merging windows
 - No unbounded sources
 - No Beam state/timers support
+- No custom trigger/pane semantics beyond one final emission at watermark max
 
 The implementation intentionally keeps the first supported transform set small and routes Beam
 execution through Gearpump's low-level runtime instead of the older DSL-based runner design.

--- a/experiments/beam/src/main/java/org/apache/beam/runners/gearpump/runtime/BeamAssignWindowsSpec.java
+++ b/experiments/beam/src/main/java/org/apache/beam/runners/gearpump/runtime/BeamAssignWindowsSpec.java
@@ -18,25 +18,27 @@
 package org.apache.beam.runners.gearpump.runtime;
 
 import java.io.Serializable;
-import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.transforms.windowing.WindowFn;
+import org.apache.beam.sdk.values.WindowingStrategy;
 
-/** Serializable runtime specification for the low-level GroupByKey task. */
-public class BeamGroupByKeySpec<K> implements Serializable {
+/** Serializable runtime specification for Beam window assignment. */
+public class BeamAssignWindowsSpec<T> implements Serializable {
 
-  private final Coder<K> keyCoder;
-  private final Coder<? extends BoundedWindow> windowCoder;
+  private final WindowFn<T, ? extends BoundedWindow> windowFn;
+  private final WindowingStrategy<?, ?> windowingStrategy;
 
-  public BeamGroupByKeySpec(Coder<K> keyCoder, Coder<? extends BoundedWindow> windowCoder) {
-    this.keyCoder = keyCoder;
-    this.windowCoder = windowCoder;
+  public BeamAssignWindowsSpec(
+      WindowFn<T, ? extends BoundedWindow> windowFn, WindowingStrategy<?, ?> windowingStrategy) {
+    this.windowFn = windowFn;
+    this.windowingStrategy = windowingStrategy;
   }
 
-  public Coder<K> getKeyCoder() {
-    return keyCoder;
+  public WindowFn<T, ? extends BoundedWindow> getWindowFn() {
+    return windowFn;
   }
 
-  public Coder<? extends BoundedWindow> getWindowCoder() {
-    return windowCoder;
+  public WindowingStrategy<?, ?> getWindowingStrategy() {
+    return windowingStrategy;
   }
 }

--- a/experiments/beam/src/main/java/org/apache/beam/runners/gearpump/runtime/BeamAssignWindowsTask.java
+++ b/experiments/beam/src/main/java/org/apache/beam/runners/gearpump/runtime/BeamAssignWindowsTask.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.gearpump.runtime;
+
+import io.gearpump.DefaultMessage;
+import io.gearpump.Message;
+import io.gearpump.cluster.UserConfig;
+import io.gearpump.streaming.task.Task;
+import io.gearpump.streaming.task.TaskContext;
+import java.time.Instant;
+import java.util.Collection;
+import org.apache.beam.runners.gearpump.translators.utils.TranslatorUtils;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.transforms.windowing.WindowFn;
+import org.apache.beam.sdk.values.WindowedValue;
+import org.apache.beam.sdk.values.WindowedValues;
+
+/** Applies Beam window assignment to incoming {@link WindowedValue} elements. */
+@SuppressWarnings("unchecked")
+public class BeamAssignWindowsTask<T> extends Task {
+
+  public static final String ASSIGN_WINDOWS_SPEC = "beam.gearpump.assign-windows-spec";
+
+  private final TaskContext taskContext;
+  private final BeamAssignWindowsSpec<T> spec;
+
+  public BeamAssignWindowsTask(TaskContext taskContext, UserConfig userConfig) {
+    super(taskContext, userConfig);
+    this.taskContext = taskContext;
+    this.spec =
+        BeamUserConfig.getValue(
+            userConfig, ASSIGN_WINDOWS_SPEC, taskContext.system());
+  }
+
+  @Override
+  public void onNext(Message message) {
+    WindowedValue<T> windowedValue = (WindowedValue<T>) message.value();
+    for (WindowedValue<T> explodedWindow : windowedValue.explodeWindows()) {
+      emitAssignedWindows(explodedWindow);
+    }
+  }
+
+  @Override
+  public void onWatermarkProgress(Instant watermark) {
+    taskContext.updateWatermark(watermark);
+  }
+
+  private void emitAssignedWindows(WindowedValue<T> windowedValue) {
+    try {
+      WindowFn<T, BoundedWindow> windowFn = (WindowFn<T, BoundedWindow>) spec.getWindowFn();
+      Collection<BoundedWindow> assignedWindows =
+          windowFn.assignWindows(
+              windowFn.new AssignContext() {
+                @Override
+                public T element() {
+                  return windowedValue.getValue();
+                }
+
+                @Override
+                public org.joda.time.Instant timestamp() {
+                  return windowedValue.getTimestamp();
+                }
+
+                @Override
+                public BoundedWindow window() {
+                  return (BoundedWindow) windowedValue.getWindows().iterator().next();
+                }
+              });
+      WindowedValue<T> assignedValue =
+          WindowedValues.of(
+              windowedValue.getValue(),
+              windowedValue.getTimestamp(),
+              assignedWindows,
+              windowedValue.getPaneInfo(),
+              windowedValue.getRecordId(),
+              windowedValue.getRecordOffset(),
+              windowedValue.causedByDrain());
+      taskContext.output(
+          new DefaultMessage(
+              assignedValue,
+              TranslatorUtils.windowedValueTimestamp(assignedValue)));
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to assign Beam windows", e);
+    }
+  }
+}

--- a/experiments/beam/src/main/java/org/apache/beam/runners/gearpump/runtime/BeamAssignWindowsTask.java
+++ b/experiments/beam/src/main/java/org/apache/beam/runners/gearpump/runtime/BeamAssignWindowsTask.java
@@ -24,6 +24,7 @@ import io.gearpump.streaming.task.Task;
 import io.gearpump.streaming.task.TaskContext;
 import java.time.Instant;
 import java.util.Collection;
+import java.util.LinkedHashSet;
 import org.apache.beam.runners.gearpump.translators.utils.TranslatorUtils;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.WindowFn;
@@ -50,9 +51,7 @@ public class BeamAssignWindowsTask<T> extends Task {
   @Override
   public void onNext(Message message) {
     WindowedValue<T> windowedValue = (WindowedValue<T>) message.value();
-    for (WindowedValue<T> explodedWindow : windowedValue.explodeWindows()) {
-      emitAssignedWindows(explodedWindow);
-    }
+    emitAssignedWindows(windowedValue);
   }
 
   @Override
@@ -62,25 +61,10 @@ public class BeamAssignWindowsTask<T> extends Task {
 
   private void emitAssignedWindows(WindowedValue<T> windowedValue) {
     try {
-      WindowFn<T, BoundedWindow> windowFn = (WindowFn<T, BoundedWindow>) spec.getWindowFn();
-      Collection<BoundedWindow> assignedWindows =
-          windowFn.assignWindows(
-              windowFn.new AssignContext() {
-                @Override
-                public T element() {
-                  return windowedValue.getValue();
-                }
-
-                @Override
-                public org.joda.time.Instant timestamp() {
-                  return windowedValue.getTimestamp();
-                }
-
-                @Override
-                public BoundedWindow window() {
-                  return (BoundedWindow) windowedValue.getWindows().iterator().next();
-                }
-              });
+      Collection<BoundedWindow> assignedWindows = new LinkedHashSet<>();
+      for (WindowedValue<T> explodedWindow : windowedValue.explodeWindows()) {
+        assignedWindows.addAll(assignWindowsFor(explodedWindow));
+      }
       WindowedValue<T> assignedValue =
           WindowedValues.of(
               windowedValue.getValue(),
@@ -97,5 +81,27 @@ public class BeamAssignWindowsTask<T> extends Task {
     } catch (Exception e) {
       throw new RuntimeException("Failed to assign Beam windows", e);
     }
+  }
+
+  private Collection<BoundedWindow> assignWindowsFor(WindowedValue<T> windowedValue)
+      throws Exception {
+    WindowFn<T, BoundedWindow> windowFn = (WindowFn<T, BoundedWindow>) spec.getWindowFn();
+    return windowFn.assignWindows(
+        windowFn.new AssignContext() {
+          @Override
+          public T element() {
+            return windowedValue.getValue();
+          }
+
+          @Override
+          public org.joda.time.Instant timestamp() {
+            return windowedValue.getTimestamp();
+          }
+
+          @Override
+          public BoundedWindow window() {
+            return (BoundedWindow) windowedValue.getWindows().iterator().next();
+          }
+        });
   }
 }

--- a/experiments/beam/src/main/java/org/apache/beam/runners/gearpump/runtime/BeamCombineGroupedValuesSpec.java
+++ b/experiments/beam/src/main/java/org/apache/beam/runners/gearpump/runtime/BeamCombineGroupedValuesSpec.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.gearpump.runtime;
+
+import java.io.Serializable;
+import org.apache.beam.runners.core.construction.SerializablePipelineOptions;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.transforms.CombineFnBase;
+
+/** Serializable runtime specification for Beam keyed combine-on-grouped-values. */
+public class BeamCombineGroupedValuesSpec<K, InputT, OutputT> implements Serializable {
+
+  private final SerializablePipelineOptions options;
+  private final CombineFnBase.GlobalCombineFn<? super InputT, ?, OutputT> combineFn;
+
+  public BeamCombineGroupedValuesSpec(
+      PipelineOptions options, CombineFnBase.GlobalCombineFn<? super InputT, ?, OutputT> combineFn) {
+    this.options = new SerializablePipelineOptions(options);
+    this.combineFn = combineFn;
+  }
+
+  public PipelineOptions getPipelineOptions() {
+    return options.get();
+  }
+
+  public CombineFnBase.GlobalCombineFn<? super InputT, ?, OutputT> getCombineFn() {
+    return combineFn;
+  }
+}

--- a/experiments/beam/src/main/java/org/apache/beam/runners/gearpump/runtime/BeamCombineGroupedValuesTask.java
+++ b/experiments/beam/src/main/java/org/apache/beam/runners/gearpump/runtime/BeamCombineGroupedValuesTask.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.gearpump.runtime;
+
+import io.gearpump.DefaultMessage;
+import io.gearpump.Message;
+import io.gearpump.cluster.UserConfig;
+import io.gearpump.streaming.task.Task;
+import io.gearpump.streaming.task.TaskContext;
+import java.time.Instant;
+import org.apache.beam.runners.core.GlobalCombineFnRunner;
+import org.apache.beam.runners.core.GlobalCombineFnRunners;
+import org.apache.beam.runners.core.NullSideInputReader;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.WindowedValue;
+import org.apache.beam.sdk.values.WindowedValues;
+
+/** Applies Beam {@code Combine.GroupedValues} to each grouped key/window record. */
+@SuppressWarnings("unchecked")
+public class BeamCombineGroupedValuesTask<K, InputT, AccumT, OutputT> extends Task {
+
+  public static final String COMBINE_GROUPED_VALUES_SPEC =
+      "beam.gearpump.combine-grouped-values-spec";
+
+  private final TaskContext taskContext;
+  private final BeamCombineGroupedValuesSpec<K, InputT, OutputT> spec;
+  private final GlobalCombineFnRunner<InputT, AccumT, OutputT> combineFnRunner;
+  private final NullSideInputReader sideInputReader = NullSideInputReader.empty();
+
+  public BeamCombineGroupedValuesTask(TaskContext taskContext, UserConfig userConfig) {
+    super(taskContext, userConfig);
+    this.taskContext = taskContext;
+    this.spec =
+        BeamUserConfig.getValue(
+            userConfig, COMBINE_GROUPED_VALUES_SPEC, taskContext.system());
+    this.combineFnRunner =
+        (GlobalCombineFnRunner<InputT, AccumT, OutputT>)
+            GlobalCombineFnRunners.create(
+                (org.apache.beam.sdk.transforms.CombineFnBase.GlobalCombineFn<
+                        InputT, AccumT, OutputT>)
+                    spec.getCombineFn());
+  }
+
+  @Override
+  public void onNext(Message message) {
+    WindowedValue<KV<K, Iterable<InputT>>> windowedValue =
+        (WindowedValue<KV<K, Iterable<InputT>>>) message.value();
+    KV<K, Iterable<InputT>> groupedValues = windowedValue.getValue();
+    AccumT accumulator =
+        combineFnRunner.createAccumulator(
+            spec.getPipelineOptions(), sideInputReader, windowedValue.getWindows());
+    for (InputT value : groupedValues.getValue()) {
+      accumulator =
+          combineFnRunner.addInput(
+              accumulator,
+              value,
+              spec.getPipelineOptions(),
+              sideInputReader,
+              windowedValue.getWindows());
+    }
+    accumulator =
+        combineFnRunner.compact(
+            accumulator,
+            spec.getPipelineOptions(),
+            sideInputReader,
+            windowedValue.getWindows());
+    OutputT output =
+        combineFnRunner.extractOutput(
+            accumulator,
+            spec.getPipelineOptions(),
+            sideInputReader,
+            windowedValue.getWindows());
+    WindowedValue<KV<K, OutputT>> outputValue =
+        WindowedValues.withValue(windowedValue, KV.of(groupedValues.getKey(), output));
+    taskContext.output(new DefaultMessage(outputValue, message.timestamp()));
+  }
+
+  @Override
+  public void onWatermarkProgress(Instant watermark) {
+    taskContext.updateWatermark(watermark);
+  }
+}

--- a/experiments/beam/src/main/java/org/apache/beam/runners/gearpump/runtime/BeamGroupByKeySpec.java
+++ b/experiments/beam/src/main/java/org/apache/beam/runners/gearpump/runtime/BeamGroupByKeySpec.java
@@ -20,16 +20,22 @@ package org.apache.beam.runners.gearpump.runtime;
 import java.io.Serializable;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.transforms.windowing.TimestampCombiner;
 
 /** Serializable runtime specification for the low-level GroupByKey task. */
 public class BeamGroupByKeySpec<K> implements Serializable {
 
   private final Coder<K> keyCoder;
   private final Coder<? extends BoundedWindow> windowCoder;
+  private final TimestampCombiner timestampCombiner;
 
-  public BeamGroupByKeySpec(Coder<K> keyCoder, Coder<? extends BoundedWindow> windowCoder) {
+  public BeamGroupByKeySpec(
+      Coder<K> keyCoder,
+      Coder<? extends BoundedWindow> windowCoder,
+      TimestampCombiner timestampCombiner) {
     this.keyCoder = keyCoder;
     this.windowCoder = windowCoder;
+    this.timestampCombiner = timestampCombiner;
   }
 
   public Coder<K> getKeyCoder() {
@@ -38,5 +44,9 @@ public class BeamGroupByKeySpec<K> implements Serializable {
 
   public Coder<? extends BoundedWindow> getWindowCoder() {
     return windowCoder;
+  }
+
+  public TimestampCombiner getTimestampCombiner() {
+    return timestampCombiner;
   }
 }

--- a/experiments/beam/src/main/java/org/apache/beam/runners/gearpump/runtime/BeamGroupByKeyTask.java
+++ b/experiments/beam/src/main/java/org/apache/beam/runners/gearpump/runtime/BeamGroupByKeyTask.java
@@ -79,6 +79,7 @@ public class BeamGroupByKeyTask<K, V> extends Task {
           groups.put(key, grouped);
         }
         grouped.values.add(value.getValue());
+        grouped.timestamps.add(explodedWindow.getTimestamp());
       }
     } catch (Exception e) {
       throw new RuntimeException("Failed to group Beam values by key", e);
@@ -99,9 +100,7 @@ public class BeamGroupByKeyTask<K, V> extends Task {
     for (GroupedValues<K, V> grouped : groups.values()) {
       KV<K, Iterable<V>> output = KV.of(grouped.key, (Iterable<V>) new ArrayList<>(grouped.values));
       org.joda.time.Instant outputTimestamp =
-          grouped.window instanceof GlobalWindow
-              ? GlobalWindow.INSTANCE.maxTimestamp()
-              : grouped.window.maxTimestamp();
+          spec.getTimestampCombiner().merge(grouped.window, grouped.timestamps);
       Instant javaTimestamp = TranslatorUtils.jodaTimeToJava8Time(outputTimestamp);
       WindowedValue<KV<K, Iterable<V>>> windowedValue =
           WindowedValues.of(
@@ -124,6 +123,7 @@ public class BeamGroupByKeyTask<K, V> extends Task {
     private final K key;
     private final BoundedWindow window;
     private final List<V> values = new ArrayList<>();
+    private final List<org.joda.time.Instant> timestamps = new ArrayList<>();
 
     private GroupedValues(K key, BoundedWindow window) {
       this.key = key;

--- a/experiments/beam/src/main/java/org/apache/beam/runners/gearpump/runtime/BeamGroupByKeyTask.java
+++ b/experiments/beam/src/main/java/org/apache/beam/runners/gearpump/runtime/BeamGroupByKeyTask.java
@@ -23,14 +23,19 @@ import io.gearpump.cluster.UserConfig;
 import io.gearpump.streaming.source.Watermark;
 import io.gearpump.streaming.task.Task;
 import io.gearpump.streaming.task.TaskContext;
+import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.beam.runners.gearpump.translators.utils.TranslatorUtils;
+import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.transforms.windowing.PaneInfo;
 import org.apache.beam.sdk.util.CoderUtils;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.WindowedValue;
@@ -39,8 +44,8 @@ import org.apache.beam.sdk.values.WindowedValues;
 /**
  * Minimal in-memory Beam GroupByKey task.
  *
- * <p>This implementation intentionally supports the default global window only and emits grouped
- * values when the input watermark reaches {@link Watermark#MAX()}.
+ * <p>This implementation emits one final pane per key/window when the input watermark reaches
+ * {@link Watermark#MAX()}.
  */
 @SuppressWarnings("unchecked")
 public class BeamGroupByKeyTask<K, V> extends Task {
@@ -64,15 +69,17 @@ public class BeamGroupByKeyTask<K, V> extends Task {
   public void onNext(Message message) {
     try {
       WindowedValue<KV<K, V>> windowedValue = (WindowedValue<KV<K, V>>) message.value();
-      KV<K, V> value = windowedValue.getValue();
-      byte[] encodedKey = CoderUtils.encodeToByteArray(spec.getKeyCoder(), value.getKey());
-      ByteArrayKey key = new ByteArrayKey(encodedKey);
-      GroupedValues<K, V> grouped = groups.get(key);
-      if (grouped == null) {
-        grouped = new GroupedValues<>(value.getKey());
-        groups.put(key, grouped);
+      for (WindowedValue<KV<K, V>> explodedWindow : windowedValue.explodeWindows()) {
+        KV<K, V> value = explodedWindow.getValue();
+        BoundedWindow window = (BoundedWindow) explodedWindow.getWindows().iterator().next();
+        ByteArrayKey key = createGroupingKey(value.getKey(), window);
+        GroupedValues<K, V> grouped = groups.get(key);
+        if (grouped == null) {
+          grouped = new GroupedValues<>(value.getKey(), window);
+          groups.put(key, grouped);
+        }
+        grouped.values.add(value.getValue());
       }
-      grouped.values.add(value.getValue());
     } catch (Exception e) {
       throw new RuntimeException("Failed to group Beam values by key", e);
     }
@@ -89,30 +96,48 @@ public class BeamGroupByKeyTask<K, V> extends Task {
   }
 
   private void emitAll() {
-    org.joda.time.Instant outputTimestamp = GlobalWindow.INSTANCE.maxTimestamp();
-    Instant javaTimestamp = TranslatorUtils.jodaTimeToJava8Time(outputTimestamp);
     for (GroupedValues<K, V> grouped : groups.values()) {
       KV<K, Iterable<V>> output = KV.of(grouped.key, (Iterable<V>) new ArrayList<>(grouped.values));
+      org.joda.time.Instant outputTimestamp =
+          grouped.window instanceof GlobalWindow
+              ? GlobalWindow.INSTANCE.maxTimestamp()
+              : grouped.window.maxTimestamp();
+      Instant javaTimestamp = TranslatorUtils.jodaTimeToJava8Time(outputTimestamp);
       WindowedValue<KV<K, Iterable<V>>> windowedValue =
-          WindowedValues.timestampedValueInGlobalWindow(output, outputTimestamp);
+          WindowedValues.of(
+              output,
+              outputTimestamp,
+              Collections.singletonList(grouped.window),
+              PaneInfo.ON_TIME_AND_ONLY_FIRING);
       taskContext.output(new DefaultMessage(windowedValue, javaTimestamp));
     }
   }
 
+  private ByteArrayKey createGroupingKey(K key, BoundedWindow window) throws IOException {
+    byte[] encodedKey = CoderUtils.encodeToByteArray(spec.getKeyCoder(), key);
+    Coder<BoundedWindow> windowCoder = (Coder<BoundedWindow>) spec.getWindowCoder();
+    byte[] encodedWindow = CoderUtils.encodeToByteArray(windowCoder, window);
+    return new ByteArrayKey(encodedKey, encodedWindow);
+  }
+
   private static final class GroupedValues<K, V> {
     private final K key;
+    private final BoundedWindow window;
     private final List<V> values = new ArrayList<>();
 
-    private GroupedValues(K key) {
+    private GroupedValues(K key, BoundedWindow window) {
       this.key = key;
+      this.window = window;
     }
   }
 
   private static final class ByteArrayKey {
-    private final byte[] value;
+    private final byte[] keyBytes;
+    private final byte[] windowBytes;
 
-    private ByteArrayKey(byte[] value) {
-      this.value = value;
+    private ByteArrayKey(byte[] keyBytes, byte[] windowBytes) {
+      this.keyBytes = keyBytes;
+      this.windowBytes = windowBytes;
     }
 
     @Override
@@ -124,12 +149,13 @@ public class BeamGroupByKeyTask<K, V> extends Task {
         return false;
       }
       ByteArrayKey that = (ByteArrayKey) other;
-      return Arrays.equals(value, that.value);
+      return Arrays.equals(keyBytes, that.keyBytes)
+          && Arrays.equals(windowBytes, that.windowBytes);
     }
 
     @Override
     public int hashCode() {
-      return Arrays.hashCode(value);
+      return 31 * Arrays.hashCode(keyBytes) + Arrays.hashCode(windowBytes);
     }
   }
 }

--- a/experiments/beam/src/main/java/org/apache/beam/runners/gearpump/translators/CombineGroupedValuesTranslator.java
+++ b/experiments/beam/src/main/java/org/apache/beam/runners/gearpump/translators/CombineGroupedValuesTranslator.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.gearpump.translators;
+
+import io.gearpump.cluster.UserConfig;
+import io.gearpump.streaming.javaapi.Processor;
+import io.gearpump.streaming.partitioner.CoLocationPartitioner;
+import org.apache.beam.runners.gearpump.runtime.BeamCombineGroupedValuesSpec;
+import org.apache.beam.runners.gearpump.runtime.BeamCombineGroupedValuesTask;
+import org.apache.beam.runners.gearpump.runtime.BeamUserConfig;
+import org.apache.beam.sdk.transforms.Combine;
+
+/** Translates Beam {@link Combine.GroupedValues} into a low-level keyed combine task. */
+public class CombineGroupedValuesTranslator<K, InputT, OutputT>
+    implements TransformTranslator<Combine.GroupedValues<K, InputT, OutputT>> {
+
+  @Override
+  public void translate(
+      Combine.GroupedValues<K, InputT, OutputT> transform, TranslationContext context) {
+    if (!transform.getSideInputs().isEmpty()) {
+      throw new UnsupportedOperationException(
+          "The low-level Gearpump Beam runner does not support combine side inputs yet.");
+    }
+
+    BeamCombineGroupedValuesSpec<K, InputT, OutputT> spec =
+        new BeamCombineGroupedValuesSpec<>(context.getPipelineOptions(), transform.getFn());
+    UserConfig userConfig =
+        BeamUserConfig.withValue(
+            UserConfig.empty(),
+            BeamCombineGroupedValuesTask.COMBINE_GROUPED_VALUES_SPEC,
+            spec,
+            context.getActorSystem());
+    Processor<BeamCombineGroupedValuesTask> combine =
+        context.addProcessor(
+            BeamCombineGroupedValuesTask.class,
+            userConfig,
+            transform.getName());
+    context.connect(context.getInput(), new CoLocationPartitioner(), combine);
+    context.setOutputProcessor(context.getOutput(), combine);
+  }
+}

--- a/experiments/beam/src/main/java/org/apache/beam/runners/gearpump/translators/GearpumpPipelineTranslator.java
+++ b/experiments/beam/src/main/java/org/apache/beam/runners/gearpump/translators/GearpumpPipelineTranslator.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.runners.TransformHierarchy;
+import org.apache.beam.sdk.transforms.Combine;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.Flatten;
 import org.apache.beam.sdk.transforms.GroupByKey;
@@ -28,6 +29,7 @@ import org.apache.beam.sdk.transforms.Impulse;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.io.Read;
+import org.apache.beam.sdk.transforms.windowing.Window;
 
 /** Translates supported Beam primitives into a low-level Gearpump graph. */
 @SuppressWarnings({"rawtypes", "unchecked"})
@@ -43,7 +45,9 @@ public class GearpumpPipelineTranslator extends Pipeline.PipelineVisitor.Default
     registerTransformTranslator(Impulse.class, new ImpulseTranslator());
     registerTransformTranslator(Read.Bounded.class, new ReadBoundedTranslator());
     registerTransformTranslator(Flatten.PCollections.class, new FlattenPCollectionsTranslator());
+    registerTransformTranslator(Window.Assign.class, new WindowAssignTranslator());
     registerTransformTranslator(GroupByKey.class, new GroupByKeyTranslator());
+    registerTransformTranslator(Combine.GroupedValues.class, new CombineGroupedValuesTranslator());
     registerTransformTranslator(ParDo.MultiOutput.class, new ParDoMultiOutputTranslator());
   }
 
@@ -80,7 +84,8 @@ public class GearpumpPipelineTranslator extends Pipeline.PipelineVisitor.Default
           "Unsupported Beam transform "
               + transform.getClass().getName()
               + ". The low-level Gearpump runner currently supports only "
-              + "Read.Bounded/Create, ParDo, Flatten, and GroupByKey in global windows.");
+              + "Read.Bounded/Create, Impulse, ParDo, Flatten, Window.Assign, "
+              + "GroupByKey in non-merging windows, and Combine.GroupedValues.");
     }
     translationContext.setCurrentTransform(node, getPipeline());
     translator.translate(transform, translationContext);

--- a/experiments/beam/src/main/java/org/apache/beam/runners/gearpump/translators/GroupByKeyTranslator.java
+++ b/experiments/beam/src/main/java/org/apache/beam/runners/gearpump/translators/GroupByKeyTranslator.java
@@ -26,7 +26,7 @@ import org.apache.beam.runners.gearpump.runtime.BeamUserConfig;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.transforms.GroupByKey;
-import org.apache.beam.sdk.transforms.windowing.GlobalWindows;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 
@@ -37,13 +37,16 @@ public class GroupByKeyTranslator<K, V> implements TransformTranslator<GroupByKe
   @Override
   public void translate(GroupByKey<K, V> transform, TranslationContext context) {
     PCollection<KV<K, V>> input = (PCollection<KV<K, V>>) context.getInput();
-    if (!(input.getWindowingStrategy().getWindowFn() instanceof GlobalWindows)) {
+    if (!input.getWindowingStrategy().getWindowFn().isNonMerging()) {
       throw new UnsupportedOperationException(
-          "The low-level Gearpump Beam runner currently supports GroupByKey only in the global window.");
+          "The low-level Gearpump Beam runner currently supports GroupByKey only for "
+              + "non-merging windows.");
     }
 
     Coder<K> keyCoder = ((KvCoder<K, V>) input.getCoder()).getKeyCoder();
-    BeamGroupByKeySpec<K> spec = new BeamGroupByKeySpec<>(keyCoder);
+    Coder<? extends BoundedWindow> windowCoder =
+        input.getWindowingStrategy().getWindowFn().windowCoder();
+    BeamGroupByKeySpec<K> spec = new BeamGroupByKeySpec<>(keyCoder, windowCoder);
     UserConfig userConfig =
         BeamUserConfig.withValue(
             UserConfig.empty(),

--- a/experiments/beam/src/main/java/org/apache/beam/runners/gearpump/translators/GroupByKeyTranslator.java
+++ b/experiments/beam/src/main/java/org/apache/beam/runners/gearpump/translators/GroupByKeyTranslator.java
@@ -30,6 +30,7 @@ import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.TimestampCombiner;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.WindowingStrategy;
 
 /** Translates Beam {@link GroupByKey} into a low-level Gearpump in-memory grouping task. */
 @SuppressWarnings("unchecked")
@@ -38,16 +39,17 @@ public class GroupByKeyTranslator<K, V> implements TransformTranslator<GroupByKe
   @Override
   public void translate(GroupByKey<K, V> transform, TranslationContext context) {
     PCollection<KV<K, V>> input = (PCollection<KV<K, V>>) context.getInput();
-    if (!input.getWindowingStrategy().getWindowFn().isNonMerging()) {
+    WindowingStrategy<?, ?> windowingStrategy = input.getWindowingStrategy();
+    if (!windowingStrategy.getWindowFn().isNonMerging()) {
       throw new UnsupportedOperationException(
           "The low-level Gearpump Beam runner currently supports GroupByKey only for "
               + "non-merging windows.");
     }
+    validateWindowingStrategy(windowingStrategy);
 
     Coder<K> keyCoder = ((KvCoder<K, V>) input.getCoder()).getKeyCoder();
-    Coder<? extends BoundedWindow> windowCoder =
-        input.getWindowingStrategy().getWindowFn().windowCoder();
-    TimestampCombiner timestampCombiner = input.getWindowingStrategy().getTimestampCombiner();
+    Coder<? extends BoundedWindow> windowCoder = windowingStrategy.getWindowFn().windowCoder();
+    TimestampCombiner timestampCombiner = windowingStrategy.getTimestampCombiner();
     BeamGroupByKeySpec<K> spec =
         new BeamGroupByKeySpec<>(keyCoder, windowCoder, timestampCombiner);
     UserConfig userConfig =
@@ -60,5 +62,19 @@ public class GroupByKeyTranslator<K, V> implements TransformTranslator<GroupByKe
         context.addProcessor(BeamGroupByKeyTask.class, userConfig, transform.getName());
     context.connect(context.getInput(), new BeamKeyPartitioner<>(keyCoder), groupByKey);
     context.setOutputProcessor(context.getOutput(), groupByKey);
+  }
+
+  private void validateWindowingStrategy(WindowingStrategy<?, ?> windowingStrategy) {
+    WindowingStrategy<?, ?> defaultStrategy =
+        WindowingStrategy.of(windowingStrategy.getWindowFn()).fixDefaults();
+    if (!windowingStrategy.getTrigger().isCompatible(defaultStrategy.getTrigger())
+        || !windowingStrategy.getAllowedLateness().equals(defaultStrategy.getAllowedLateness())
+        || windowingStrategy.getMode() != defaultStrategy.getMode()
+        || windowingStrategy.getClosingBehavior() != defaultStrategy.getClosingBehavior()
+        || windowingStrategy.getOnTimeBehavior() != defaultStrategy.getOnTimeBehavior()) {
+      throw new UnsupportedOperationException(
+          "The low-level Gearpump Beam runner currently supports GroupByKey only with default "
+              + "trigger/pane semantics and zero allowed lateness.");
+    }
   }
 }

--- a/experiments/beam/src/main/java/org/apache/beam/runners/gearpump/translators/GroupByKeyTranslator.java
+++ b/experiments/beam/src/main/java/org/apache/beam/runners/gearpump/translators/GroupByKeyTranslator.java
@@ -27,6 +27,7 @@ import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.transforms.GroupByKey;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.transforms.windowing.TimestampCombiner;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 
@@ -46,7 +47,9 @@ public class GroupByKeyTranslator<K, V> implements TransformTranslator<GroupByKe
     Coder<K> keyCoder = ((KvCoder<K, V>) input.getCoder()).getKeyCoder();
     Coder<? extends BoundedWindow> windowCoder =
         input.getWindowingStrategy().getWindowFn().windowCoder();
-    BeamGroupByKeySpec<K> spec = new BeamGroupByKeySpec<>(keyCoder, windowCoder);
+    TimestampCombiner timestampCombiner = input.getWindowingStrategy().getTimestampCombiner();
+    BeamGroupByKeySpec<K> spec =
+        new BeamGroupByKeySpec<>(keyCoder, windowCoder, timestampCombiner);
     UserConfig userConfig =
         BeamUserConfig.withValue(
             UserConfig.empty(),

--- a/experiments/beam/src/main/java/org/apache/beam/runners/gearpump/translators/WindowAssignTranslator.java
+++ b/experiments/beam/src/main/java/org/apache/beam/runners/gearpump/translators/WindowAssignTranslator.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.gearpump.translators;
+
+import io.gearpump.cluster.UserConfig;
+import io.gearpump.streaming.javaapi.Processor;
+import io.gearpump.streaming.partitioner.CoLocationPartitioner;
+import org.apache.beam.runners.gearpump.runtime.BeamAssignWindowsSpec;
+import org.apache.beam.runners.gearpump.runtime.BeamAssignWindowsTask;
+import org.apache.beam.runners.gearpump.runtime.BeamUserConfig;
+import org.apache.beam.sdk.transforms.windowing.Window;
+import org.apache.beam.sdk.values.PCollection;
+
+/** Translates Beam {@link Window.Assign} into a low-level Gearpump window-assignment task. */
+@SuppressWarnings("unchecked")
+public class WindowAssignTranslator<T> implements TransformTranslator<Window.Assign<T>> {
+
+  @Override
+  public void translate(Window.Assign<T> transform, TranslationContext context) {
+    PCollection<T> input = (PCollection<T>) context.getInput();
+    BeamAssignWindowsSpec<T> spec =
+        new BeamAssignWindowsSpec<>(transform.getWindowFn(), input.getWindowingStrategy());
+    UserConfig userConfig =
+        BeamUserConfig.withValue(
+            UserConfig.empty(),
+            BeamAssignWindowsTask.ASSIGN_WINDOWS_SPEC,
+            spec,
+            context.getActorSystem());
+    Processor<BeamAssignWindowsTask> assignWindows =
+        context.addProcessor(BeamAssignWindowsTask.class, userConfig, transform.getName());
+    context.connect(context.getInput(), new CoLocationPartitioner(), assignWindows);
+    context.setOutputProcessor(context.getOutput(), assignWindows);
+  }
+}

--- a/experiments/beam/src/test/java/org/apache/beam/runners/gearpump/GearpumpRunnerIntegrationTest.java
+++ b/experiments/beam/src/test/java/org/apache/beam/runners/gearpump/GearpumpRunnerIntegrationTest.java
@@ -30,6 +30,7 @@ import org.apache.beam.sdk.transforms.GroupByKey;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.Sum;
 import org.apache.beam.sdk.transforms.windowing.FixedWindows;
+import org.apache.beam.sdk.transforms.windowing.SlidingWindows;
 import org.apache.beam.sdk.transforms.windowing.TimestampCombiner;
 import org.apache.beam.sdk.transforms.windowing.Window;
 import org.apache.beam.sdk.values.KV;
@@ -100,6 +101,24 @@ public class GearpumpRunnerIntegrationTest {
         .apply("captureWindowedSums", ParDo.of(new CaptureGroupedSumsFn()));
 
     assertPipelineOutputs(pipeline, "a=3", "a=5");
+  }
+
+  @Test
+  public void rewindowingShouldNotDuplicateElementsAcrossExistingWindows() {
+    Pipeline pipeline = Pipeline.create(options);
+    pipeline
+        .apply(
+            Create.timestamped(
+                TimestampedValue.of(KV.of("a", 1), new Instant(5_000L))))
+        .apply(
+            Window.into(
+                SlidingWindows.of(Duration.standardSeconds(10))
+                    .every(Duration.standardSeconds(5))))
+        .apply(Window.into(FixedWindows.of(Duration.standardSeconds(10))))
+        .apply(GroupByKey.create())
+        .apply("captureRewindowedSums", ParDo.of(new CaptureGroupedSumsFn()));
+
+    assertPipelineOutputs(pipeline, "a=1");
   }
 
   @Test

--- a/experiments/beam/src/test/java/org/apache/beam/runners/gearpump/GearpumpRunnerIntegrationTest.java
+++ b/experiments/beam/src/test/java/org/apache/beam/runners/gearpump/GearpumpRunnerIntegrationTest.java
@@ -30,6 +30,7 @@ import org.apache.beam.sdk.transforms.GroupByKey;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.Sum;
 import org.apache.beam.sdk.transforms.windowing.FixedWindows;
+import org.apache.beam.sdk.transforms.windowing.TimestampCombiner;
 import org.apache.beam.sdk.transforms.windowing.Window;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.TimestampedValue;
@@ -99,6 +100,40 @@ public class GearpumpRunnerIntegrationTest {
         .apply("captureWindowedSums", ParDo.of(new CaptureGroupedSumsFn()));
 
     assertPipelineOutputs(pipeline, "a=3", "a=5");
+  }
+
+  @Test
+  public void runsWindowedGroupByKeyWithEarliestTimestampCombiner() {
+    Pipeline pipeline = Pipeline.create(options);
+    pipeline
+        .apply(
+            Create.timestamped(
+                TimestampedValue.of(KV.of("a", 1), new Instant(1_000L)),
+                TimestampedValue.of(KV.of("a", 2), new Instant(5_000L))))
+        .apply(
+            Window.<KV<String, Integer>>into(FixedWindows.of(Duration.standardSeconds(10)))
+                .withTimestampCombiner(TimestampCombiner.EARLIEST))
+        .apply(GroupByKey.create())
+        .apply("captureEarliestWindowedSums", ParDo.of(new CaptureTimestampedGroupedSumsFn()));
+
+    assertPipelineOutputs(pipeline, "a@1000=3");
+  }
+
+  @Test
+  public void runsWindowedGroupByKeyWithLatestTimestampCombiner() {
+    Pipeline pipeline = Pipeline.create(options);
+    pipeline
+        .apply(
+            Create.timestamped(
+                TimestampedValue.of(KV.of("a", 1), new Instant(1_000L)),
+                TimestampedValue.of(KV.of("a", 2), new Instant(5_000L))))
+        .apply(
+            Window.<KV<String, Integer>>into(FixedWindows.of(Duration.standardSeconds(10)))
+                .withTimestampCombiner(TimestampCombiner.LATEST))
+        .apply(GroupByKey.create())
+        .apply("captureLatestWindowedSums", ParDo.of(new CaptureTimestampedGroupedSumsFn()));
+
+    assertPipelineOutputs(pipeline, "a@5000=3");
   }
 
   @Test
@@ -183,6 +218,22 @@ public class GearpumpRunnerIntegrationTest {
         sum += value;
       }
       String output = element.getKey() + "=" + sum;
+      CAPTURED.add(output);
+      context.output(output);
+    }
+  }
+
+  private static final class CaptureTimestampedGroupedSumsFn
+      extends DoFn<KV<String, Iterable<Integer>>, String> {
+    @ProcessElement
+    public void processElement(ProcessContext context) {
+      KV<String, Iterable<Integer>> element = context.element();
+      int sum = 0;
+      for (Integer value : element.getValue()) {
+        sum += value;
+      }
+      String output =
+          element.getKey() + "@" + context.timestamp().getMillis() + "=" + sum;
       CAPTURED.add(output);
       context.output(output);
     }

--- a/experiments/beam/src/test/java/org/apache/beam/runners/gearpump/GearpumpRunnerIntegrationTest.java
+++ b/experiments/beam/src/test/java/org/apache/beam/runners/gearpump/GearpumpRunnerIntegrationTest.java
@@ -28,10 +28,16 @@ import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.GroupByKey;
 import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.Sum;
+import org.apache.beam.sdk.transforms.windowing.FixedWindows;
+import org.apache.beam.sdk.transforms.windowing.Window;
 import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.TimestampedValue;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.joda.time.Duration;
+import org.joda.time.Instant;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -75,6 +81,33 @@ public class GearpumpRunnerIntegrationTest {
         .apply(Create.of(KV.of("a", 1), KV.of("a", 2), KV.of("b", 5)))
         .apply(GroupByKey.create())
         .apply("captureSums", ParDo.of(new CaptureGroupedSumsFn()));
+
+    assertPipelineOutputs(pipeline, "a=3", "b=5");
+  }
+
+  @Test
+  public void runsWindowedGroupByKeyPipelineInEmbeddedCluster() {
+    Pipeline pipeline = Pipeline.create(options);
+    pipeline
+        .apply(
+            Create.timestamped(
+                TimestampedValue.of(KV.of("a", 1), new Instant(0L)),
+                TimestampedValue.of(KV.of("a", 2), new Instant(5_000L)),
+                TimestampedValue.of(KV.of("a", 5), new Instant(15_000L))))
+        .apply(Window.into(FixedWindows.of(Duration.standardSeconds(10))))
+        .apply(GroupByKey.create())
+        .apply("captureWindowedSums", ParDo.of(new CaptureGroupedSumsFn()));
+
+    assertPipelineOutputs(pipeline, "a=3", "a=5");
+  }
+
+  @Test
+  public void runsKeyedCombinePipelineInEmbeddedCluster() {
+    Pipeline pipeline = Pipeline.create(options);
+    pipeline
+        .apply(Create.of(KV.of("a", 1), KV.of("a", 2), KV.of("b", 5)))
+        .apply(Sum.integersPerKey())
+        .apply("captureCombinedSums", ParDo.of(new CaptureCombinedSumsFn()));
 
     assertPipelineOutputs(pipeline, "a=3", "b=5");
   }
@@ -150,6 +183,16 @@ public class GearpumpRunnerIntegrationTest {
         sum += value;
       }
       String output = element.getKey() + "=" + sum;
+      CAPTURED.add(output);
+      context.output(output);
+    }
+  }
+
+  private static final class CaptureCombinedSumsFn extends DoFn<KV<String, Integer>, String> {
+    @ProcessElement
+    public void processElement(ProcessContext context) {
+      KV<String, Integer> element = context.element();
+      String output = element.getKey() + "=" + element.getValue();
       CAPTURED.add(output);
       context.output(output);
     }

--- a/experiments/beam/src/test/java/org/apache/beam/runners/gearpump/translators/GearpumpPipelineTranslatorTest.java
+++ b/experiments/beam/src/test/java/org/apache/beam/runners/gearpump/translators/GearpumpPipelineTranslatorTest.java
@@ -27,13 +27,16 @@ import org.apache.beam.runners.gearpump.runtime.BeamGroupByKeyTask;
 import org.apache.beam.runners.gearpump.runtime.BeamParDoTask;
 import org.apache.beam.runners.gearpump.runtime.BeamTaggedOutputTask;
 import org.apache.beam.runners.gearpump.GearpumpPipelineOptions;
+import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.transforms.windowing.AfterPane;
 import org.apache.beam.sdk.transforms.Combine;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.GroupByKey;
 import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.windowing.Repeatedly;
 import org.apache.beam.sdk.transforms.Sum;
 import org.apache.beam.sdk.transforms.windowing.FixedWindows;
 import org.apache.beam.sdk.transforms.windowing.Window;
@@ -52,6 +55,7 @@ import org.joda.time.Instant;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /** Tests for low-level Beam-to-Gearpump graph translation. */
 public class GearpumpPipelineTranslatorTest {
@@ -131,6 +135,33 @@ public class GearpumpPipelineTranslatorTest {
     assertTrue(containsProcessor(processors, BeamGroupByKeyTask.class));
     assertEquals(
         BeamGroupByKeyTask.class, context.getOutputProcessor(context.getOutput()).taskClass());
+  }
+
+  @Test
+  public void rejectsGroupByKeyWithCustomTrigger() {
+    Pipeline pipeline = Pipeline.create();
+    pipeline
+        .apply(
+            Create.timestamped(
+                TimestampedValue.of(KV.of("a", 1), new Instant(0L)))
+                .withCoder(
+                    KvCoder.of(
+                        org.apache.beam.sdk.coders.StringUtf8Coder.of(),
+                        org.apache.beam.sdk.coders.VarIntCoder.of())))
+        .apply(
+            Window.<KV<String, Integer>>into(FixedWindows.of(Duration.standardSeconds(10)))
+                .triggering(Repeatedly.forever(AfterPane.elementCountAtLeast(1)))
+                .withAllowedLateness(Duration.ZERO)
+                .discardingFiredPanes())
+        .apply(GroupByKey.create());
+
+    TranslationContext context = new TranslationContext("beam-test", options, actorSystem);
+    try {
+      new GearpumpPipelineTranslator(context).translate(pipeline);
+      fail("Expected custom trigger support to be rejected");
+    } catch (UnsupportedOperationException e) {
+      assertTrue(e.getMessage().contains("default trigger/pane semantics"));
+    }
   }
 
   @Test

--- a/experiments/beam/src/test/java/org/apache/beam/runners/gearpump/translators/GearpumpPipelineTranslatorTest.java
+++ b/experiments/beam/src/test/java/org/apache/beam/runners/gearpump/translators/GearpumpPipelineTranslatorTest.java
@@ -22,17 +22,23 @@ import io.gearpump.cluster.ClusterConfig;
 import io.gearpump.streaming.Processor;
 import io.gearpump.streaming.task.Task;
 import org.apache.beam.runners.gearpump.GearpumpRunner;
+import org.apache.beam.runners.gearpump.runtime.BeamAssignWindowsTask;
 import org.apache.beam.runners.gearpump.runtime.BeamGroupByKeyTask;
 import org.apache.beam.runners.gearpump.runtime.BeamParDoTask;
 import org.apache.beam.runners.gearpump.runtime.BeamTaggedOutputTask;
 import org.apache.beam.runners.gearpump.GearpumpPipelineOptions;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.transforms.Combine;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.GroupByKey;
 import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.Sum;
+import org.apache.beam.sdk.transforms.windowing.FixedWindows;
+import org.apache.beam.sdk.transforms.windowing.Window;
 import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.TimestampedValue;
 import org.apache.pekko.actor.ActorSystem;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -40,8 +46,11 @@ import org.junit.jupiter.api.Test;
 import scala.collection.JavaConverters;
 
 import java.util.List;
+import org.joda.time.Duration;
+import org.joda.time.Instant;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Tests for low-level Beam-to-Gearpump graph translation. */
@@ -99,6 +108,47 @@ public class GearpumpPipelineTranslatorTest {
     assertTrue(containsProcessor(processors, BeamGroupByKeyTask.class));
     assertEquals(
         BeamGroupByKeyTask.class, context.getOutputProcessor(context.getOutput()).taskClass());
+  }
+
+  @Test
+  public void translatesWindowedGroupByKeyToLowLevelGraph() {
+    Pipeline pipeline = Pipeline.create();
+    pipeline
+        .apply(
+            Create.timestamped(
+                TimestampedValue.of(KV.of("a", 1), new Instant(0L)),
+                TimestampedValue.of(KV.of("a", 2), new Instant(15_000L))))
+        .apply(Window.into(FixedWindows.of(Duration.standardSeconds(10))))
+        .apply(GroupByKey.create());
+
+    TranslationContext context = new TranslationContext("beam-test", options, actorSystem);
+    new GearpumpPipelineTranslator(context).translate(pipeline);
+
+    List<Processor<? extends Task>> processors =
+        JavaConverters.seqAsJavaListConverter(context.getGraph().getVertices()).asJava();
+    assertTrue(processors.size() >= 3);
+    assertTrue(containsProcessor(processors, BeamAssignWindowsTask.class));
+    assertTrue(containsProcessor(processors, BeamGroupByKeyTask.class));
+    assertEquals(
+        BeamGroupByKeyTask.class, context.getOutputProcessor(context.getOutput()).taskClass());
+  }
+
+  @Test
+  public void translatesKeyedCombineToLowLevelGraph() {
+    Pipeline pipeline = Pipeline.create();
+    pipeline
+        .apply(Create.of(KV.of("a", 1), KV.of("a", 2), KV.of("b", 5)))
+        .apply(GroupByKey.create())
+        .apply(Combine.groupedValues(Sum.ofIntegers()));
+
+    TranslationContext context = new TranslationContext("beam-test", options, actorSystem);
+    new GearpumpPipelineTranslator(context).translate(pipeline);
+
+    List<Processor<? extends Task>> processors =
+        JavaConverters.seqAsJavaListConverter(context.getGraph().getVertices()).asJava();
+    assertTrue(processors.size() >= 2);
+    assertTrue(containsProcessor(processors, BeamGroupByKeyTask.class));
+    assertNotNull(context.getOutputProcessor(context.getOutput()));
   }
 
   private static boolean containsProcessor(


### PR DESCRIPTION
## Summary
- add non-merging Window.into support to the low-level Beam runner
- make GroupByKey window-aware for non-merging windows and add grouped combine support used by keyed sums
- extend translator and integration coverage for fixed-window and combine pipelines

## Testing
- sbt -java-home /opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home -Dsbt.log.noformat=true gearpump-beam-runner/test
