### PR TITLE
Upgrade Beam tests to JUnit 5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -142,9 +142,7 @@ lazy val services: Project = Project(
 lazy val beamRunner = Project(
   id = "gearpump-beam-runner",
   base = file("experiments/beam"))
-  .settings(commonSettings ++ javadocSettings ++ beamRunnerDependencies ++ Seq(
-    testFrameworks += new TestFramework("com.novocode.junit.JUnitFramework")
-  ): _*)
+  .settings(commonSettings ++ javadocSettings ++ beamRunnerDependencies: _*)
   .dependsOn(core % "provided", streaming % "provided")
 
 /**

--- a/experiments/beam/src/test/java/org/apache/beam/runners/gearpump/GearpumpRunnerIntegrationTest.java
+++ b/experiments/beam/src/test/java/org/apache/beam/runners/gearpump/GearpumpRunnerIntegrationTest.java
@@ -29,12 +29,12 @@ import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.GroupByKey;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.values.KV;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /** Embedded-runner integration tests for the low-level Gearpump Beam runner. */
 public class GearpumpRunnerIntegrationTest {
@@ -43,7 +43,7 @@ public class GearpumpRunnerIntegrationTest {
 
   private GearpumpPipelineOptions options;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     CAPTURED.clear();
     options = PipelineOptionsFactory.create().as(GearpumpPipelineOptions.class);
@@ -52,7 +52,7 @@ public class GearpumpRunnerIntegrationTest {
     options.setParallelism(1);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     CAPTURED.clear();
   }

--- a/experiments/beam/src/test/java/org/apache/beam/runners/gearpump/GearpumpRunnerTest.java
+++ b/experiments/beam/src/test/java/org/apache/beam/runners/gearpump/GearpumpRunnerTest.java
@@ -27,10 +27,10 @@ import org.apache.beam.sdk.PipelineResult;
 import org.apache.pekko.actor.ActorRef;
 import org.apache.pekko.util.Timeout;
 import org.joda.time.Duration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class GearpumpRunnerTest {
 

--- a/experiments/beam/src/test/java/org/apache/beam/runners/gearpump/translators/GearpumpPipelineTranslatorTest.java
+++ b/experiments/beam/src/test/java/org/apache/beam/runners/gearpump/translators/GearpumpPipelineTranslatorTest.java
@@ -34,15 +34,15 @@ import org.apache.beam.sdk.transforms.GroupByKey;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.values.KV;
 import org.apache.pekko.actor.ActorSystem;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import scala.collection.JavaConverters;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Tests for low-level Beam-to-Gearpump graph translation. */
 public class GearpumpPipelineTranslatorTest {
@@ -50,7 +50,7 @@ public class GearpumpPipelineTranslatorTest {
   private ActorSystem actorSystem;
   private GearpumpPipelineOptions options;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     options = PipelineOptionsFactory.as(GearpumpPipelineOptions.class);
     options.setParallelism(1);
@@ -58,7 +58,7 @@ public class GearpumpPipelineTranslatorTest {
     actorSystem = ActorSystem.create("beam-runner-translator-test", config);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     actorSystem.terminate();
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -29,8 +29,8 @@ object Dependencies {
   val commonsIOVersion = "2.4"
   val dataReplicationVersion = "0.7"
   val upickleVersion = "0.9.9"
-  val junitVersion = "4.12"
-  val junitInterfaceVersion = "0.13.3"
+  val junitJupiterVersion = "5.14.4"
+  val jupiterInterfaceVersion = "0.16.0"
   val jsonSimpleVersion = "1.1"
   val slf4jVersion = "1.7.16"
   val slf4jSimpleVersion = "2.0.17"
@@ -104,7 +104,8 @@ object Dependencies {
       "org.scalatest" %% "scalatest" % scalaTestVersion % "test",
       "org.scalacheck" %% "scalacheck" % scalaCheckVersion % "test",
       "org.mockito" % "mockito-core" % mockitoVersion % "test",
-      "junit" % "junit" % junitVersion % "test"
+      "org.junit.jupiter" % "junit-jupiter" % junitJupiterVersion % "test",
+      "com.github.sbt.junit" % "jupiter-interface" % jupiterInterfaceVersion % "test"
     ) ++ annotationDependencies ++ compilerDependencies
   )
 
@@ -115,8 +116,8 @@ object Dependencies {
       // Override Beam's transitive snappy-java so Java 17 tests work on macOS/aarch64.
       "org.xerial.snappy" % "snappy-java" % snappyJavaVersion,
       "org.slf4j" % "slf4j-simple" % slf4jSimpleVersion % "test",
-      "junit" % "junit" % junitVersion % "test",
-      "com.github.sbt" % "junit-interface" % junitInterfaceVersion % "test"
+      "org.junit.jupiter" % "junit-jupiter" % junitJupiterVersion % "test",
+      "com.github.sbt.junit" % "jupiter-interface" % jupiterInterfaceVersion % "test"
     ) ++ annotationDependencies
   )
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -17,3 +17,5 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.3")
 
 addSbtPlugin("org.scalastyle" % "scalastyle-sbt-plugin" % "1.0.0")
+
+addSbtPlugin("com.github.sbt.junit" % "sbt-jupiter-interface" % "0.16.0")


### PR DESCRIPTION
### Motivation
- Move Beam runner tests and build tooling from JUnit 4 / Novocode `junit-interface` to JUnit Jupiter so tests use modern JUnit 5 APIs and can run with the sbt JUnit 5 integration. 
- Remove an explicit legacy Novocode `JUnitFramework` test framework registration in the Beam runner project which is unnecessary with the sbt JUnit Jupiter plugin. 
- Update Java test sources to use JUnit Jupiter annotations and assertions for consistency and to avoid mixing JUnit 4 and JUnit 5 APIs.

### Description
- Replaced JUnit 4 variables and dependencies in `project/Dependencies.scala` with `junit-jupiter` (`5.14.4`) and `jupiter-interface` (`0.16.0`) test dependencies. 
- Added the sbt plugin `sbt-jupiter-interface` to `project/plugins.sbt` and removed the explicit `com.novocode.junit.JUnitFramework` test framework line from `build.sbt` for the `beamRunner` project. 
- Migrated Beam runner Java tests under `experiments/beam/src/test/java/org/apache/beam/runners/gearpump/` to JUnit Jupiter by replacing `org.junit` imports with `org.junit.jupiter.api` annotations and switching assertions to `org.junit.jupiter.api.Assertions`. 

### Testing
- Ran `git diff --check` to ensure no whitespace or index errors and it passed. 
- Searched the tree with `rg` for legacy JUnit 4 symbols and explicit `JUnitFramework` usage and confirmed there are no remaining JUnit 4 API references outside historical license text. 
- Attempted `sbt 'beamRunner / Test / compile'` to compile tests but compilation was not run because `sbt` is not installed in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ac4f202588330ac4feee2fd4e387d)