### PR TITLE
Migrate tests to ScalaTest 3.2+ APIs (AnyFlatSpec/AnyWordSpec and should.Matchers)

### DIFF
--- a/core/src/test/scala/io/gearpump/cluster/ApplicationStatusSpec.scala
+++ b/core/src/test/scala/io/gearpump/cluster/ApplicationStatusSpec.scala
@@ -13,9 +13,11 @@
  */
 package io.gearpump.cluster
 
-import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class ApplicationStatusSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
+class ApplicationStatusSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEach {
 
   "ApplicationStatus" should "check status transition properly" in {
     val pending = ApplicationStatus.PENDING

--- a/core/src/test/scala/io/gearpump/cluster/appmaster/AppManagerSpec.scala
+++ b/core/src/test/scala/io/gearpump/cluster/appmaster/AppManagerSpec.scala
@@ -27,10 +27,12 @@ import io.gearpump.cluster.master.AppManager._
 import io.gearpump.cluster.master.InMemoryKVService.{GetKV, GetKVSuccess, PutKV, PutKVSuccess}
 import io.gearpump.cluster.worker.WorkerId
 import io.gearpump.util.LogUtil
-import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import scala.util.Success
 
-class AppManagerSpec extends FlatSpec with Matchers with BeforeAndAfterEach with MasterHarness {
+class AppManagerSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEach with MasterHarness {
   var kvService: TestProbe = null
   var haService: TestProbe = null
   var appLauncher: TestProbe = null

--- a/core/src/test/scala/io/gearpump/cluster/appmaster/AppMasterRuntimeEnvironmentSpec.scala
+++ b/core/src/test/scala/io/gearpump/cluster/appmaster/AppMasterRuntimeEnvironmentSpec.scala
@@ -23,11 +23,13 @@ import io.gearpump.cluster.appmaster.AppMasterRuntimeEnvironment._
 import io.gearpump.cluster.appmaster.AppMasterRuntimeEnvironmentSpec.TestAppMasterEnv
 import io.gearpump.cluster.appmaster.ExecutorSystemScheduler.StartExecutorSystems
 import io.gearpump.cluster.appmaster.MasterConnectionKeeper.MasterConnectionStatus.{MasterConnected, MasterStopped}
-import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-class AppMasterRuntimeEnvironmentSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
+class AppMasterRuntimeEnvironmentSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
   implicit var system: ActorSystem = null
 
   override def beforeAll(): Unit = {

--- a/core/src/test/scala/io/gearpump/cluster/appmaster/ExecutorSystemLauncherSpec.scala
+++ b/core/src/test/scala/io/gearpump/cluster/appmaster/ExecutorSystemLauncherSpec.scala
@@ -26,11 +26,13 @@ import io.gearpump.cluster.scheduler.Resource
 import io.gearpump.cluster.worker.WorkerId
 import io.gearpump.util.ActorSystemBooter.{ActorSystemRegistered, RegisterActorSystem}
 import io.gearpump.util.Constants
-import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class ExecutorSystemLauncherSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
+class ExecutorSystemLauncherSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
   implicit var system: ActorSystem = null
   val workerId: WorkerId = WorkerId(0, 0L)
   val appId = 0

--- a/core/src/test/scala/io/gearpump/cluster/appmaster/ExecutorSystemSchedulerSpec.scala
+++ b/core/src/test/scala/io/gearpump/cluster/appmaster/ExecutorSystemSchedulerSpec.scala
@@ -25,11 +25,13 @@ import io.gearpump.cluster.appmaster.ExecutorSystemSchedulerSpec.{ExecutorSystem
 import io.gearpump.cluster.scheduler.{Resource, ResourceAllocation, ResourceRequest}
 import io.gearpump.cluster.worker.WorkerId
 import io.gearpump.jarstore.FilePath
-import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class ExecutorSystemSchedulerSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
+class ExecutorSystemSchedulerSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEach {
   val appId = 0
   val workerId = WorkerId(0, 0L)
   val resource = Resource(1)

--- a/core/src/test/scala/io/gearpump/cluster/appmaster/InMemoryKVServiceSpec.scala
+++ b/core/src/test/scala/io/gearpump/cluster/appmaster/InMemoryKVServiceSpec.scala
@@ -20,11 +20,13 @@ import com.typesafe.config.Config
 import io.gearpump.cluster.{MasterHarness, TestUtil}
 import io.gearpump.cluster.master.InMemoryKVService
 import io.gearpump.cluster.master.InMemoryKVService._
-import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import scala.concurrent.duration._
 
 class InMemoryKVServiceSpec
-  extends FlatSpec with Matchers with BeforeAndAfterEach with MasterHarness {
+  extends AnyFlatSpec with Matchers with BeforeAndAfterEach with MasterHarness {
 
   override def beforeEach(): Unit = {
     startActorSystem()

--- a/core/src/test/scala/io/gearpump/cluster/appmaster/MasterConnectionKeeperSpec.scala
+++ b/core/src/test/scala/io/gearpump/cluster/appmaster/MasterConnectionKeeperSpec.scala
@@ -22,11 +22,13 @@ import io.gearpump.cluster.TestUtil
 import io.gearpump.cluster.appmaster.MasterConnectionKeeper.MasterConnectionStatus.{MasterConnected, _}
 import io.gearpump.cluster.appmaster.MasterConnectionKeeperSpec.ConnectionKeeperTestEnv
 import io.gearpump.cluster.master.MasterProxy.WatchMaster
-import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class MasterConnectionKeeperSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
+class MasterConnectionKeeperSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
 
   implicit var system: ActorSystem = null
   val appId = 0

--- a/core/src/test/scala/io/gearpump/cluster/client/RunningApplicationSpec.scala
+++ b/core/src/test/scala/io/gearpump/cluster/client/RunningApplicationSpec.scala
@@ -22,13 +22,15 @@ import io.gearpump.cluster.MasterToClient.{ResolveAppIdResult, ShutdownApplicati
 import io.gearpump.cluster.TestUtil
 import io.gearpump.cluster.client.RunningApplicationSpec.{MockAskAppMasterRequest, MockAskAppMasterResponse}
 import java.util.concurrent.TimeUnit
-import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import scala.concurrent.{Await, Future}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.Duration
 import scala.util.{Failure, Success}
 
-class RunningApplicationSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
+class RunningApplicationSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
   implicit var system: ActorSystem = _
 
   override def beforeAll(): Unit = {

--- a/core/src/test/scala/io/gearpump/cluster/main/ArgumentParserSpec.scala
+++ b/core/src/test/scala/io/gearpump/cluster/main/ArgumentParserSpec.scala
@@ -14,9 +14,10 @@
 
 package io.gearpump.cluster.main
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class ArgumentParserSpec extends FlatSpec with Matchers {
+class ArgumentParserSpec extends AnyFlatSpec with Matchers {
   it should "parse arguments correctly" in {
 
     val parser = new ArgumentsParser {

--- a/core/src/test/scala/io/gearpump/cluster/main/MainSpec.scala
+++ b/core/src/test/scala/io/gearpump/cluster/main/MainSpec.scala
@@ -27,7 +27,9 @@ import io.gearpump.transport.HostPort
 import io.gearpump.util.{Constants, LogUtil, Util}
 import io.gearpump.util.Constants._
 import java.util.Properties
-import org.scalatest._
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import scala.concurrent.Future
 import scala.util.Success
 

--- a/core/src/test/scala/io/gearpump/cluster/main/MainSpec.scala
+++ b/core/src/test/scala/io/gearpump/cluster/main/MainSpec.scala
@@ -31,7 +31,7 @@ import org.scalatest._
 import scala.concurrent.Future
 import scala.util.Success
 
-class MainSpec extends FlatSpec with Matchers with BeforeAndAfterEach with MasterHarness {
+class MainSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEach with MasterHarness {
 
   private val LOG = LogUtil.getLogger(getClass)
 

--- a/core/src/test/scala/io/gearpump/cluster/main/MasterWatcherSpec.scala
+++ b/core/src/test/scala/io/gearpump/cluster/main/MasterWatcherSpec.scala
@@ -17,11 +17,12 @@ import org.apache.pekko.actor.{ActorSystem, Props}
 import org.apache.pekko.testkit.TestProbe
 import com.typesafe.config.Config
 import io.gearpump.cluster.TestUtil
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class MasterWatcherSpec extends FlatSpec with Matchers {
+class MasterWatcherSpec extends AnyFlatSpec with Matchers {
   def config: Config = TestUtil.MASTER_CONFIG
 
   "MasterWatcher" should "kill itself when can not get a quorum" in {

--- a/core/src/test/scala/io/gearpump/cluster/master/AppMasterLauncherSpec.scala
+++ b/core/src/test/scala/io/gearpump/cluster/master/AppMasterLauncherSpec.scala
@@ -26,10 +26,12 @@ import io.gearpump.cluster.WorkerToAppMaster.ExecutorLaunchRejected
 import io.gearpump.cluster.scheduler.{Resource, ResourceAllocation, ResourceRequest}
 import io.gearpump.cluster.worker.WorkerId
 import io.gearpump.util.ActorSystemBooter._
-import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import scala.util.Success
 
-class AppMasterLauncherSpec extends FlatSpec with Matchers
+class AppMasterLauncherSpec extends AnyFlatSpec with Matchers
   with BeforeAndAfterEach with MasterHarness {
 
   override def config: Config = TestUtil.DEFAULT_CONFIG

--- a/core/src/test/scala/io/gearpump/cluster/master/ApplicationMetaDataSpec.scala
+++ b/core/src/test/scala/io/gearpump/cluster/master/ApplicationMetaDataSpec.scala
@@ -16,9 +16,11 @@ package io.gearpump.cluster.master
 
 import io.gearpump.cluster.AppDescription
 import io.gearpump.cluster.appmaster.ApplicationMetaData
-import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class ApplicationMetaDataSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
+class ApplicationMetaDataSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEach {
 
   "ApplicationMetaData" should "check equal with respect to only appId and attemptId" in {
     val appDescription = AppDescription("app", "AppMaster", null)

--- a/core/src/test/scala/io/gearpump/cluster/scheduler/PrioritySchedulerSpec.scala
+++ b/core/src/test/scala/io/gearpump/cluster/scheduler/PrioritySchedulerSpec.scala
@@ -24,7 +24,8 @@ import io.gearpump.cluster.master.Master.MasterInfo
 import io.gearpump.cluster.scheduler.Priority.{HIGH, LOW, NORMAL}
 import io.gearpump.cluster.scheduler.Scheduler.ApplicationFinished
 import io.gearpump.cluster.worker.WorkerId
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
+import org.scalatest.{BeforeAndAfterAll, WordSpecLike}
+import org.scalatest.matchers.should.Matchers
 import scala.concurrent.duration._
 
 class PrioritySchedulerSpec(_system: ActorSystem) extends TestKit(_system) with ImplicitSender

--- a/core/src/test/scala/io/gearpump/cluster/scheduler/PrioritySchedulerSpec.scala
+++ b/core/src/test/scala/io/gearpump/cluster/scheduler/PrioritySchedulerSpec.scala
@@ -25,12 +25,12 @@ import io.gearpump.cluster.scheduler.Priority.{HIGH, LOW, NORMAL}
 import io.gearpump.cluster.scheduler.Scheduler.ApplicationFinished
 import io.gearpump.cluster.worker.WorkerId
 import org.scalatest.BeforeAndAfterAll
-import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
 import scala.concurrent.duration._
 
 class PrioritySchedulerSpec(_system: ActorSystem) extends TestKit(_system) with ImplicitSender
-  with AnyWordSpecLike with Matchers with BeforeAndAfterAll {
+  with AnyWordSpec with Matchers with BeforeAndAfterAll {
 
   def this() = this(ActorSystem("PrioritySchedulerSpec", TestUtil.DEFAULT_CONFIG))
   val appId = 0

--- a/core/src/test/scala/io/gearpump/cluster/scheduler/PrioritySchedulerSpec.scala
+++ b/core/src/test/scala/io/gearpump/cluster/scheduler/PrioritySchedulerSpec.scala
@@ -25,12 +25,12 @@ import io.gearpump.cluster.scheduler.Priority.{HIGH, LOW, NORMAL}
 import io.gearpump.cluster.scheduler.Scheduler.ApplicationFinished
 import io.gearpump.cluster.worker.WorkerId
 import org.scalatest.BeforeAndAfterAll
-import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatest.matchers.should.Matchers
 import scala.concurrent.duration._
 
 class PrioritySchedulerSpec(_system: ActorSystem) extends TestKit(_system) with ImplicitSender
-  with AnyWordSpec with Matchers with BeforeAndAfterAll{
+  with AnyWordSpecLike with Matchers with BeforeAndAfterAll{
 
   def this() = this(ActorSystem("PrioritySchedulerSpec", TestUtil.DEFAULT_CONFIG))
   val appId = 0

--- a/core/src/test/scala/io/gearpump/cluster/scheduler/PrioritySchedulerSpec.scala
+++ b/core/src/test/scala/io/gearpump/cluster/scheduler/PrioritySchedulerSpec.scala
@@ -25,12 +25,12 @@ import io.gearpump.cluster.scheduler.Priority.{HIGH, LOW, NORMAL}
 import io.gearpump.cluster.scheduler.Scheduler.ApplicationFinished
 import io.gearpump.cluster.worker.WorkerId
 import org.scalatest.BeforeAndAfterAll
-import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatest.matchers.should.Matchers
 import scala.concurrent.duration._
 
 class PrioritySchedulerSpec(_system: ActorSystem) extends TestKit(_system) with ImplicitSender
-  with AnyWordSpec with Matchers with BeforeAndAfterAll {
+  with AnyWordSpecLike with Matchers with BeforeAndAfterAll {
 
   def this() = this(ActorSystem("PrioritySchedulerSpec", TestUtil.DEFAULT_CONFIG))
   val appId = 0

--- a/core/src/test/scala/io/gearpump/cluster/scheduler/PrioritySchedulerSpec.scala
+++ b/core/src/test/scala/io/gearpump/cluster/scheduler/PrioritySchedulerSpec.scala
@@ -24,12 +24,13 @@ import io.gearpump.cluster.master.Master.MasterInfo
 import io.gearpump.cluster.scheduler.Priority.{HIGH, LOW, NORMAL}
 import io.gearpump.cluster.scheduler.Scheduler.ApplicationFinished
 import io.gearpump.cluster.worker.WorkerId
-import org.scalatest.{BeforeAndAfterAll, WordSpecLike}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
 import scala.concurrent.duration._
 
 class PrioritySchedulerSpec(_system: ActorSystem) extends TestKit(_system) with ImplicitSender
-  with WordSpecLike with Matchers with BeforeAndAfterAll{
+  with AnyWordSpec with Matchers with BeforeAndAfterAll{
 
   def this() = this(ActorSystem("PrioritySchedulerSpec", TestUtil.DEFAULT_CONFIG))
   val appId = 0

--- a/core/src/test/scala/io/gearpump/cluster/scheduler/PrioritySchedulerSpec.scala
+++ b/core/src/test/scala/io/gearpump/cluster/scheduler/PrioritySchedulerSpec.scala
@@ -30,7 +30,7 @@ import org.scalatest.matchers.should.Matchers
 import scala.concurrent.duration._
 
 class PrioritySchedulerSpec(_system: ActorSystem) extends TestKit(_system) with ImplicitSender
-  with AnyWordSpecLike with Matchers with BeforeAndAfterAll{
+  with AnyWordSpecLike with Matchers with BeforeAndAfterAll {
 
   def this() = this(ActorSystem("PrioritySchedulerSpec", TestUtil.DEFAULT_CONFIG))
   val appId = 0

--- a/core/src/test/scala/io/gearpump/cluster/worker/WorkerSpec.scala
+++ b/core/src/test/scala/io/gearpump/cluster/worker/WorkerSpec.scala
@@ -28,7 +28,7 @@ import org.scalatest._
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class WorkerSpec extends WordSpec with Matchers with BeforeAndAfterEach with MasterHarness {
+class WorkerSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach with MasterHarness {
   override def config: Config = TestUtil.DEFAULT_CONFIG
 
   val appId = 1

--- a/core/src/test/scala/io/gearpump/cluster/worker/WorkerSpec.scala
+++ b/core/src/test/scala/io/gearpump/cluster/worker/WorkerSpec.scala
@@ -24,7 +24,9 @@ import io.gearpump.cluster.WorkerToMaster.{RegisterNewWorker, RegisterWorker, Re
 import io.gearpump.cluster.master.Master.MasterInfo
 import io.gearpump.cluster.scheduler.Resource
 import io.gearpump.util.{ActorSystemBooter, ActorUtil, Constants}
-import org.scalatest._
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import scala.concurrent.Await
 import scala.concurrent.duration._
 

--- a/core/src/test/scala/io/gearpump/jarstore/FileServerSpec.scala
+++ b/core/src/test/scala/io/gearpump/jarstore/FileServerSpec.scala
@@ -23,12 +23,13 @@ import io.gearpump.jarstore.local.LocalJarStore
 import io.gearpump.util.{FileUtils, LogUtil}
 import java.io.File
 import java.util.concurrent.TimeUnit
-import org.scalatest.{BeforeAndAfterAll, WordSpecLike}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-class FileServerSpec extends WordSpecLike with Matchers with BeforeAndAfterAll {
+class FileServerSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll {
 
   implicit val timeout: org.apache.pekko.util.Timeout =
     org.apache.pekko.util.Timeout(25, TimeUnit.SECONDS)

--- a/core/src/test/scala/io/gearpump/jarstore/FileServerSpec.scala
+++ b/core/src/test/scala/io/gearpump/jarstore/FileServerSpec.scala
@@ -23,7 +23,8 @@ import io.gearpump.jarstore.local.LocalJarStore
 import io.gearpump.util.{FileUtils, LogUtil}
 import java.io.File
 import java.util.concurrent.TimeUnit
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
+import org.scalatest.{BeforeAndAfterAll, WordSpecLike}
+import org.scalatest.matchers.should.Matchers
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 

--- a/core/src/test/scala/io/gearpump/metrics/MetricsSpec.scala
+++ b/core/src/test/scala/io/gearpump/metrics/MetricsSpec.scala
@@ -19,7 +19,7 @@ import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.mockito.MockitoSugar
+import io.gearpump.testkit.MockitoSugar
 
 
 class MetricsSpec extends AnyFlatSpec with Matchers with MockitoSugar {

--- a/core/src/test/scala/io/gearpump/metrics/MetricsSpec.scala
+++ b/core/src/test/scala/io/gearpump/metrics/MetricsSpec.scala
@@ -17,11 +17,12 @@ package io.gearpump.metrics
 import com.codahale.metrics.{Counter => CodaHaleCounter, Histogram => CodaHaleHistogram, Meter => CodaHaleMeter}
 import org.mockito.Matchers._
 import org.mockito.Mockito._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.mockito.MockitoSugar
 
 
-class MetricsSpec extends FlatSpec with Matchers with MockitoSugar {
+class MetricsSpec extends AnyFlatSpec with Matchers with MockitoSugar {
 
   "Counter" should "handle sampleRate == 1" in {
 

--- a/core/src/test/scala/io/gearpump/security/ConfigFileBasedAuthenticatorSpec.scala
+++ b/core/src/test/scala/io/gearpump/security/ConfigFileBasedAuthenticatorSpec.scala
@@ -16,11 +16,12 @@ package io.gearpump.security
 
 import org.apache.pekko.actor.ActorSystem
 import io.gearpump.cluster.TestUtil
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class ConfigFileBasedAuthenticatorSpec extends FlatSpec with Matchers {
+class ConfigFileBasedAuthenticatorSpec extends AnyFlatSpec with Matchers {
   it should "authenticate correctly" in {
     val config = TestUtil.UI_CONFIG
     implicit val system = ActorSystem("ConfigFileBasedAuthenticatorSpec", config)

--- a/core/src/test/scala/io/gearpump/security/PasswordUtilSpec.scala
+++ b/core/src/test/scala/io/gearpump/security/PasswordUtilSpec.scala
@@ -14,9 +14,10 @@
 
 package io.gearpump.security
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class PasswordUtilSpec extends FlatSpec with Matchers {
+class PasswordUtilSpec extends AnyFlatSpec with Matchers {
 
   it should "verify the credential correctly" in {
     val password = "password"

--- a/core/src/test/scala/io/gearpump/serializer/SerializerSpec.scala
+++ b/core/src/test/scala/io/gearpump/serializer/SerializerSpec.scala
@@ -20,14 +20,15 @@ import com.esotericsoftware.kryo.kryo5.io.{Input, Output}
 import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
 import io.gearpump.cluster.TestUtil
 import io.gearpump.serializer.SerializerSpec._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.mockito.MockitoSugar
 import scala.jdk.CollectionConverters._
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
 
-class SerializerSpec extends FlatSpec with Matchers with MockitoSugar {
+class SerializerSpec extends AnyFlatSpec with Matchers with MockitoSugar {
   val config = ConfigFactory.empty.withValue("gearpump.serializers",
     ConfigValueFactory.fromAnyRef(Map(classOf[ClassA].getName -> classOf[ClassASerializer].getName,
       classOf[ClassB].getName -> classOf[ClassBSerializer].getName).asJava))

--- a/core/src/test/scala/io/gearpump/serializer/SerializerSpec.scala
+++ b/core/src/test/scala/io/gearpump/serializer/SerializerSpec.scala
@@ -22,7 +22,7 @@ import io.gearpump.cluster.TestUtil
 import io.gearpump.serializer.SerializerSpec._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.mockito.MockitoSugar
+import io.gearpump.testkit.MockitoSugar
 import scala.jdk.CollectionConverters._
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration

--- a/core/src/test/scala/io/gearpump/testkit/MockitoSugar.scala
+++ b/core/src/test/scala/io/gearpump/testkit/MockitoSugar.scala
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gearpump.testkit
+
+import scala.reflect.ClassTag
+
+trait MockitoSugar {
+  def mock[T <: AnyRef](implicit classTag: ClassTag[T]): T = {
+    org.mockito.Mockito.mock(classTag.runtimeClass.asInstanceOf[Class[T]])
+  }
+}

--- a/core/src/test/scala/io/gearpump/transport/NettySpec.scala
+++ b/core/src/test/scala/io/gearpump/transport/NettySpec.scala
@@ -21,12 +21,13 @@ import io.gearpump.transport.MockTransportSerializer.NettyMessage
 import io.gearpump.transport.netty.{Context, TaskMessage}
 import io.gearpump.util.Util
 import java.util.concurrent.TimeUnit
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.mockito.MockitoSugar
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class NettySpec extends FlatSpec with Matchers with MockitoSugar {
+class NettySpec extends AnyFlatSpec with Matchers with MockitoSugar {
 
   "Netty Transport" should "send and receive message correctly " in {
     val conf = TestUtil.DEFAULT_CONFIG

--- a/core/src/test/scala/io/gearpump/transport/NettySpec.scala
+++ b/core/src/test/scala/io/gearpump/transport/NettySpec.scala
@@ -23,7 +23,7 @@ import io.gearpump.util.Util
 import java.util.concurrent.TimeUnit
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.mockito.MockitoSugar
+import io.gearpump.testkit.MockitoSugar
 import scala.concurrent.Await
 import scala.concurrent.duration._
 

--- a/core/src/test/scala/io/gearpump/util/ActorSystemBooterSpec.scala
+++ b/core/src/test/scala/io/gearpump/util/ActorSystemBooterSpec.scala
@@ -19,12 +19,13 @@ import org.apache.pekko.testkit.TestProbe
 import io.gearpump.cluster.TestUtil
 import io.gearpump.util.ActorSystemBooter.{ActorCreated, RegisterActorSystem, _}
 import io.gearpump.util.ActorSystemBooterSpec._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.mockito.MockitoSugar
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-class ActorSystemBooterSpec extends FlatSpec with Matchers with MockitoSugar {
+class ActorSystemBooterSpec extends AnyFlatSpec with Matchers with MockitoSugar {
 
   "ActorSystemBooter" should "report its address back" in {
     val boot = bootSystem()

--- a/core/src/test/scala/io/gearpump/util/ActorSystemBooterSpec.scala
+++ b/core/src/test/scala/io/gearpump/util/ActorSystemBooterSpec.scala
@@ -21,7 +21,7 @@ import io.gearpump.util.ActorSystemBooter.{ActorCreated, RegisterActorSystem, _}
 import io.gearpump.util.ActorSystemBooterSpec._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.mockito.MockitoSugar
+import io.gearpump.testkit.MockitoSugar
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 

--- a/core/src/test/scala/io/gearpump/util/ActorUtilSpec.scala
+++ b/core/src/test/scala/io/gearpump/util/ActorUtilSpec.scala
@@ -15,9 +15,9 @@
 package io.gearpump.util
 
 import io.gearpump.transport.HostPort
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 
-class ActorUtilSpec extends FlatSpec {
+class ActorUtilSpec extends AnyFlatSpec {
   "masterActorPath" should "construct the ActorPath from HostPort" in {
     import Constants.MASTER
 

--- a/core/src/test/scala/io/gearpump/util/ConfigsSpec.scala
+++ b/core/src/test/scala/io/gearpump/util/ConfigsSpec.scala
@@ -19,7 +19,7 @@ import io.gearpump.cluster.{ClusterConfig, ClusterConfigSource, UserConfig}
 import java.io.File
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.mockito.MockitoSugar
+import io.gearpump.testkit.MockitoSugar
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 

--- a/core/src/test/scala/io/gearpump/util/ConfigsSpec.scala
+++ b/core/src/test/scala/io/gearpump/util/ConfigsSpec.scala
@@ -17,12 +17,13 @@ package io.gearpump.util
 import org.apache.pekko.actor.ActorSystem
 import io.gearpump.cluster.{ClusterConfig, ClusterConfigSource, UserConfig}
 import java.io.File
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.mockito.MockitoSugar
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-class ConfigsSpec extends FlatSpec with Matchers with MockitoSugar {
+class ConfigsSpec extends AnyFlatSpec with Matchers with MockitoSugar {
   "Typesafe Cluster Configs" should "follow the override rules" in {
 
     val conf =

--- a/core/src/test/scala/io/gearpump/util/FileUtilsSpec.scala
+++ b/core/src/test/scala/io/gearpump/util/FileUtilsSpec.scala
@@ -17,9 +17,9 @@ package io.gearpump.util
 import com.google.common.io.Files
 import java.io.File
 import java.util
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 
-class FileUtilsSpec extends FlatSpec {
+class FileUtilsSpec extends AnyFlatSpec {
   val TXT =
     """
       |This is a multiple line

--- a/core/src/test/scala/io/gearpump/util/GraphSpec.scala
+++ b/core/src/test/scala/io/gearpump/util/GraphSpec.scala
@@ -16,10 +16,11 @@ package io.gearpump.util
 
 import io.gearpump.util.Graph.{Node, Path}
 import org.scalacheck.Gen
-import org.scalatest.{Matchers, PropSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
 import org.scalatest.prop.PropertyChecks
 
-class GraphSpec extends PropSpec with PropertyChecks with Matchers {
+class GraphSpec extends AnyPropSpec with PropertyChecks with Matchers {
 
   case class Vertex(id: Int)
   case class Edge(from: Int, to: Int)

--- a/core/src/test/scala/io/gearpump/util/GraphSpec.scala
+++ b/core/src/test/scala/io/gearpump/util/GraphSpec.scala
@@ -18,9 +18,9 @@ import io.gearpump.util.Graph.{Node, Path}
 import org.scalacheck.Gen
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.propspec.AnyPropSpec
-import org.scalatest.prop.PropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
-class GraphSpec extends AnyPropSpec with PropertyChecks with Matchers {
+class GraphSpec extends AnyPropSpec with ScalaCheckPropertyChecks with Matchers {
 
   case class Vertex(id: Int)
   case class Edge(from: Int, to: Int)

--- a/core/src/test/scala/io/gearpump/util/RestartPolicySpec.scala
+++ b/core/src/test/scala/io/gearpump/util/RestartPolicySpec.scala
@@ -14,9 +14,10 @@
 
 package io.gearpump.util
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class RestartPolicySpec extends FlatSpec with Matchers {
+class RestartPolicySpec extends AnyFlatSpec with Matchers {
 
   "RestartPolicy" should "forbid too many restarts" in {
     val policy = new RestartPolicy(2)

--- a/core/src/test/scala/io/gearpump/util/TimeOutSchedulerSpec.scala
+++ b/core/src/test/scala/io/gearpump/util/TimeOutSchedulerSpec.scala
@@ -17,7 +17,8 @@ package io.gearpump.util
 import org.apache.pekko.actor._
 import org.apache.pekko.testkit.{ImplicitSender, TestActorRef, TestKit, TestProbe}
 import io.gearpump.cluster.TestUtil
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
+import org.scalatest.{BeforeAndAfterAll, WordSpecLike}
+import org.scalatest.matchers.should.Matchers
 import scala.concurrent.duration._
 
 class TimeOutSchedulerSpec(_system: ActorSystem) extends TestKit(_system) with ImplicitSender

--- a/core/src/test/scala/io/gearpump/util/TimeOutSchedulerSpec.scala
+++ b/core/src/test/scala/io/gearpump/util/TimeOutSchedulerSpec.scala
@@ -18,12 +18,12 @@ import org.apache.pekko.actor._
 import org.apache.pekko.testkit.{ImplicitSender, TestActorRef, TestKit, TestProbe}
 import io.gearpump.cluster.TestUtil
 import org.scalatest.BeforeAndAfterAll
-import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
 import scala.concurrent.duration._
 
 class TimeOutSchedulerSpec(_system: ActorSystem) extends TestKit(_system) with ImplicitSender
-  with AnyWordSpecLike with Matchers with BeforeAndAfterAll {
+  with AnyWordSpec with Matchers with BeforeAndAfterAll {
 
   def this() = this(ActorSystem("WorkerSpec", TestUtil.DEFAULT_CONFIG))
   val mockActor = TestProbe()

--- a/core/src/test/scala/io/gearpump/util/TimeOutSchedulerSpec.scala
+++ b/core/src/test/scala/io/gearpump/util/TimeOutSchedulerSpec.scala
@@ -17,12 +17,13 @@ package io.gearpump.util
 import org.apache.pekko.actor._
 import org.apache.pekko.testkit.{ImplicitSender, TestActorRef, TestKit, TestProbe}
 import io.gearpump.cluster.TestUtil
-import org.scalatest.{BeforeAndAfterAll, WordSpecLike}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
 import scala.concurrent.duration._
 
 class TimeOutSchedulerSpec(_system: ActorSystem) extends TestKit(_system) with ImplicitSender
-  with WordSpecLike with Matchers with BeforeAndAfterAll {
+  with AnyWordSpec with Matchers with BeforeAndAfterAll {
 
   def this() = this(ActorSystem("WorkerSpec", TestUtil.DEFAULT_CONFIG))
   val mockActor = TestProbe()

--- a/core/src/test/scala/io/gearpump/util/TimeOutSchedulerSpec.scala
+++ b/core/src/test/scala/io/gearpump/util/TimeOutSchedulerSpec.scala
@@ -18,12 +18,12 @@ import org.apache.pekko.actor._
 import org.apache.pekko.testkit.{ImplicitSender, TestActorRef, TestKit, TestProbe}
 import io.gearpump.cluster.TestUtil
 import org.scalatest.BeforeAndAfterAll
-import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatest.matchers.should.Matchers
 import scala.concurrent.duration._
 
 class TimeOutSchedulerSpec(_system: ActorSystem) extends TestKit(_system) with ImplicitSender
-  with AnyWordSpec with Matchers with BeforeAndAfterAll {
+  with AnyWordSpecLike with Matchers with BeforeAndAfterAll {
 
   def this() = this(ActorSystem("WorkerSpec", TestUtil.DEFAULT_CONFIG))
   val mockActor = TestProbe()

--- a/core/src/test/scala/io/gearpump/util/UtilSpec.scala
+++ b/core/src/test/scala/io/gearpump/util/UtilSpec.scala
@@ -18,7 +18,7 @@ import io.gearpump.transport.HostPort
 import io.gearpump.util.Util._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.mockito.MockitoSugar
+import io.gearpump.testkit.MockitoSugar
 
 class UtilSpec extends AnyFlatSpec with Matchers with MockitoSugar {
   it should "work" in {

--- a/core/src/test/scala/io/gearpump/util/UtilSpec.scala
+++ b/core/src/test/scala/io/gearpump/util/UtilSpec.scala
@@ -16,10 +16,11 @@ package io.gearpump.util
 
 import io.gearpump.transport.HostPort
 import io.gearpump.util.Util._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.mockito.MockitoSugar
 
-class UtilSpec extends FlatSpec with Matchers with MockitoSugar {
+class UtilSpec extends AnyFlatSpec with Matchers with MockitoSugar {
   it should "work" in {
 
     assert(findFreePort().isSuccess)

--- a/examples/distributedshell/src/test/scala/io/gearpump/examples/distributedshell/DistShellAppMasterSpec.scala
+++ b/examples/distributedshell/src/test/scala/io/gearpump/examples/distributedshell/DistShellAppMasterSpec.scala
@@ -24,11 +24,13 @@ import io.gearpump.cluster.scheduler.{Relaxation, Resource, ResourceAllocation, 
 import io.gearpump.cluster.worker.WorkerId
 import io.gearpump.util.ActorSystemBooter.RegisterActorSystem
 import io.gearpump.util.ActorUtil
-import org.scalatest.{BeforeAndAfter, Matchers, WordSpec}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-class DistShellAppMasterSpec extends WordSpec with Matchers with BeforeAndAfter {
+class DistShellAppMasterSpec extends AnyWordSpec with Matchers with BeforeAndAfter {
   implicit val system: ActorSystem = ActorSystem("AppMasterSpec", TestUtil.DEFAULT_CONFIG)
   val mockMaster = TestProbe()(system)
   val masterProxy = mockMaster.ref

--- a/examples/distributedshell/src/test/scala/io/gearpump/examples/distributedshell/DistributedShellClientSpec.scala
+++ b/examples/distributedshell/src/test/scala/io/gearpump/examples/distributedshell/DistributedShellClientSpec.scala
@@ -19,12 +19,14 @@ import io.gearpump.cluster.ClientToMaster.ResolveAppId
 import io.gearpump.cluster.MasterToClient.ResolveAppIdResult
 import io.gearpump.examples.distributedshell.DistShellAppMaster.ShellCommand
 import io.gearpump.util.LogUtil
-import org.scalatest.{BeforeAndAfter, Matchers, PropSpec}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
 import scala.concurrent.Future
 import scala.util.{Success, Try}
 
 class DistributedShellClientSpec
-  extends PropSpec with Matchers with BeforeAndAfter with MasterHarness {
+  extends AnyPropSpec with Matchers with BeforeAndAfter with MasterHarness {
 
   private val LOG = LogUtil.getLogger(getClass)
 

--- a/examples/distributedshell/src/test/scala/io/gearpump/examples/distributedshell/DistributedShellSpec.scala
+++ b/examples/distributedshell/src/test/scala/io/gearpump/examples/distributedshell/DistributedShellSpec.scala
@@ -17,13 +17,15 @@ import com.typesafe.config.Config
 import io.gearpump.cluster.{MasterHarness, TestUtil}
 import io.gearpump.cluster.ClientToMaster.SubmitApplication
 import io.gearpump.cluster.MasterToClient.SubmitApplicationResult
-import org.scalatest.{BeforeAndAfter, Matchers, PropSpec}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
 import org.scalatest.prop.PropertyChecks
 import scala.concurrent.Future
 import scala.util.Success
 
 class DistributedShellSpec
-  extends PropSpec with PropertyChecks with Matchers with BeforeAndAfter with MasterHarness {
+  extends AnyPropSpec with PropertyChecks with Matchers with BeforeAndAfter with MasterHarness {
 
   before {
     startActorSystem()

--- a/examples/distributedshell/src/test/scala/io/gearpump/examples/distributedshell/DistributedShellSpec.scala
+++ b/examples/distributedshell/src/test/scala/io/gearpump/examples/distributedshell/DistributedShellSpec.scala
@@ -20,12 +20,12 @@ import io.gearpump.cluster.MasterToClient.SubmitApplicationResult
 import org.scalatest.BeforeAndAfter
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.propspec.AnyPropSpec
-import org.scalatest.prop.PropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import scala.concurrent.Future
 import scala.util.Success
 
 class DistributedShellSpec
-  extends AnyPropSpec with PropertyChecks with Matchers with BeforeAndAfter with MasterHarness {
+  extends AnyPropSpec with ScalaCheckPropertyChecks with Matchers with BeforeAndAfter with MasterHarness {
 
   before {
     startActorSystem()

--- a/examples/distributedshell/src/test/scala/io/gearpump/examples/distributedshell/ShellCommandResultAggregatorSpec.scala
+++ b/examples/distributedshell/src/test/scala/io/gearpump/examples/distributedshell/ShellCommandResultAggregatorSpec.scala
@@ -14,9 +14,11 @@
 package io.gearpump.examples.distributedshell
 
 import io.gearpump.examples.distributedshell.DistShellAppMaster.{ShellCommandResult, ShellCommandResultAggregator}
-import org.scalatest.{BeforeAndAfter, Matchers, WordSpec}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class ShellCommandResultAggregatorSpec extends WordSpec with Matchers with BeforeAndAfter {
+class ShellCommandResultAggregatorSpec extends AnyWordSpec with Matchers with BeforeAndAfter {
   "ShellCommandResultAggregator" should {
     "aggregate ShellCommandResult" in {
       val executorId1 = 1

--- a/examples/distributedshell/src/test/scala/io/gearpump/examples/distributedshell/ShellExecutorSpec.scala
+++ b/examples/distributedshell/src/test/scala/io/gearpump/examples/distributedshell/ShellExecutorSpec.scala
@@ -20,13 +20,14 @@ import io.gearpump.cluster.appmaster.WorkerInfo
 import io.gearpump.cluster.scheduler.Resource
 import io.gearpump.cluster.worker.WorkerId
 import io.gearpump.examples.distributedshell.DistShellAppMaster.{ShellCommand, ShellCommandResult}
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 import scala.sys.process._
 import scala.util.{Failure, Success, Try}
 
-class ShellExecutorSpec extends WordSpec with Matchers {
+class ShellExecutorSpec extends AnyWordSpec with Matchers {
 
   "ShellExecutor" should {
     "execute the shell command and return the result" in {

--- a/examples/streaming/complexdag/src/test/scala/io/gearpump/streaming/examples/complexdag/DagSpec.scala
+++ b/examples/streaming/complexdag/src/test/scala/io/gearpump/streaming/examples/complexdag/DagSpec.scala
@@ -20,11 +20,11 @@ import io.gearpump.cluster.MasterToClient.SubmitApplicationResult
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.propspec.AnyPropSpec
-import org.scalatest.prop.PropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import scala.concurrent.Future
 import scala.util.Success
 
-class DagSpec extends AnyPropSpec with PropertyChecks
+class DagSpec extends AnyPropSpec with ScalaCheckPropertyChecks
   with Matchers with BeforeAndAfterAll with MasterHarness {
 
   override def beforeAll(): Unit = {

--- a/examples/streaming/complexdag/src/test/scala/io/gearpump/streaming/examples/complexdag/DagSpec.scala
+++ b/examples/streaming/complexdag/src/test/scala/io/gearpump/streaming/examples/complexdag/DagSpec.scala
@@ -17,12 +17,14 @@ package io.gearpump.streaming.examples.complexdag
 import io.gearpump.cluster.{MasterHarness, TestUtil}
 import io.gearpump.cluster.ClientToMaster.SubmitApplication
 import io.gearpump.cluster.MasterToClient.SubmitApplicationResult
-import org.scalatest._
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
 import org.scalatest.prop.PropertyChecks
 import scala.concurrent.Future
 import scala.util.Success
 
-class DagSpec extends PropSpec with PropertyChecks
+class DagSpec extends AnyPropSpec with PropertyChecks
   with Matchers with BeforeAndAfterAll with MasterHarness {
 
   override def beforeAll(): Unit = {

--- a/examples/streaming/complexdag/src/test/scala/io/gearpump/streaming/examples/complexdag/NodeSpec.scala
+++ b/examples/streaming/complexdag/src/test/scala/io/gearpump/streaming/examples/complexdag/NodeSpec.scala
@@ -21,9 +21,9 @@ import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfter
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.propspec.AnyPropSpec
-import org.scalatest.prop.PropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
-class NodeSpec extends AnyPropSpec with PropertyChecks with Matchers with BeforeAndAfter {
+class NodeSpec extends AnyPropSpec with ScalaCheckPropertyChecks with Matchers with BeforeAndAfter {
 
   val context = MockUtil.mockTaskContext
 

--- a/examples/streaming/complexdag/src/test/scala/io/gearpump/streaming/examples/complexdag/NodeSpec.scala
+++ b/examples/streaming/complexdag/src/test/scala/io/gearpump/streaming/examples/complexdag/NodeSpec.scala
@@ -18,10 +18,12 @@ import io.gearpump.cluster.UserConfig
 import io.gearpump.streaming.MockUtil
 import io.gearpump.streaming.MockUtil._
 import org.mockito.Mockito._
-import org.scalatest.{BeforeAndAfter, Matchers, PropSpec}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
 import org.scalatest.prop.PropertyChecks
 
-class NodeSpec extends PropSpec with PropertyChecks with Matchers with BeforeAndAfter {
+class NodeSpec extends AnyPropSpec with PropertyChecks with Matchers with BeforeAndAfter {
 
   val context = MockUtil.mockTaskContext
 

--- a/examples/streaming/complexdag/src/test/scala/io/gearpump/streaming/examples/complexdag/SinkSpec.scala
+++ b/examples/streaming/complexdag/src/test/scala/io/gearpump/streaming/examples/complexdag/SinkSpec.scala
@@ -19,9 +19,9 @@ import io.gearpump.streaming.MockUtil
 import org.scalatest.BeforeAndAfter
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.propspec.AnyPropSpec
-import org.scalatest.prop.PropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
-class SinkSpec extends AnyPropSpec with PropertyChecks with Matchers with BeforeAndAfter {
+class SinkSpec extends AnyPropSpec with ScalaCheckPropertyChecks with Matchers with BeforeAndAfter {
 
   val context = MockUtil.mockTaskContext
 

--- a/examples/streaming/complexdag/src/test/scala/io/gearpump/streaming/examples/complexdag/SinkSpec.scala
+++ b/examples/streaming/complexdag/src/test/scala/io/gearpump/streaming/examples/complexdag/SinkSpec.scala
@@ -16,10 +16,12 @@ package io.gearpump.streaming.examples.complexdag
 import io.gearpump.Message
 import io.gearpump.cluster.UserConfig
 import io.gearpump.streaming.MockUtil
-import org.scalatest.{BeforeAndAfter, Matchers, PropSpec}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
 import org.scalatest.prop.PropertyChecks
 
-class SinkSpec extends PropSpec with PropertyChecks with Matchers with BeforeAndAfter {
+class SinkSpec extends AnyPropSpec with PropertyChecks with Matchers with BeforeAndAfter {
 
   val context = MockUtil.mockTaskContext
 

--- a/examples/streaming/complexdag/src/test/scala/io/gearpump/streaming/examples/complexdag/SourceSpec.scala
+++ b/examples/streaming/complexdag/src/test/scala/io/gearpump/streaming/examples/complexdag/SourceSpec.scala
@@ -19,9 +19,10 @@ import io.gearpump.cluster.{TestUtil, UserConfig}
 import io.gearpump.streaming.MockUtil
 import io.gearpump.streaming.MockUtil._
 import org.mockito.Mockito._
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class SourceSpec extends WordSpec with Matchers {
+class SourceSpec extends AnyWordSpec with Matchers {
 
   "Source" should {
     "Source should send a msg of Vector[String](classOf[Source].getCanonicalName)" in {

--- a/examples/streaming/sol/src/test/scala/io/gearpump/streaming/examples/sol/SOLSpec.scala
+++ b/examples/streaming/sol/src/test/scala/io/gearpump/streaming/examples/sol/SOLSpec.scala
@@ -18,13 +18,15 @@ import com.typesafe.config.Config
 import io.gearpump.cluster.{MasterHarness, TestUtil}
 import io.gearpump.cluster.ClientToMaster.SubmitApplication
 import io.gearpump.cluster.MasterToClient.SubmitApplicationResult
-import org.scalatest.{BeforeAndAfterAll, Matchers, PropSpec}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
 import org.scalatest.prop.PropertyChecks
 import scala.concurrent.Future
 import scala.util.Success
 
 class SOLSpec
-  extends PropSpec with PropertyChecks with Matchers with BeforeAndAfterAll with MasterHarness {
+  extends AnyPropSpec with PropertyChecks with Matchers with BeforeAndAfterAll with MasterHarness {
   override def beforeAll(): Unit = {
     startActorSystem()
   }

--- a/examples/streaming/sol/src/test/scala/io/gearpump/streaming/examples/sol/SOLSpec.scala
+++ b/examples/streaming/sol/src/test/scala/io/gearpump/streaming/examples/sol/SOLSpec.scala
@@ -21,12 +21,12 @@ import io.gearpump.cluster.MasterToClient.SubmitApplicationResult
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.propspec.AnyPropSpec
-import org.scalatest.prop.PropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import scala.concurrent.Future
 import scala.util.Success
 
 class SOLSpec
-  extends AnyPropSpec with PropertyChecks with Matchers with BeforeAndAfterAll with MasterHarness {
+  extends AnyPropSpec with ScalaCheckPropertyChecks with Matchers with BeforeAndAfterAll with MasterHarness {
   override def beforeAll(): Unit = {
     startActorSystem()
   }

--- a/examples/streaming/sol/src/test/scala/io/gearpump/streaming/examples/sol/SOLStreamProcessorSpec.scala
+++ b/examples/streaming/sol/src/test/scala/io/gearpump/streaming/examples/sol/SOLStreamProcessorSpec.scala
@@ -18,9 +18,10 @@ import io.gearpump.cluster.UserConfig
 import io.gearpump.streaming.MockUtil
 import java.time.Instant
 import org.mockito.Mockito._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class SOLStreamProcessorSpec extends FlatSpec with Matchers {
+class SOLStreamProcessorSpec extends AnyFlatSpec with Matchers {
 
   it should "pass the message downstream" in {
     val context = MockUtil.mockTaskContext

--- a/examples/streaming/sol/src/test/scala/io/gearpump/streaming/examples/sol/SOLStreamProducerSpec.scala
+++ b/examples/streaming/sol/src/test/scala/io/gearpump/streaming/examples/sol/SOLStreamProducerSpec.scala
@@ -19,9 +19,10 @@ import io.gearpump.streaming.MockUtil
 import java.time.Instant
 import org.mockito.Matchers._
 import org.mockito.Mockito._
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class SOLStreamProducerSpec extends WordSpec with Matchers {
+class SOLStreamProducerSpec extends AnyWordSpec with Matchers {
 
   "SOLStreamProducer" should {
     "producer message continuously" in {

--- a/examples/streaming/wordcount-java/src/test/scala/io/gearpump/streaming/examples/wordcountjava/WordCountSpec.scala
+++ b/examples/streaming/wordcount-java/src/test/scala/io/gearpump/streaming/examples/wordcountjava/WordCountSpec.scala
@@ -20,12 +20,12 @@ import io.gearpump.cluster.MasterToClient.SubmitApplicationResult
 import org.scalatest.BeforeAndAfter
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.propspec.AnyPropSpec
-import org.scalatest.prop.PropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import scala.concurrent.Future
 import scala.util.Success
 
 class WordCountSpec
-  extends AnyPropSpec with PropertyChecks with Matchers with BeforeAndAfter with MasterHarness {
+  extends AnyPropSpec with ScalaCheckPropertyChecks with Matchers with BeforeAndAfter with MasterHarness {
 
   before {
     startActorSystem()

--- a/examples/streaming/wordcount-java/src/test/scala/io/gearpump/streaming/examples/wordcountjava/WordCountSpec.scala
+++ b/examples/streaming/wordcount-java/src/test/scala/io/gearpump/streaming/examples/wordcountjava/WordCountSpec.scala
@@ -17,13 +17,15 @@ package io.gearpump.streaming.examples.wordcountjava
 import io.gearpump.cluster.{MasterHarness, TestUtil}
 import io.gearpump.cluster.ClientToMaster.SubmitApplication
 import io.gearpump.cluster.MasterToClient.SubmitApplicationResult
-import org.scalatest.{BeforeAndAfter, Matchers, PropSpec}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
 import org.scalatest.prop.PropertyChecks
 import scala.concurrent.Future
 import scala.util.Success
 
 class WordCountSpec
-  extends PropSpec with PropertyChecks with Matchers with BeforeAndAfter with MasterHarness {
+  extends AnyPropSpec with PropertyChecks with Matchers with BeforeAndAfter with MasterHarness {
 
   before {
     startActorSystem()

--- a/examples/streaming/wordcount/src/test/scala/io/gearpump/streaming/examples/wordcount/SplitSpec.scala
+++ b/examples/streaming/wordcount/src/test/scala/io/gearpump/streaming/examples/wordcount/SplitSpec.scala
@@ -20,11 +20,12 @@ import io.gearpump.cluster.TestUtil
 import io.gearpump.streaming.MockUtil
 import java.time.Instant
 import org.mockito.Mockito._
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-class SplitSpec extends WordSpec with Matchers {
+class SplitSpec extends AnyWordSpec with Matchers {
 
   "Split" should {
     "split the text and deliver to next task" in {

--- a/examples/streaming/wordcount/src/test/scala/io/gearpump/streaming/examples/wordcount/SumSpec.scala
+++ b/examples/streaming/wordcount/src/test/scala/io/gearpump/streaming/examples/wordcount/SumSpec.scala
@@ -21,9 +21,9 @@ import org.scalacheck.Gen
 import org.scalatest.BeforeAndAfter
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.propspec.AnyPropSpec
-import org.scalatest.prop.PropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
-class SumSpec extends AnyPropSpec with PropertyChecks with Matchers with BeforeAndAfter {
+class SumSpec extends AnyPropSpec with ScalaCheckPropertyChecks with Matchers with BeforeAndAfter {
   val stringGenerator = Gen.alphaStr
 
   var wordcount = 0

--- a/examples/streaming/wordcount/src/test/scala/io/gearpump/streaming/examples/wordcount/SumSpec.scala
+++ b/examples/streaming/wordcount/src/test/scala/io/gearpump/streaming/examples/wordcount/SumSpec.scala
@@ -18,10 +18,12 @@ import io.gearpump.cluster.UserConfig
 import io.gearpump.streaming.MockUtil
 import java.time.Instant
 import org.scalacheck.Gen
-import org.scalatest.{BeforeAndAfter, Matchers, PropSpec}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
 import org.scalatest.prop.PropertyChecks
 
-class SumSpec extends PropSpec with PropertyChecks with Matchers with BeforeAndAfter {
+class SumSpec extends AnyPropSpec with PropertyChecks with Matchers with BeforeAndAfter {
   val stringGenerator = Gen.alphaStr
 
   var wordcount = 0

--- a/examples/streaming/wordcount/src/test/scala/io/gearpump/streaming/examples/wordcount/WordCountSpec.scala
+++ b/examples/streaming/wordcount/src/test/scala/io/gearpump/streaming/examples/wordcount/WordCountSpec.scala
@@ -20,12 +20,12 @@ import io.gearpump.cluster.MasterToClient.SubmitApplicationResult
 import org.scalatest.BeforeAndAfter
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.propspec.AnyPropSpec
-import org.scalatest.prop.PropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import scala.concurrent.Future
 import scala.util.Success
 
 class WordCountSpec
-  extends AnyPropSpec with PropertyChecks with Matchers with BeforeAndAfter with MasterHarness {
+  extends AnyPropSpec with ScalaCheckPropertyChecks with Matchers with BeforeAndAfter with MasterHarness {
 
   before {
     startActorSystem()

--- a/examples/streaming/wordcount/src/test/scala/io/gearpump/streaming/examples/wordcount/WordCountSpec.scala
+++ b/examples/streaming/wordcount/src/test/scala/io/gearpump/streaming/examples/wordcount/WordCountSpec.scala
@@ -17,13 +17,15 @@ package io.gearpump.streaming.examples.wordcount
 import io.gearpump.cluster.{MasterHarness, TestUtil}
 import io.gearpump.cluster.ClientToMaster.SubmitApplication
 import io.gearpump.cluster.MasterToClient.SubmitApplicationResult
-import org.scalatest.{BeforeAndAfter, Matchers, PropSpec}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
 import org.scalatest.prop.PropertyChecks
 import scala.concurrent.Future
 import scala.util.Success
 
 class WordCountSpec
-  extends PropSpec with PropertyChecks with Matchers with BeforeAndAfter with MasterHarness {
+  extends AnyPropSpec with PropertyChecks with Matchers with BeforeAndAfter with MasterHarness {
 
   before {
     startActorSystem()

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -42,7 +42,8 @@ object Dependencies {
   val sprayVersion = "1.3.2"
   val sprayJsonVersion = "1.3.1"
   val scalaTestVersion = "3.2.20"
-  val scalaCheckVersion = "1.14.0"
+  val scalaTestPlusScalaCheckVersion = "3.2.20.0"
+  val scalaCheckVersion = "1.19.0"
   val mockitoVersion = "1.10.17"
   val beamVersion = "2.73.0"
   val snappyJavaVersion = "1.1.10.7"
@@ -103,6 +104,7 @@ object Dependencies {
       "org.apache.pekko" %% "pekko-testkit" % pekkoVersion % "test",
       "org.scalatest" %% "scalatest" % scalaTestVersion % "test",
       "org.scalacheck" %% "scalacheck" % scalaCheckVersion % "test",
+      "org.scalatestplus" %% "scalacheck-1-19" % scalaTestPlusScalaCheckVersion % "test",
       "org.mockito" % "mockito-core" % mockitoVersion % "test",
       "org.junit.jupiter" % "junit-jupiter" % junitJupiterVersion % "test",
       "com.github.sbt.junit" % "jupiter-interface" % jupiterInterfaceVersion % "test"

--- a/services/jvm/src/test/scala/io/gearpump/services/AdminServiceSpec.scala
+++ b/services/jvm/src/test/scala/io/gearpump/services/AdminServiceSpec.scala
@@ -18,12 +18,14 @@ import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
 import com.typesafe.config.Config
 import io.gearpump.cluster.TestUtil
-import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
 class AdminServiceSpec
-  extends FlatSpec with ScalatestRouteTest with Matchers with BeforeAndAfterAll {
+  extends AnyFlatSpec with ScalatestRouteTest with Matchers with BeforeAndAfterAll {
 
   override def testConfig: Config = TestUtil.DEFAULT_CONFIG
 

--- a/services/jvm/src/test/scala/io/gearpump/services/AppMasterServiceSpec.scala
+++ b/services/jvm/src/test/scala/io/gearpump/services/AppMasterServiceSpec.scala
@@ -28,12 +28,14 @@ import io.gearpump.cluster.MasterToClient._
 import io.gearpump.jarstore.JarStoreClient
 import io.gearpump.services.util.UpickleUtil._
 import io.gearpump.streaming.executor.Executor.{ExecutorConfig, ExecutorSummary, GetExecutorSummary, QueryExecutorConfig}
-import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import scala.concurrent.duration._
 import scala.util.{Success, Try}
 import upickle.default.read
 
-class AppMasterServiceSpec extends FlatSpec with ScalatestRouteTest
+class AppMasterServiceSpec extends AnyFlatSpec with ScalatestRouteTest
   with Matchers with BeforeAndAfterAll {
 
   override def testConfig: Config = TestUtil.UI_CONFIG

--- a/services/jvm/src/test/scala/io/gearpump/services/MasterServiceSpec.scala
+++ b/services/jvm/src/test/scala/io/gearpump/services/MasterServiceSpec.scala
@@ -35,12 +35,14 @@ import io.gearpump.services.util.UpickleUtil._
 import io.gearpump.streaming.ProcessorDescription
 import io.gearpump.util.Graph
 import java.io.File
-import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.{Success, Try}
 
-class MasterServiceSpec extends FlatSpec with ScalatestRouteTest
+class MasterServiceSpec extends AnyFlatSpec with ScalatestRouteTest
   with Matchers with BeforeAndAfterAll {
   import upickle.default.{read, write}
 

--- a/services/jvm/src/test/scala/io/gearpump/services/SecurityServiceSpec.scala
+++ b/services/jvm/src/test/scala/io/gearpump/services/SecurityServiceSpec.scala
@@ -22,12 +22,14 @@ import org.apache.pekko.http.scaladsl.server.Directives._
 import org.apache.pekko.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
 import com.typesafe.config.Config
 import io.gearpump.cluster.TestUtil
-import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import scala.concurrent.duration._
 // NOTE: This cannot be removed!!!
 
 class SecurityServiceSpec
-  extends FlatSpec with ScalatestRouteTest with Matchers with BeforeAndAfterAll {
+  extends AnyFlatSpec with ScalatestRouteTest with Matchers with BeforeAndAfterAll {
 
   override def testConfig: Config = TestUtil.UI_CONFIG
 

--- a/services/jvm/src/test/scala/io/gearpump/services/StaticServiceSpec.scala
+++ b/services/jvm/src/test/scala/io/gearpump/services/StaticServiceSpec.scala
@@ -19,11 +19,13 @@ import org.apache.pekko.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteT
 import com.typesafe.config.Config
 import io.gearpump.cluster.TestUtil
 import io.gearpump.util.Constants
-import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import scala.concurrent.duration._
 
 class StaticServiceSpec
-  extends FlatSpec with ScalatestRouteTest with Matchers with BeforeAndAfterAll {
+  extends AnyFlatSpec with ScalatestRouteTest with Matchers with BeforeAndAfterAll {
 
   override def testConfig: Config = TestUtil.UI_CONFIG
   private val supervisorPath = system.settings.config.getString(

--- a/services/jvm/src/test/scala/io/gearpump/services/SupervisorServiceSpec.scala
+++ b/services/jvm/src/test/scala/io/gearpump/services/SupervisorServiceSpec.scala
@@ -25,13 +25,15 @@ import io.gearpump.cluster.ClientToMaster._
 import io.gearpump.cluster.MasterToClient.ResolveWorkerIdResult
 import io.gearpump.cluster.TestUtil
 import io.gearpump.cluster.worker.{WorkerId, WorkerSummary}
-import org.scalatest.{BeforeAndAfterAll, FlatSpec, Ignore, Matchers}
+import org.scalatest.{BeforeAndAfterAll, Ignore}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import scala.concurrent.duration._
 import scala.util.Success
 
 @Ignore
 class SupervisorServiceSpec
-  extends FlatSpec with ScalatestRouteTest with Matchers with BeforeAndAfterAll {
+  extends AnyFlatSpec with ScalatestRouteTest with Matchers with BeforeAndAfterAll {
 
   override def testConfig: Config = TestUtil.DEFAULT_CONFIG
 

--- a/services/jvm/src/test/scala/io/gearpump/services/WorkerServiceSpec.scala
+++ b/services/jvm/src/test/scala/io/gearpump/services/WorkerServiceSpec.scala
@@ -25,12 +25,14 @@ import io.gearpump.cluster.ClientToMaster.{QueryHistoryMetrics, QueryWorkerConfi
 import io.gearpump.cluster.MasterToClient.{HistoryMetrics, HistoryMetricsItem, ResolveWorkerIdResult, WorkerConfig}
 import io.gearpump.cluster.TestUtil
 import io.gearpump.cluster.worker.{WorkerId, WorkerSummary}
-import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import scala.concurrent.duration._
 import scala.util.{Success, Try}
 
 class WorkerServiceSpec
-  extends FlatSpec with ScalatestRouteTest with Matchers with BeforeAndAfterAll {
+  extends AnyFlatSpec with ScalatestRouteTest with Matchers with BeforeAndAfterAll {
 
   override def testConfig: Config = TestUtil.DEFAULT_CONFIG
 

--- a/services/jvm/src/test/scala/io/gearpump/services/security/oauth2/CloudFoundryUAAOAuth2AuthenticatorSpec.scala
+++ b/services/jvm/src/test/scala/io/gearpump/services/security/oauth2/CloudFoundryUAAOAuth2AuthenticatorSpec.scala
@@ -23,12 +23,12 @@ import org.apache.pekko.http.scaladsl.testkit.ScalatestRouteTest
 import com.typesafe.config.ConfigFactory
 import io.gearpump.security.Authenticator
 import io.gearpump.services.security.oauth2.impl.CloudFoundryUAAOAuth2Authenticator
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 import scala.jdk.CollectionConverters._
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class CloudFoundryUAAOAuth2AuthenticatorSpec extends FlatSpec with ScalatestRouteTest {
+class CloudFoundryUAAOAuth2AuthenticatorSpec extends AnyFlatSpec with ScalatestRouteTest {
 
   implicit val actorSystem: ActorSystem = system
   private val server = new MockOAuth2Server(system, null)

--- a/services/jvm/src/test/scala/io/gearpump/services/security/oauth2/GoogleOAuth2AuthenticatorSpec.scala
+++ b/services/jvm/src/test/scala/io/gearpump/services/security/oauth2/GoogleOAuth2AuthenticatorSpec.scala
@@ -24,12 +24,12 @@ import com.typesafe.config.ConfigFactory
 import io.gearpump.security.Authenticator
 import io.gearpump.services.security.oauth2.GoogleOAuth2AuthenticatorSpec.MockGoogleAuthenticator
 import io.gearpump.services.security.oauth2.impl.GoogleOAuth2Authenticator
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 import scala.jdk.CollectionConverters._
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class GoogleOAuth2AuthenticatorSpec extends FlatSpec with ScalatestRouteTest {
+class GoogleOAuth2AuthenticatorSpec extends AnyFlatSpec with ScalatestRouteTest {
 
   implicit val actorSystem: ActorSystem = system
   private val server = new MockOAuth2Server(system, null)

--- a/services/jvm/src/test/scala/io/gearpump/services/util/UpickleSpec.scala
+++ b/services/jvm/src/test/scala/io/gearpump/services/util/UpickleSpec.scala
@@ -20,10 +20,12 @@ import io.gearpump.services.util.UpickleUtil._
 import io.gearpump.streaming.ProcessorId
 import io.gearpump.streaming.appmaster.{ProcessorSummary, StreamAppMasterSummary}
 import io.gearpump.util.Graph
-import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import upickle.default.{read, write}
 
-class UpickleSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
+class UpickleSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEach {
 
   "UserConfig" should "serialize and deserialize with upickle correctly" in {
     val conf = UserConfig.empty.withString("key", "value")

--- a/streaming/src/test/scala/io/gearpump/streaming/DAGSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/DAGSpec.scala
@@ -20,9 +20,9 @@ import io.gearpump.util.Graph
 import org.scalacheck.Gen
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.propspec.AnyPropSpec
-import org.scalatest.prop.PropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
-class DAGSpec extends AnyPropSpec with PropertyChecks with Matchers {
+class DAGSpec extends AnyPropSpec with ScalaCheckPropertyChecks with Matchers {
 
   val parallelismGen = Gen.chooseNum[Int](1, 100)
 

--- a/streaming/src/test/scala/io/gearpump/streaming/DAGSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/DAGSpec.scala
@@ -18,10 +18,11 @@ import io.gearpump.streaming.partitioner.PartitionerDescription
 import io.gearpump.streaming.task.TaskId
 import io.gearpump.util.Graph
 import org.scalacheck.Gen
-import org.scalatest.{Matchers, PropSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
 import org.scalatest.prop.PropertyChecks
 
-class DAGSpec extends PropSpec with PropertyChecks with Matchers {
+class DAGSpec extends AnyPropSpec with PropertyChecks with Matchers {
 
   val parallelismGen = Gen.chooseNum[Int](1, 100)
 

--- a/streaming/src/test/scala/io/gearpump/streaming/MessageSerializerSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/MessageSerializerSpec.scala
@@ -17,9 +17,10 @@ import io.gearpump.streaming.source.Watermark
 import io.gearpump.streaming.task.{Ack, AckRequest, InitialAckRequest, SerializedMessage, SerializedMessageSerializer, TaskId, TaskMessageSerializer}
 import io.gearpump.transport.netty.WrappedChannelBuffer
 import org.jboss.netty.buffer.{ChannelBufferOutputStream, ChannelBuffers}
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class MessageSerializerSpec extends WordSpec with Matchers {
+class MessageSerializerSpec extends AnyWordSpec with Matchers {
 
   def testSerializer[T](obj: T, taskMessageSerializer: TaskMessageSerializer[T]): T = {
     val length = taskMessageSerializer.getLength(obj)

--- a/streaming/src/test/scala/io/gearpump/streaming/appmaster/AppMasterSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/appmaster/AppMasterSpec.scala
@@ -36,7 +36,9 @@ import io.gearpump.streaming.task.{TaskContext, _}
 import io.gearpump.util.{ActorUtil, Graph}
 import io.gearpump.util.ActorSystemBooter.RegisterActorSystem
 import io.gearpump.util.Graph._
-import org.scalatest._
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import scala.concurrent.duration._
 
 class AppMasterSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach with MasterHarness {

--- a/streaming/src/test/scala/io/gearpump/streaming/appmaster/AppMasterSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/appmaster/AppMasterSpec.scala
@@ -39,7 +39,7 @@ import io.gearpump.util.Graph._
 import org.scalatest._
 import scala.concurrent.duration._
 
-class AppMasterSpec extends WordSpec with Matchers with BeforeAndAfterEach with MasterHarness {
+class AppMasterSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach with MasterHarness {
   protected override def config = TestUtil.DEFAULT_CONFIG
 
   var appMaster: ActorRef = null

--- a/streaming/src/test/scala/io/gearpump/streaming/appmaster/ClockServiceSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/appmaster/ClockServiceSpec.scala
@@ -25,12 +25,12 @@ import io.gearpump.streaming.task.{GetLatestMinClock, GetStartClock, UpstreamMin
 import io.gearpump.util.Graph
 import io.gearpump.util.Graph._
 import org.scalatest.BeforeAndAfterAll
-import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
 import scala.concurrent.{Future, Promise}
 
 class ClockServiceSpec(_system: ActorSystem) extends TestKit(_system) with ImplicitSender
-  with AnyWordSpecLike with Matchers with BeforeAndAfterAll {
+  with AnyWordSpec with Matchers with BeforeAndAfterAll {
 
   def this() = this(ActorSystem("ClockServiceSpec", TestUtil.DEFAULT_CONFIG))
 

--- a/streaming/src/test/scala/io/gearpump/streaming/appmaster/ClockServiceSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/appmaster/ClockServiceSpec.scala
@@ -24,12 +24,13 @@ import io.gearpump.streaming.storage.AppDataStore
 import io.gearpump.streaming.task.{GetLatestMinClock, GetStartClock, UpstreamMinClock, _}
 import io.gearpump.util.Graph
 import io.gearpump.util.Graph._
-import org.scalatest.{BeforeAndAfterAll, WordSpecLike}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
 import scala.concurrent.{Future, Promise}
 
 class ClockServiceSpec(_system: ActorSystem) extends TestKit(_system) with ImplicitSender
-  with WordSpecLike with Matchers with BeforeAndAfterAll {
+  with AnyWordSpec with Matchers with BeforeAndAfterAll {
 
   def this() = this(ActorSystem("ClockServiceSpec", TestUtil.DEFAULT_CONFIG))
 

--- a/streaming/src/test/scala/io/gearpump/streaming/appmaster/ClockServiceSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/appmaster/ClockServiceSpec.scala
@@ -25,12 +25,12 @@ import io.gearpump.streaming.task.{GetLatestMinClock, GetStartClock, UpstreamMin
 import io.gearpump.util.Graph
 import io.gearpump.util.Graph._
 import org.scalatest.BeforeAndAfterAll
-import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatest.matchers.should.Matchers
 import scala.concurrent.{Future, Promise}
 
 class ClockServiceSpec(_system: ActorSystem) extends TestKit(_system) with ImplicitSender
-  with AnyWordSpec with Matchers with BeforeAndAfterAll {
+  with AnyWordSpecLike with Matchers with BeforeAndAfterAll {
 
   def this() = this(ActorSystem("ClockServiceSpec", TestUtil.DEFAULT_CONFIG))
 

--- a/streaming/src/test/scala/io/gearpump/streaming/appmaster/ClockServiceSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/appmaster/ClockServiceSpec.scala
@@ -24,7 +24,8 @@ import io.gearpump.streaming.storage.AppDataStore
 import io.gearpump.streaming.task.{GetLatestMinClock, GetStartClock, UpstreamMinClock, _}
 import io.gearpump.util.Graph
 import io.gearpump.util.Graph._
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
+import org.scalatest.{BeforeAndAfterAll, WordSpecLike}
+import org.scalatest.matchers.should.Matchers
 import scala.concurrent.{Future, Promise}
 
 class ClockServiceSpec(_system: ActorSystem) extends TestKit(_system) with ImplicitSender

--- a/streaming/src/test/scala/io/gearpump/streaming/appmaster/DagManagerSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/appmaster/DagManagerSpec.scala
@@ -23,12 +23,13 @@ import io.gearpump.streaming.partitioner.{HashPartitioner, Partitioner}
 import io.gearpump.streaming.task.{Subscriber, TaskActor}
 import io.gearpump.util.Graph
 import io.gearpump.util.Graph._
-import org.scalatest.{BeforeAndAfterAll, WordSpecLike}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-class DagManagerSpec extends WordSpecLike with Matchers with BeforeAndAfterAll {
+class DagManagerSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll {
 
   val hash = Partitioner[HashPartitioner]
   val task1 = ProcessorDescription(id = 1, taskClass = classOf[TaskActor].getName, parallelism = 1)

--- a/streaming/src/test/scala/io/gearpump/streaming/appmaster/DagManagerSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/appmaster/DagManagerSpec.scala
@@ -23,7 +23,8 @@ import io.gearpump.streaming.partitioner.{HashPartitioner, Partitioner}
 import io.gearpump.streaming.task.{Subscriber, TaskActor}
 import io.gearpump.util.Graph
 import io.gearpump.util.Graph._
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
+import org.scalatest.{BeforeAndAfterAll, WordSpecLike}
+import org.scalatest.matchers.should.Matchers
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 

--- a/streaming/src/test/scala/io/gearpump/streaming/appmaster/ExecutorManagerSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/appmaster/ExecutorManagerSpec.scala
@@ -31,7 +31,9 @@ import io.gearpump.streaming.appmaster.ExecutorManager.{ExecutorStarted, _}
 import io.gearpump.streaming.appmaster.ExecutorManagerSpec.StartExecutorActorPlease
 import io.gearpump.util.ActorSystemBooter.BindLifeCycle
 import io.gearpump.util.LogUtil
-import org.scalatest._
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 

--- a/streaming/src/test/scala/io/gearpump/streaming/appmaster/ExecutorManagerSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/appmaster/ExecutorManagerSpec.scala
@@ -35,7 +35,7 @@ import org.scalatest._
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-class ExecutorManagerSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
+class ExecutorManagerSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
   implicit var system: ActorSystem = null
 
   private val LOG = LogUtil.getLogger(getClass)

--- a/streaming/src/test/scala/io/gearpump/streaming/appmaster/HistoryMetricsServiceSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/appmaster/HistoryMetricsServiceSpec.scala
@@ -22,10 +22,12 @@ import io.gearpump.cluster.TestUtil
 import io.gearpump.metrics.Metrics.{Counter, Histogram, Meter}
 import io.gearpump.util.HistoryMetricsService
 import io.gearpump.util.HistoryMetricsService._
-import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import scala.concurrent.Await
 
-class HistoryMetricsServiceSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
+class HistoryMetricsServiceSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEach {
 
   val count = 2
   val intervalMs = 10

--- a/streaming/src/test/scala/io/gearpump/streaming/appmaster/JarSchedulerSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/appmaster/JarSchedulerSpec.scala
@@ -24,10 +24,11 @@ import io.gearpump.streaming.partitioner.{HashPartitioner, Partitioner}
 import io.gearpump.streaming.task.TaskId
 import io.gearpump.util.Graph
 import io.gearpump.util.Graph._
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import scala.concurrent.{Await, Future}
 
-class JarSchedulerSpec extends WordSpec with Matchers {
+class JarSchedulerSpec extends AnyWordSpec with Matchers {
   val mockJar1 = AppJar("jar1", FilePath("path"))
   val mockJar2 = AppJar("jar2", FilePath("path"))
   val task1 = ProcessorDescription(id = 0, taskClass = classOf[TestTask1].getName, parallelism = 1,

--- a/streaming/src/test/scala/io/gearpump/streaming/appmaster/TaskLocatorSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/appmaster/TaskLocatorSpec.scala
@@ -17,9 +17,11 @@ package io.gearpump.streaming.appmaster
 import io.gearpump.cluster.worker.WorkerId
 import io.gearpump.streaming.appmaster.TaskLocator.Localities
 import io.gearpump.streaming.task.TaskId
-import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class TaskLocatorSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
+class TaskLocatorSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
   it should "serialize/deserialize correctly" in {
     val localities = new Localities(Map(WorkerId(0, 0L) -> Array(TaskId(0, 1), TaskId(1, 2))))
     Localities.toJson(localities)

--- a/streaming/src/test/scala/io/gearpump/streaming/appmaster/TaskManagerSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/appmaster/TaskManagerSpec.scala
@@ -39,11 +39,13 @@ import io.gearpump.transport.HostPort
 import io.gearpump.util.Graph
 import io.gearpump.util.Graph._
 import org.mockito.Mockito._
-import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration.Duration
 
-class TaskManagerSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
+class TaskManagerSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEach {
 
   implicit var system: ActorSystem = null
 

--- a/streaming/src/test/scala/io/gearpump/streaming/appmaster/TaskRegistrySpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/appmaster/TaskRegistrySpec.scala
@@ -18,8 +18,10 @@ import io.gearpump.cluster.scheduler.Resource
 import io.gearpump.streaming.appmaster.TaskRegistry.{Accept, Reject, TaskLocation, TaskLocations}
 import io.gearpump.streaming.task.TaskId
 import io.gearpump.transport.HostPort
-import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
-class TaskRegistrySpec extends FlatSpec with Matchers with BeforeAndAfterEach {
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+class TaskRegistrySpec extends AnyFlatSpec with Matchers with BeforeAndAfterEach {
 
   it should "maintain registered tasks" in {
     val task0 = TaskId(0, 0)

--- a/streaming/src/test/scala/io/gearpump/streaming/appmaster/TaskSchedulerSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/appmaster/TaskSchedulerSpec.scala
@@ -24,10 +24,11 @@ import io.gearpump.streaming.partitioner.{HashPartitioner, Partitioner}
 import io.gearpump.streaming.task.{Task, TaskContext, TaskId}
 import io.gearpump.util.Graph
 import io.gearpump.util.Graph._
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import scala.collection.mutable.ArrayBuffer
 
-class TaskSchedulerSpec extends WordSpec with Matchers {
+class TaskSchedulerSpec extends AnyWordSpec with Matchers {
   val task1 = ProcessorDescription(id = 0, taskClass = classOf[TestTask1].getName, parallelism = 4)
   val task2 = ProcessorDescription(id = 1, taskClass = classOf[TestTask2].getName, parallelism = 2)
 

--- a/streaming/src/test/scala/io/gearpump/streaming/executor/ExecutorSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/executor/ExecutorSpec.scala
@@ -30,11 +30,13 @@ import io.gearpump.streaming.task.{Subscriber, TaskId}
 import io.gearpump.transport.HostPort
 import org.mockito.Matchers._
 import org.mockito.Mockito.{times, _}
-import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-class ExecutorSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
+class ExecutorSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
   val appId = 0
   val executorId = 0
   val workerId = WorkerId(0, 0L)

--- a/streaming/src/test/scala/io/gearpump/streaming/executor/TaskArgumentStoreSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/executor/TaskArgumentStoreSpec.scala
@@ -16,7 +16,9 @@ package io.gearpump.streaming.executor
 import io.gearpump.streaming.executor.Executor.TaskArgumentStore
 import io.gearpump.streaming.executor.TaskLauncher.TaskArgument
 import io.gearpump.streaming.task.TaskId
-import org.scalatest._
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 class TaskArgumentStoreSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEach {
   it should "retain all history of taskArgument" in {

--- a/streaming/src/test/scala/io/gearpump/streaming/executor/TaskArgumentStoreSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/executor/TaskArgumentStoreSpec.scala
@@ -18,7 +18,7 @@ import io.gearpump.streaming.executor.TaskLauncher.TaskArgument
 import io.gearpump.streaming.task.TaskId
 import org.scalatest._
 
-class TaskArgumentStoreSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
+class TaskArgumentStoreSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEach {
   it should "retain all history of taskArgument" in {
     val version0 = TaskArgument(0, null, null)
     val version2 = version0.copy(dagVersion = 2)

--- a/streaming/src/test/scala/io/gearpump/streaming/executor/TaskLauncherSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/executor/TaskLauncherSpec.scala
@@ -25,7 +25,7 @@ import org.scalatest._
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-class TaskLauncherSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
+class TaskLauncherSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
   val appId = 0
   val executorId = 0
   var appMaster: TestProbe = null

--- a/streaming/src/test/scala/io/gearpump/streaming/executor/TaskLauncherSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/executor/TaskLauncherSpec.scala
@@ -21,7 +21,9 @@ import io.gearpump.streaming.ProcessorDescription
 import io.gearpump.streaming.executor.TaskLauncher.TaskArgument
 import io.gearpump.streaming.executor.TaskLauncherSpec.{MockTask, MockTaskActor}
 import io.gearpump.streaming.task.{Task, TaskContext, TaskContextData, TaskId, TaskWrapper}
-import org.scalatest._
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 

--- a/streaming/src/test/scala/io/gearpump/streaming/metrics/ProcessorAggregatorSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/metrics/ProcessorAggregatorSpec.scala
@@ -20,11 +20,12 @@ import io.gearpump.metrics.Metrics.{Gauge, Histogram, Meter}
 import io.gearpump.streaming.metrics.ProcessorAggregator.{AggregatorFactory, HistogramAggregator, MeterAggregator, MultiLayerMap}
 import io.gearpump.streaming.task.TaskId
 import io.gearpump.util.HistoryMetricsService.HistoryMetricsConfig
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import scala.jdk.CollectionConverters._
 import scala.util.Random
 
-class ProcessorAggregatorSpec extends FlatSpec with Matchers {
+class ProcessorAggregatorSpec extends AnyFlatSpec with Matchers {
 
   "MultiLayerMap" should "maintain multiple layers HashMap" in {
     val layers = 3

--- a/streaming/src/test/scala/io/gearpump/streaming/metrics/TaskFilterAggregatorSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/metrics/TaskFilterAggregatorSpec.scala
@@ -18,10 +18,11 @@ import io.gearpump.cluster.MasterToClient.HistoryMetricsItem
 import io.gearpump.metrics.Metrics.{Histogram, Meter}
 import io.gearpump.streaming.metrics.TaskFilterAggregator.Options
 import io.gearpump.streaming.task.TaskId
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import scala.util.Random
 
-class TaskFilterAggregatorSpec extends FlatSpec with Matchers {
+class TaskFilterAggregatorSpec extends AnyFlatSpec with Matchers {
 
   def metric(taskId: TaskId): HistoryMetricsItem = {
     val random = new Random()

--- a/streaming/src/test/scala/io/gearpump/streaming/partitioner/GroupByPartitionerSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/partitioner/GroupByPartitionerSpec.scala
@@ -16,9 +16,11 @@ package io.gearpump.streaming.partitioner
 
 import io.gearpump.Message
 import io.gearpump.streaming.partitioner.GroupByPartitionerSpec.People
-import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class GroupByPartitionerSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
+class GroupByPartitionerSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
 
   it should "group by message payload and window" in {
     val mark = People("Mark", "male")

--- a/streaming/src/test/scala/io/gearpump/streaming/partitioner/PartitionerSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/partitioner/PartitionerSpec.scala
@@ -15,9 +15,10 @@
 package io.gearpump.streaming.partitioner
 
 import io.gearpump.Message
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class PartitionerSpec extends FlatSpec with Matchers {
+class PartitionerSpec extends AnyFlatSpec with Matchers {
   val NUM = 10
 
   "HashPartitioner" should "hash same key to same slots" in {

--- a/streaming/src/test/scala/io/gearpump/streaming/sink/DataSinkTaskSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/sink/DataSinkTaskSpec.scala
@@ -22,10 +22,10 @@ import org.mockito.Mockito._
 import org.scalacheck.Gen
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.propspec.AnyPropSpec
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.prop.PropertyChecks
+import io.gearpump.testkit.MockitoSugar
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
-class DataSinkTaskSpec extends AnyPropSpec with PropertyChecks with Matchers with MockitoSugar {
+class DataSinkTaskSpec extends AnyPropSpec with ScalaCheckPropertyChecks with Matchers with MockitoSugar {
 
   property("DataSinkTask.onStart should call DataSink.open" ) {
     forAll(Gen.chooseNum[Long](0L, 1000L).map(Instant.ofEpochMilli)) { (startTime: Instant) =>

--- a/streaming/src/test/scala/io/gearpump/streaming/sink/DataSinkTaskSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/sink/DataSinkTaskSpec.scala
@@ -20,11 +20,12 @@ import io.gearpump.streaming.MockUtil
 import java.time.Instant
 import org.mockito.Mockito._
 import org.scalacheck.Gen
-import org.scalatest.{Matchers, PropSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.prop.PropertyChecks
 
-class DataSinkTaskSpec extends PropSpec with PropertyChecks with Matchers with MockitoSugar {
+class DataSinkTaskSpec extends AnyPropSpec with PropertyChecks with Matchers with MockitoSugar {
 
   property("DataSinkTask.onStart should call DataSink.open" ) {
     forAll(Gen.chooseNum[Long](0L, 1000L).map(Instant.ofEpochMilli)) { (startTime: Instant) =>

--- a/streaming/src/test/scala/io/gearpump/streaming/source/DataSourceTaskSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/source/DataSourceTaskSpec.scala
@@ -23,11 +23,11 @@ import org.slf4j.{Logger, LoggerFactory}
 import org.scalacheck.Gen
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.propspec.AnyPropSpec
-import org.scalatest.prop.PropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.duration.FiniteDuration
 
-class DataSourceTaskSpec extends AnyPropSpec with PropertyChecks with Matchers {
+class DataSourceTaskSpec extends AnyPropSpec with ScalaCheckPropertyChecks with Matchers {
 
   private val system = ActorSystem("DataSourceTaskSpec")
   private val inbox = system.actorOf(Props(new Actor {

--- a/streaming/src/test/scala/io/gearpump/streaming/source/DataSourceTaskSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/source/DataSourceTaskSpec.scala
@@ -21,12 +21,13 @@ import java.time.Instant
 import org.apache.pekko.actor.{Actor, ActorRef, ActorSystem, Cancellable, Props}
 import org.slf4j.{Logger, LoggerFactory}
 import org.scalacheck.Gen
-import org.scalatest.{Matchers, PropSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
 import org.scalatest.prop.PropertyChecks
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.duration.FiniteDuration
 
-class DataSourceTaskSpec extends PropSpec with PropertyChecks with Matchers {
+class DataSourceTaskSpec extends AnyPropSpec with PropertyChecks with Matchers {
 
   private val system = ActorSystem("DataSourceTaskSpec")
   private val inbox = system.actorOf(Props(new Actor {

--- a/streaming/src/test/scala/io/gearpump/streaming/state/impl/CheckpointManagerSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/state/impl/CheckpointManagerSpec.scala
@@ -21,10 +21,10 @@ import org.mockito.Mockito._
 import org.scalacheck.Gen
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.propspec.AnyPropSpec
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.prop.PropertyChecks
+import io.gearpump.testkit.MockitoSugar
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
-class CheckpointManagerSpec extends AnyPropSpec with PropertyChecks with Matchers with MockitoSugar {
+class CheckpointManagerSpec extends AnyPropSpec with ScalaCheckPropertyChecks with Matchers with MockitoSugar {
 
   val timestampGen = Gen.chooseNum[Long](0L, 1000L)
   val checkpointIntervalGen = Gen.chooseNum[Long](100L, 10000L)

--- a/streaming/src/test/scala/io/gearpump/streaming/state/impl/CheckpointManagerSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/state/impl/CheckpointManagerSpec.scala
@@ -19,11 +19,12 @@ import io.gearpump.streaming.transaction.api.CheckpointStore
 import org.mockito.{Matchers => MockitoMatchers}
 import org.mockito.Mockito._
 import org.scalacheck.Gen
-import org.scalatest.{Matchers, PropSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.prop.PropertyChecks
 
-class CheckpointManagerSpec extends PropSpec with PropertyChecks with Matchers with MockitoSugar {
+class CheckpointManagerSpec extends AnyPropSpec with PropertyChecks with Matchers with MockitoSugar {
 
   val timestampGen = Gen.chooseNum[Long](0L, 1000L)
   val checkpointIntervalGen = Gen.chooseNum[Long](100L, 10000L)

--- a/streaming/src/test/scala/io/gearpump/streaming/state/impl/InMemoryCheckpointStoreSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/state/impl/InMemoryCheckpointStoreSpec.scala
@@ -15,10 +15,11 @@
 package io.gearpump.streaming.state.impl
 
 import org.scalacheck.Gen
-import org.scalatest.{Matchers, PropSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
 import org.scalatest.prop.PropertyChecks
 
-class InMemoryCheckpointStoreSpec extends PropSpec with PropertyChecks with Matchers {
+class InMemoryCheckpointStoreSpec extends AnyPropSpec with PropertyChecks with Matchers {
 
   property("InMemoryCheckpointStore should provide read / write checkpoint") {
     val timestampGen = Gen.chooseNum[Long](1, 1000)

--- a/streaming/src/test/scala/io/gearpump/streaming/state/impl/InMemoryCheckpointStoreSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/state/impl/InMemoryCheckpointStoreSpec.scala
@@ -17,9 +17,9 @@ package io.gearpump.streaming.state.impl
 import org.scalacheck.Gen
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.propspec.AnyPropSpec
-import org.scalatest.prop.PropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
-class InMemoryCheckpointStoreSpec extends AnyPropSpec with PropertyChecks with Matchers {
+class InMemoryCheckpointStoreSpec extends AnyPropSpec with ScalaCheckPropertyChecks with Matchers {
 
   property("InMemoryCheckpointStore should provide read / write checkpoint") {
     val timestampGen = Gen.chooseNum[Long](1, 1000)

--- a/streaming/src/test/scala/io/gearpump/streaming/state/impl/NonWindowStateSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/state/impl/NonWindowStateSpec.scala
@@ -20,11 +20,11 @@ import org.mockito.Mockito._
 import org.scalacheck.Gen
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.propspec.AnyPropSpec
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.prop.PropertyChecks
+import io.gearpump.testkit.MockitoSugar
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import scala.util.Success
 
-class NonWindowStateSpec extends AnyPropSpec with PropertyChecks with Matchers with MockitoSugar {
+class NonWindowStateSpec extends AnyPropSpec with ScalaCheckPropertyChecks with Matchers with MockitoSugar {
 
   val longGen = Gen.chooseNum[Long](100L, System.currentTimeMillis())
 

--- a/streaming/src/test/scala/io/gearpump/streaming/state/impl/NonWindowStateSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/state/impl/NonWindowStateSpec.scala
@@ -18,12 +18,13 @@ import io.gearpump.Time.MilliSeconds
 import io.gearpump.streaming.state.api.{Monoid, Serializer}
 import org.mockito.Mockito._
 import org.scalacheck.Gen
-import org.scalatest.{Matchers, PropSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.prop.PropertyChecks
 import scala.util.Success
 
-class NonWindowStateSpec extends PropSpec with PropertyChecks with Matchers with MockitoSugar {
+class NonWindowStateSpec extends AnyPropSpec with PropertyChecks with Matchers with MockitoSugar {
 
   val longGen = Gen.chooseNum[Long](100L, System.currentTimeMillis())
 

--- a/streaming/src/test/scala/io/gearpump/streaming/state/impl/WindowSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/state/impl/WindowSpec.scala
@@ -16,11 +16,12 @@ package io.gearpump.streaming.state.impl
 
 import io.gearpump.Time.MilliSeconds
 import org.scalacheck.Gen
-import org.scalatest.{Matchers, PropSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.prop.PropertyChecks
 
-class WindowSpec extends PropSpec with PropertyChecks with Matchers with MockitoSugar {
+class WindowSpec extends AnyPropSpec with PropertyChecks with Matchers with MockitoSugar {
 
   val windowSizeGen = Gen.chooseNum[Long](1L, 1000L)
   val windowStepGen = Gen.chooseNum[Long](1L, 1000L)

--- a/streaming/src/test/scala/io/gearpump/streaming/state/impl/WindowSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/state/impl/WindowSpec.scala
@@ -18,10 +18,10 @@ import io.gearpump.Time.MilliSeconds
 import org.scalacheck.Gen
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.propspec.AnyPropSpec
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.prop.PropertyChecks
+import io.gearpump.testkit.MockitoSugar
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
-class WindowSpec extends AnyPropSpec with PropertyChecks with Matchers with MockitoSugar {
+class WindowSpec extends AnyPropSpec with ScalaCheckPropertyChecks with Matchers with MockitoSugar {
 
   val windowSizeGen = Gen.chooseNum[Long](1L, 1000L)
   val windowStepGen = Gen.chooseNum[Long](1L, 1000L)

--- a/streaming/src/test/scala/io/gearpump/streaming/state/impl/WindowStateSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/state/impl/WindowStateSpec.scala
@@ -19,13 +19,14 @@ import io.gearpump.streaming.MockUtil
 import io.gearpump.streaming.state.api.{Group, Serializer}
 import org.mockito.Mockito._
 import org.scalacheck.Gen
-import org.scalatest.{Matchers, PropSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.prop.PropertyChecks
 import scala.collection.immutable.TreeMap
 import scala.util.Success
 
-class WindowStateSpec extends PropSpec with PropertyChecks with Matchers with MockitoSugar {
+class WindowStateSpec extends AnyPropSpec with PropertyChecks with Matchers with MockitoSugar {
 
   val longGen = Gen.chooseNum[Long](100L, 10000L)
 

--- a/streaming/src/test/scala/io/gearpump/streaming/state/impl/WindowStateSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/state/impl/WindowStateSpec.scala
@@ -21,12 +21,12 @@ import org.mockito.Mockito._
 import org.scalacheck.Gen
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.propspec.AnyPropSpec
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.prop.PropertyChecks
+import io.gearpump.testkit.MockitoSugar
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import scala.collection.immutable.TreeMap
 import scala.util.Success
 
-class WindowStateSpec extends AnyPropSpec with PropertyChecks with Matchers with MockitoSugar {
+class WindowStateSpec extends AnyPropSpec with ScalaCheckPropertyChecks with Matchers with MockitoSugar {
 
   val longGen = Gen.chooseNum[Long](100L, 10000L)
 

--- a/streaming/src/test/scala/io/gearpump/streaming/storage/InMemoryAppStoreOnMasterSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/storage/InMemoryAppStoreOnMasterSpec.scala
@@ -16,7 +16,9 @@ package io.gearpump.streaming.storage
 import io.gearpump.cluster.{MasterHarness, MiniCluster}
 import io.gearpump.streaming.StreamingTestUtil
 import io.gearpump.util.Constants
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import scala.concurrent.Await
 import scala.concurrent.duration._
 

--- a/streaming/src/test/scala/io/gearpump/streaming/storage/InMemoryAppStoreOnMasterSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/storage/InMemoryAppStoreOnMasterSpec.scala
@@ -20,7 +20,7 @@ import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class InMemoryAppStoreOnMasterSpec extends WordSpec with Matchers with BeforeAndAfterAll {
+class InMemoryAppStoreOnMasterSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll {
   implicit val timeout: org.apache.pekko.util.Timeout = Constants.FUTURE_TIMEOUT
   implicit val dispatcher: scala.concurrent.ExecutionContext = MasterHarness.cachedPool
 

--- a/streaming/src/test/scala/io/gearpump/streaming/task/SubscriberSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/task/SubscriberSpec.scala
@@ -18,9 +18,10 @@ import io.gearpump.streaming.partitioner.{HashPartitioner, Partitioner}
 import io.gearpump.streaming.task.SubscriberSpec.TestTask
 import io.gearpump.util.Graph
 import io.gearpump.util.Graph._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class SubscriberSpec extends FlatSpec with Matchers {
+class SubscriberSpec extends AnyFlatSpec with Matchers {
   "Subscriber.of" should "return all subscriber for a processor" in {
 
     val sourceProcessorId = 0

--- a/streaming/src/test/scala/io/gearpump/streaming/task/SubscriptionSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/task/SubscriptionSpec.scala
@@ -25,7 +25,7 @@ import java.util.Random
 import org.mockito.Mockito._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.mockito.MockitoSugar
+import io.gearpump.testkit.MockitoSugar
 
 class SubscriptionSpec extends AnyFlatSpec with Matchers with MockitoSugar {
 

--- a/streaming/src/test/scala/io/gearpump/streaming/task/SubscriptionSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/task/SubscriptionSpec.scala
@@ -23,10 +23,11 @@ import io.gearpump.streaming.task.SubscriptionSpec.NextTask
 import java.time.Instant
 import java.util.Random
 import org.mockito.Mockito._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.mockito.MockitoSugar
 
-class SubscriptionSpec extends FlatSpec with Matchers with MockitoSugar {
+class SubscriptionSpec extends AnyFlatSpec with Matchers with MockitoSugar {
 
   val appId = 0
   val executorId = 0

--- a/streaming/src/test/scala/io/gearpump/streaming/task/TaskActorSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/task/TaskActorSpec.scala
@@ -26,7 +26,9 @@ import io.gearpump.streaming.task.TaskActorSpec.TestTask
 import io.gearpump.util.{Graph, Util}
 import io.gearpump.util.Graph._
 import org.mockito.Mockito.{mock, times, verify, when}
-import org.scalatest.{BeforeAndAfterEach, Matchers, WordSpec}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 class TaskActorSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach with MasterHarness {
   protected override def config: Config = {

--- a/streaming/src/test/scala/io/gearpump/streaming/task/TaskActorSpec.scala
+++ b/streaming/src/test/scala/io/gearpump/streaming/task/TaskActorSpec.scala
@@ -28,7 +28,7 @@ import io.gearpump.util.Graph._
 import org.mockito.Mockito.{mock, times, verify, when}
 import org.scalatest.{BeforeAndAfterEach, Matchers, WordSpec}
 
-class TaskActorSpec extends WordSpec with Matchers with BeforeAndAfterEach with MasterHarness {
+class TaskActorSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach with MasterHarness {
   protected override def config: Config = {
     ConfigFactory.parseString(
       """ pekko.loggers = ["org.apache.pekko.testkit.TestEventListener"]


### PR DESCRIPTION
### Motivation

- Update test code to use the newer ScalaTest 3.2+ APIs and remove deprecated/unqualified trait imports to maintain compatibility with current ScalaTest versions.
- Standardize test base classes and matcher imports across modules to avoid deprecation warnings and ensure consistent test style.

### Description

- Replaced legacy `FlatSpec`/`WordSpec` with `AnyFlatSpec`/`AnyWordSpec` across multiple test files. 
- Switched `org.scalatest.Matchers` to `org.scalatest.matchers.should.Matchers` and adjusted imports to explicit single-type imports (e.g. `BeforeAndAfterAll`, `BeforeAndAfterEach`).
- Updated test class inheritance to use the new traits (for example `class XSpec extends AnyFlatSpec with Matchers ...`).
- Applied the same migration across tests in `core`, `streaming`, `examples`, and `services/jvm` modules to keep the repository consistent.

### Testing

- Ran the project's test suite via `sbt test` (unit tests) after the changes and verified that the test compilation and execution completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e931b73308330b787e17ebe697f9a)