### PR TITLE
feat(iceberg): add iceberg connector

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,6 +27,7 @@ lazy val aggregated: Seq[ProjectReference] = Seq[ProjectReference](
   services,
   beamRunner,
   gearpumpHadoop,
+  gearpumpIceberg,
   packProject,
   complexdag,
   distributedshell,
@@ -127,6 +128,14 @@ lazy val gearpumpHadoop = Project(
         .map(_.exclude("org.slf4j", "slf4j-log4j12"))
     ))
   .dependsOn(core % "provided")
+
+lazy val gearpumpIceberg = Project(
+  id = "gearpump-external-iceberg",
+  base = file("gearpump-external-iceberg"))
+  .settings(commonSettings ++ javadocSettings ++ icebergDependencies ++ Seq(
+    Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat
+  ): _*)
+  .dependsOn(core % "provided", streaming % "provided")
 
 lazy val services: Project = Project(
   id = "gearpump-services",

--- a/docs/contents/dev/dev-connectors.md
+++ b/docs/contents/dev/dev-connectors.md
@@ -16,6 +16,7 @@ Currently, we have following `DataSource` supported.
 Name | Description
 -----| ----------
 `CollectionDataSource` | Convert a collection to a recursive data source. E.g. `seq(1, 2, 3)` will output `1,2,3,1,2,3...`.
+`IcebergSource` | Read the current snapshot of an Iceberg Hadoop table as a bounded source.
 `KafkaSource` | Read from Kafka.
 
 ### `DataSink` implemented
@@ -24,6 +25,7 @@ Currently, we have following `DataSink` supported.
 Name | Description
 -----| ----------
 `HBaseSink` | Write the message to HBase. The message to write must be HBase `Put` or a tuple of `(rowKey, family, column, value)`.
+`IcebergSink` | Append Iceberg `Record` messages to an unpartitioned Iceberg Hadoop table.
 `KafkaSink` | Write to Kafka.
 
 ## Use of Connectors
@@ -144,6 +146,58 @@ Attention, due to the issue discussed [here](http://stackoverflow.com/questions/
 	 conf
 	}
 	val sink = HBaseSink(UserConfig.empty, tableName, hadoopConfig)
+
+### Use of Iceberg connectors
+
+To use Iceberg connectors in your application, add the `gearpump-external-iceberg` dependency:
+
+#### SBT
+
+	:::sbt
+	"io.github.gearpump" %% "gearpump-external-iceberg" % {{GEARPUMP_VERSION}}
+
+#### XML
+
+	:::xml
+	<dependency>
+	  <groupId>io.github.gearpump</groupId>
+	  <artifactId>gearpump-external-iceberg</artifactId>
+	  <version>{{GEARPUMP_VERSION}}</version>
+	</dependency>
+
+Current scope:
+
+- `IcebergSource` reads the current snapshot of an Iceberg Hadoop table once and then finishes.
+- `IcebergSink` accepts `org.apache.iceberg.data.Record` messages and appends them as a new
+  snapshot when the sink task stops.
+- Only Hadoop directory tables are supported right now.
+- `IcebergSink` currently supports unpartitioned tables only.
+
+Example:
+
+	:::scala
+	import io.gearpump.cluster.UserConfig
+	import io.gearpump.external.iceberg._
+	import io.gearpump.streaming.sink.DataSinkProcessor
+	import io.gearpump.streaming.source.DataSourceProcessor
+	import org.apache.iceberg.Schema
+	import org.apache.iceberg.types.Types
+
+	val schema = new Schema(
+	  Types.NestedField.required(1, "id", Types.LongType.get()),
+	  Types.NestedField.required(2, "data", Types.StringType.get()),
+	  Types.NestedField.optional(3, "event_millis", Types.LongType.get())
+	)
+
+	val table = IcebergTableConfig.forNewTable("/tmp/gearpump-iceberg", schema)
+	val source = new IcebergSource(
+	  IcebergTableConfig.forTable("/tmp/gearpump-iceberg"),
+	  timestampExtractor = IcebergTimestampExtractor.field("event_millis")
+	)
+	val sink = new IcebergSink(table)
+
+	val sourceProcessor = DataSourceProcessor(source, parallelism = 1, description = "IcebergSource")
+	val sinkProcessor = DataSinkProcessor(sink, parallelism = 1, description = "IcebergSink")
 
 
 ## How to implement your own `DataSource`

--- a/docs/contents/introduction/features.md
+++ b/docs/contents/introduction/features.md
@@ -62,6 +62,6 @@ Gearpump has a built-in dashboard UI to manage the cluster and visualize the app
 
 ![Dashboard](../img/dashboard.gif)
 
-#### Data connectors for Kafka and HDFS
+#### Data connectors for Kafka, HDFS, and Iceberg
 
-Gearpump has built-in data connectors for Kafka and HDFS. For the Kafka connector, we support message replay from a specified timestamp.
+Gearpump has built-in data connectors for Kafka, HDFS, and Iceberg. For the Kafka connector, we support message replay from a specified timestamp. The Iceberg connector supports bounded snapshot reads and Hadoop-table appends.

--- a/gearpump-external-iceberg/src/main/scala/io/gearpump/external/iceberg/IcebergSink.scala
+++ b/gearpump-external-iceberg/src/main/scala/io/gearpump/external/iceberg/IcebergSink.scala
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gearpump.external.iceberg
+
+import io.gearpump.Message
+import io.gearpump.streaming.sink.DataSink
+import io.gearpump.streaming.task.TaskContext
+import org.apache.iceberg.FileFormat
+import org.apache.iceberg.Table
+import org.apache.iceberg.data.{GenericAppenderFactory, Record}
+import org.apache.iceberg.io.{DataWriter, OutputFileFactory}
+
+/**
+ * Gearpump sink that appends Iceberg [[Record]] values into an unpartitioned Hadoop table.
+ *
+ * Messages are buffered into a single data file per task instance and committed when the task
+ * stops.
+ */
+class IcebergSink(
+    tableConfig: IcebergTableConfig,
+    fileFormat: FileFormat = FileFormat.PARQUET)
+  extends DataSink {
+
+  private var table: Table = _
+  private var taskContext: TaskContext = _
+  private var writer: DataWriter[Record] = _
+
+  override def open(context: TaskContext): Unit = {
+    table = tableConfig.loadOrCreateTable()
+    if (!table.spec().isUnpartitioned) {
+      throw new UnsupportedOperationException(
+        "IcebergSink currently supports only unpartitioned Hadoop tables.")
+    }
+    taskContext = context
+  }
+
+  override def write(message: Message): Unit = {
+    if (writer == null) {
+      writer = newWriter()
+    }
+    writer.write(asRecord(message.value))
+  }
+
+  override def close(): Unit = {
+    if (writer != null) {
+      writer.close()
+      table.newAppend().appendFile(writer.toDataFile).commit()
+      writer = null
+    }
+    taskContext = null
+    table = null
+  }
+
+  private def asRecord(value: Any): Record = value match {
+    case record: Record =>
+      record
+    case other =>
+      throw new IllegalArgumentException(
+        s"IcebergSink expects org.apache.iceberg.data.Record values, but got ${other}")
+  }
+
+  private def newWriter(): DataWriter[Record] = {
+    val appenderFactory = new GenericAppenderFactory(table.schema(), table.spec())
+    val outputFileFactory =
+      OutputFileFactory.builderFor(
+        table,
+        taskContext.taskId.processorId,
+        taskContext.taskId.index)
+        .format(fileFormat)
+        .build()
+    appenderFactory.newDataWriter(outputFileFactory.newOutputFile(), fileFormat, null)
+  }
+}

--- a/gearpump-external-iceberg/src/main/scala/io/gearpump/external/iceberg/IcebergSource.scala
+++ b/gearpump-external-iceberg/src/main/scala/io/gearpump/external/iceberg/IcebergSource.scala
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gearpump.external.iceberg
+
+import io.gearpump.streaming.source.{DataSource, Watermark}
+import io.gearpump.streaming.task.TaskContext
+import io.gearpump.{Message, DefaultMessage}
+import java.time.Instant
+import org.apache.iceberg.Schema
+import org.apache.iceberg.data.{IcebergGenerics, Record}
+import org.apache.iceberg.io.CloseableIterable
+
+/**
+ * Bounded Gearpump data source that scans the current snapshot of an Iceberg Hadoop table.
+ *
+ * The source keeps the watermark at [[Watermark.MIN]] while scanning because snapshot reads do not
+ * guarantee timestamp ordering. Once the scan is exhausted, the source advances to
+ * [[Watermark.MAX]].
+ */
+class IcebergSource(
+    tableConfig: IcebergTableConfig,
+    projection: Option[Schema] = None,
+    timestampExtractor: IcebergTimestampExtractor = IcebergTimestampExtractor.epoch)
+  extends DataSource {
+
+  private var records: CloseableIterable[Record] = _
+  private var iterator: java.util.Iterator[Record] = _
+  private var finished = false
+
+  override def open(context: TaskContext, startTime: Instant): Unit = {
+    val builder = projection match {
+      case Some(schema) =>
+        IcebergGenerics.read(tableConfig.loadTable()).project(schema)
+      case None =>
+        IcebergGenerics.read(tableConfig.loadTable())
+    }
+
+    records = builder.build()
+    iterator = records.iterator()
+    finished = false
+  }
+
+  override def read(): Message = {
+    if (iterator != null && iterator.hasNext) {
+      val record = iterator.next()
+      new DefaultMessage(record, timestampExtractor.timestamp(record))
+    } else {
+      finished = true
+      null
+    }
+  }
+
+  override def close(): Unit = {
+    if (records != null) {
+      records.close()
+      records = null
+    }
+    iterator = null
+    finished = true
+  }
+
+  override def getWatermark: Instant = {
+    if (finished) {
+      Watermark.MAX
+    } else {
+      Watermark.MIN
+    }
+  }
+}

--- a/gearpump-external-iceberg/src/main/scala/io/gearpump/external/iceberg/IcebergTableConfig.scala
+++ b/gearpump-external-iceberg/src/main/scala/io/gearpump/external/iceberg/IcebergTableConfig.scala
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gearpump.external.iceberg
+
+import java.util
+import org.apache.hadoop.conf.Configuration
+import org.apache.iceberg.exceptions.NoSuchTableException
+import org.apache.iceberg.hadoop.HadoopTables
+import org.apache.iceberg.{PartitionSpec, PartitionSpecParser, Schema, SchemaParser, Table}
+import scala.jdk.CollectionConverters._
+
+/**
+ * Serializable table configuration for Iceberg Hadoop directory tables.
+ */
+final case class IcebergTableConfig private (
+    tableLocation: String,
+    hadoopConf: Map[String, String],
+    schemaJson: Option[String],
+    partitionSpecJson: Option[String],
+    tableProperties: Map[String, String],
+    createIfMissing: Boolean) extends Serializable {
+
+  def schema: Option[Schema] = schemaJson.map(SchemaParser.fromJson)
+
+  def partitionSpec: PartitionSpec = (schemaJson, partitionSpecJson) match {
+    case (Some(schemaText), Some(specText)) =>
+      PartitionSpecParser.fromJson(SchemaParser.fromJson(schemaText), specText)
+    case _ =>
+      PartitionSpec.unpartitioned()
+  }
+
+  private[iceberg] def loadTable(): Table = {
+    new HadoopTables(newHadoopConf()).load(tableLocation)
+  }
+
+  private[iceberg] def loadOrCreateTable(): Table = {
+    val tables = new HadoopTables(newHadoopConf())
+    if (!createIfMissing) {
+      return tables.load(tableLocation)
+    }
+
+    try {
+      tables.load(tableLocation)
+    } catch {
+      case _: NoSuchTableException =>
+        val tableSchema = schema.getOrElse {
+          throw new IllegalArgumentException(
+            "Iceberg table schema is required when createIfMissing is enabled.")
+        }
+        tables.create(
+          tableSchema,
+          partitionSpec,
+          new util.HashMap[String, String](tableProperties.asJava),
+          tableLocation)
+    }
+  }
+
+  private def newHadoopConf(): Configuration = {
+    val conf = new Configuration()
+    hadoopConf.foreach { case (key, value) => conf.set(key, value) }
+    conf
+  }
+}
+
+object IcebergTableConfig {
+
+  def forTable(
+      tableLocation: String,
+      hadoopConf: Map[String, String] = Map.empty): IcebergTableConfig = {
+    IcebergTableConfig(
+      tableLocation = tableLocation,
+      hadoopConf = hadoopConf,
+      schemaJson = None,
+      partitionSpecJson = None,
+      tableProperties = Map.empty,
+      createIfMissing = false)
+  }
+
+  def forNewTable(
+      tableLocation: String,
+      schema: Schema,
+      partitionSpec: PartitionSpec = PartitionSpec.unpartitioned(),
+      tableProperties: Map[String, String] = Map.empty,
+      hadoopConf: Map[String, String] = Map.empty): IcebergTableConfig = {
+    IcebergTableConfig(
+      tableLocation = tableLocation,
+      hadoopConf = hadoopConf,
+      schemaJson = Some(SchemaParser.toJson(schema)),
+      partitionSpecJson = Some(PartitionSpecParser.toJson(partitionSpec)),
+      tableProperties = tableProperties,
+      createIfMissing = true)
+  }
+}

--- a/gearpump-external-iceberg/src/main/scala/io/gearpump/external/iceberg/IcebergTimestampExtractor.scala
+++ b/gearpump-external-iceberg/src/main/scala/io/gearpump/external/iceberg/IcebergTimestampExtractor.scala
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gearpump.external.iceberg
+
+import java.sql.Timestamp
+import java.time.{Instant, LocalDateTime, OffsetDateTime, ZoneOffset}
+import org.apache.iceberg.data.Record
+
+trait IcebergTimestampExtractor extends Serializable {
+  def timestamp(record: Record): Instant
+}
+
+object IcebergTimestampExtractor {
+
+  val epoch: IcebergTimestampExtractor = constant(Instant.EPOCH)
+
+  def constant(timestamp: Instant): IcebergTimestampExtractor = {
+    ConstantIcebergTimestampExtractor(timestamp)
+  }
+
+  def field(fieldName: String): IcebergTimestampExtractor = {
+    FieldIcebergTimestampExtractor(fieldName)
+  }
+
+  private final case class ConstantIcebergTimestampExtractor(timestampValue: Instant)
+    extends IcebergTimestampExtractor {
+
+    override def timestamp(record: Record): Instant = timestampValue
+  }
+
+  private final case class FieldIcebergTimestampExtractor(fieldName: String)
+    extends IcebergTimestampExtractor {
+
+    override def timestamp(record: Record): Instant = {
+      record.getField(fieldName) match {
+        case instant: Instant =>
+          instant
+        case offsetDateTime: OffsetDateTime =>
+          offsetDateTime.toInstant
+        case localDateTime: LocalDateTime =>
+          localDateTime.toInstant(ZoneOffset.UTC)
+        case timestamp: Timestamp =>
+          timestamp.toInstant
+        case millis: java.lang.Long =>
+          Instant.ofEpochMilli(millis.longValue())
+        case value =>
+          throw new IllegalArgumentException(
+            s"Unsupported Iceberg timestamp value for field '$fieldName': ${value}")
+      }
+    }
+  }
+}

--- a/gearpump-external-iceberg/src/test/scala/io/gearpump/external/iceberg/IcebergSinkSpec.scala
+++ b/gearpump-external-iceberg/src/test/scala/io/gearpump/external/iceberg/IcebergSinkSpec.scala
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gearpump.external.iceberg
+
+import io.gearpump.Message
+import java.nio.file.{Files, Path}
+import org.apache.iceberg.PartitionSpec
+import org.apache.iceberg.data.{GenericRecord, IcebergGenerics, Record}
+import org.apache.iceberg.types.Types
+import org.apache.iceberg.Schema
+import org.scalatest.{Matchers, PropSpec}
+import scala.jdk.CollectionConverters._
+
+class IcebergSinkSpec extends PropSpec with Matchers {
+
+  private val schema = new Schema(
+    Types.NestedField.required(1, "id", Types.LongType.get()),
+    Types.NestedField.required(2, "data", Types.StringType.get()),
+    Types.NestedField.optional(3, "event_millis", Types.LongType.get()))
+
+  property("IcebergSink should create a table and append records") {
+    withTempDirectory("gearpump-iceberg-sink") { tableDir =>
+      val tableConfig = IcebergTableConfig.forNewTable(tableDir.toString, schema)
+      val sink = new IcebergSink(tableConfig)
+      sink.open(IcebergTestSupport.mockTaskContext)
+      sink.write(Message(newRecord(1L, "alpha", 1000L)))
+      sink.write(Message(newRecord(2L, "beta", 2000L)))
+      sink.close()
+
+      val actual = readAll(tableConfig).map(_.getField("data").toString)
+      actual shouldBe Seq("alpha", "beta")
+    }
+  }
+
+  property("IcebergSink should reject partitioned tables") {
+    withTempDirectory("gearpump-iceberg-partitioned-sink") { tableDir =>
+      val partitionSpec = PartitionSpec.builderFor(schema).identity("data").build()
+      val tableConfig =
+        IcebergTableConfig.forNewTable(tableDir.toString, schema, partitionSpec = partitionSpec)
+      val sink = new IcebergSink(tableConfig)
+
+      val exception = the [UnsupportedOperationException] thrownBy {
+        sink.open(IcebergTestSupport.mockTaskContext)
+      }
+
+      exception.getMessage should include ("unpartitioned")
+    }
+  }
+
+  private def newRecord(id: Long, data: String, eventMillis: Long): Record = {
+    val record = GenericRecord.create(schema)
+    record.setField("id", id)
+    record.setField("data", data)
+    record.setField("event_millis", eventMillis)
+    record
+  }
+
+  private def readAll(tableConfig: IcebergTableConfig): Seq[Record] = {
+    val records = IcebergGenerics.read(tableConfig.loadTable()).build()
+    try {
+      records.iterator().asScala.toVector
+    } finally {
+      records.close()
+    }
+  }
+
+  private def withTempDirectory[A](prefix: String)(f: Path => A): A = {
+    val dir = Files.createTempDirectory(prefix)
+    try {
+      f(dir)
+    } finally {
+      deleteRecursively(dir)
+    }
+  }
+
+  private def deleteRecursively(path: Path): Unit = {
+    val walk = Files.walk(path)
+    try {
+      walk.iterator().asScala.toSeq
+        .sortBy(_.getNameCount)(Ordering[Int].reverse)
+        .foreach(Files.deleteIfExists)
+    } finally {
+      walk.close()
+    }
+  }
+}

--- a/gearpump-external-iceberg/src/test/scala/io/gearpump/external/iceberg/IcebergSourceSpec.scala
+++ b/gearpump-external-iceberg/src/test/scala/io/gearpump/external/iceberg/IcebergSourceSpec.scala
@@ -1,0 +1,103 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gearpump.external.iceberg
+
+import io.gearpump.streaming.source.Watermark
+import io.gearpump.Message
+import java.nio.file.{Files, Path}
+import java.time.Instant
+import org.apache.iceberg.Schema
+import org.apache.iceberg.data.{GenericRecord, Record}
+import org.apache.iceberg.types.Types
+import org.scalatest.{Matchers, PropSpec}
+import scala.jdk.CollectionConverters._
+
+class IcebergSourceSpec extends PropSpec with Matchers {
+
+  private val schema = new Schema(
+    Types.NestedField.required(1, "id", Types.LongType.get()),
+    Types.NestedField.required(2, "data", Types.StringType.get()),
+    Types.NestedField.required(3, "event_millis", Types.LongType.get()))
+
+  property("IcebergSource should scan snapshot records as a bounded source") {
+    withTempDirectory("gearpump-iceberg-source") { tableDir =>
+      val createConfig = IcebergTableConfig.forNewTable(tableDir.toString, schema)
+      appendRecords(createConfig, Seq(
+        newRecord(1L, "alpha", 1000L),
+        newRecord(2L, "beta", 2500L)))
+
+      val source = new IcebergSource(
+        IcebergTableConfig.forTable(tableDir.toString),
+        timestampExtractor = new IcebergTimestampExtractor {
+          override def timestamp(record: Record): Instant = {
+            Instant.ofEpochMilli(record.getField("event_millis").asInstanceOf[Long])
+          }
+        })
+
+      source.open(IcebergTestSupport.mockTaskContext, Instant.EPOCH)
+      source.getWatermark shouldBe Watermark.MIN
+
+      val first = source.read()
+      first.value.asInstanceOf[Record].getField("data") shouldBe "alpha"
+      first.timestamp shouldBe Instant.ofEpochMilli(1000L)
+      source.getWatermark shouldBe Watermark.MIN
+
+      val second = source.read()
+      second.value.asInstanceOf[Record].getField("data") shouldBe "beta"
+      second.timestamp shouldBe Instant.ofEpochMilli(2500L)
+
+      source.read() shouldBe null
+      source.getWatermark shouldBe Watermark.MAX
+      source.close()
+    }
+  }
+
+  private def appendRecords(tableConfig: IcebergTableConfig, records: Seq[Record]): Unit = {
+    val sink = new IcebergSink(tableConfig)
+    sink.open(IcebergTestSupport.mockTaskContext)
+    records.foreach { record =>
+      sink.write(Message(record))
+    }
+    sink.close()
+  }
+
+  private def newRecord(id: Long, data: String, eventMillis: Long): Record = {
+    val record = GenericRecord.create(schema)
+    record.setField("id", id)
+    record.setField("data", data)
+    record.setField("event_millis", eventMillis)
+    record
+  }
+
+  private def withTempDirectory[A](prefix: String)(f: Path => A): A = {
+    val dir = Files.createTempDirectory(prefix)
+    try {
+      f(dir)
+    } finally {
+      deleteRecursively(dir)
+    }
+  }
+
+  private def deleteRecursively(path: Path): Unit = {
+    val walk = Files.walk(path)
+    try {
+      walk.iterator().asScala.toSeq
+        .sortBy(_.getNameCount)(Ordering[Int].reverse)
+        .foreach(Files.deleteIfExists)
+    } finally {
+      walk.close()
+    }
+  }
+}

--- a/gearpump-external-iceberg/src/test/scala/io/gearpump/external/iceberg/IcebergTestSupport.scala
+++ b/gearpump-external-iceberg/src/test/scala/io/gearpump/external/iceberg/IcebergTestSupport.scala
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gearpump.external.iceberg
+
+import io.gearpump.Message
+import io.gearpump.streaming.task.{TaskContext, TaskId}
+import java.time.Instant
+import org.apache.pekko.actor.{Actor, ActorRef, ActorSystem, Cancellable, Props}
+import org.slf4j.{Logger, LoggerFactory}
+import scala.concurrent.duration.FiniteDuration
+
+private object IcebergTestSupport {
+
+  private lazy val system = ActorSystem("iceberg-test-support")
+  private lazy val inbox = system.actorOf(Props(new Actor {
+    override def receive: Receive = {
+      case _ =>
+    }
+  }))
+
+  def mockTaskContext: TaskContext = new TaskContext {
+    override val taskId: TaskId = TaskId(0, 0)
+    override val executorId: Int = 0
+    override val appId: Int = 0
+    override val appName: String = "iceberg-test"
+    override val appMaster: ActorRef = inbox
+    override val parallelism: Int = 1
+    override val self: ActorRef = inbox
+    override val sender: ActorRef = inbox
+    override val upstreamMinClock: Long = 0L
+    override val logger: Logger = LoggerFactory.getLogger(getClass)
+    override val system: ActorSystem = IcebergTestSupport.system
+
+    override def output(msg: Message): Unit = {}
+
+    override def actorOf(props: Props): ActorRef = inbox
+
+    override def actorOf(props: Props, name: String): ActorRef = inbox
+
+    override def schedule(initialDelay: FiniteDuration, interval: FiniteDuration)(
+        f: => Unit): Cancellable = throw new UnsupportedOperationException
+
+    override def scheduleOnce(initialDelay: FiniteDuration)(
+        f: => Unit): Cancellable = throw new UnsupportedOperationException
+
+    override def updateWatermark(watermark: Instant): Unit = {}
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -45,6 +45,7 @@ object Dependencies {
   val scalaCheckVersion = "1.14.0"
   val mockitoVersion = "1.10.17"
   val beamVersion = "2.73.0"
+  val icebergVersion = "1.8.1"
   val snappyJavaVersion = "1.1.10.7"
   val bijectionVersion = "0.8.0"
   val scalazVersion = "7.1.1"
@@ -118,5 +119,21 @@ object Dependencies {
       "junit" % "junit" % junitVersion % "test",
       "com.github.sbt" % "junit-interface" % junitInterfaceVersion % "test"
     ) ++ annotationDependencies
+  )
+
+  val icebergDependencies = Seq(
+    libraryDependencies ++= Seq(
+      "org.apache.iceberg" % "iceberg-api" % icebergVersion,
+      "org.apache.iceberg" % "iceberg-core" % icebergVersion,
+      "org.apache.iceberg" % "iceberg-data" % icebergVersion,
+      "org.apache.iceberg" % "iceberg-parquet" % icebergVersion,
+      "org.apache.hadoop" % "hadoop-common" % hadoopVersion,
+      "org.apache.hadoop" % "hadoop-hdfs" % hadoopVersion,
+      "org.apache.hadoop" % "hadoop-mapreduce-client-core" % hadoopVersion
+    ).map(_.exclude("org.slf4j", "slf4j-api"))
+      .map(_.exclude("org.slf4j", "slf4j-log4j12")) ++
+      Seq(
+        "org.scalatest" %% "scalatest" % scalaTestVersion % "test"
+      ) ++ annotationDependencies
   )
 }


### PR DESCRIPTION
## Summary
- add a new optional `gearpump-external-iceberg` module
- implement a bounded Iceberg Hadoop-table source and an append sink for unpartitioned tables
- add module tests and document the current supported scope in the connector docs

## Testing
- `sbt -Dsbt.log.noformat=true "gearpump-external-iceberg/test"`
