### PR TITLE
fix: resolve build failure after ScalaTest bump by pinning to 3.2.19

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -41,7 +41,7 @@ object Dependencies {
   val gsCollectionsVersion = "6.2.0"
   val sprayVersion = "1.3.2"
   val sprayJsonVersion = "1.3.1"
-  val scalaTestVersion = "3.2.20"
+  val scalaTestVersion = "3.2.19"
   val scalaCheckVersion = "1.14.0"
   val mockitoVersion = "1.10.17"
   val beamVersion = "2.73.0"


### PR DESCRIPTION
### Motivation

- The dependency bump to ScalaTest `3.2.20` caused a build/test regression in this repository context, so a targeted rollback was needed to restore the known-good test dependency.

### Description

- Changed `scalaTestVersion` from `"3.2.20"` to `"3.2.19"` in `project/Dependencies.scala`.
- Created a commit with message `build: pin scalatest to 3.2.19 to fix CI` and opened a follow-up PR titled `fix: resolve build failure after ScalaTest bump by pinning to 3.2.19`.

### Testing

- Attempted to run `sbt test` in the workspace but the command failed because `sbt` is not installed in the execution environment (`/bin/bash: line 1: sbt: command not found`).
- No other automated tests were executed in this environment after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e931b73308330b787e17ebe697f9a)