### PR TITLE
Upgrade Hadoop dependencies to 3.4.1

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,7 +22,7 @@ object Dependencies {
   val pekkoVersion = "1.6.0"
   val pekkoHttpVersion = "1.3.0"
   val pekkoHttpSessionVersion = "0.7.1"
-  val hadoopVersion = "3.1.4"
+  val hadoopVersion = "3.4.1"
   val commonsHttpVersion = "3.1"
   val commonsLoggingVersion = "1.3.6"
   val commonsLangVersion = "2.6"


### PR DESCRIPTION
### Motivation
- Bump the shared `hadoopVersion` so modules that consume it (notably `gearpump-hadoop` which uses `hadoop-hdfs` and `hadoop-common`) move to Hadoop 3.4.1.

### Description
- Update `project/Dependencies.scala` to set `val hadoopVersion = "3.4.1"` (was `"3.1.4"`).

### Testing
- Ran `sbt gearpump-hadoop/compile`, which failed to run because `sbt` is not installed in this execution environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a150dbcc8948330b46c1ec283b07b48)