### PR TITLE
[codex] Enable Dependabot for sbt

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,5 @@
 version: 2
+enable-beta-ecosystems: true
 updates:
   - package-ecosystem: github-actions
     directory: "/"
@@ -14,3 +15,13 @@ updates:
       github-actions:
         patterns:
           - "*"
+  - package-ecosystem: sbt
+    directory: "/"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: build
+    labels:
+      - dependencies
+      - sbt
+    open-pull-requests-limit: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,4 +24,3 @@ updates:
     labels:
       - dependencies
       - sbt
-    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary
- Enable Dependabot beta ecosystems for the repository.
- Add a weekly Dependabot updater for the sbt ecosystem at the repository root.

## Validation
- Parsed `.github/dependabot.yml` with Ruby YAML.
- Verified the beta flag and sbt updater are present.
- Ran `git diff --check -- .github/dependabot.yml`.