### PR TITLE
Migrate logging backend to Log4j 2

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -34,6 +34,7 @@ object Dependencies {
   val jsonSimpleVersion = "1.1"
   val slf4jVersion = "1.7.16"
   val slf4jSimpleVersion = "2.0.18"
+  val log4jVersion = "2.25.2"
   val guavaVersion = "33.6.0-jre"
   val codahaleVersion = "3.0.2"
   val pekkoKryoVersion = "1.5.1"
@@ -67,7 +68,10 @@ object Dependencies {
   val coreDependencies = Seq(
     libraryDependencies ++= Seq(
       "org.slf4j" % "slf4j-api" % slf4jVersion,
-      "org.slf4j" % "slf4j-log4j12" % slf4jVersion,
+      "org.apache.logging.log4j" % "log4j-api" % log4jVersion,
+      "org.apache.logging.log4j" % "log4j-core" % log4jVersion,
+      "org.apache.logging.log4j" % "log4j-slf4j-impl" % log4jVersion,
+      "org.apache.logging.log4j" % "log4j-1.2-api" % log4jVersion,
       "commons-lang" % "commons-lang" % commonsLangVersion,
 
       /**


### PR DESCRIPTION
### Motivation
- Replace the legacy Log4j 1.x SLF4J binding with Log4j 2 so SLF4J calls and any Log4j 1 API usage are routed through a modern Log4j 2 implementation.

### Description
- Added `val log4jVersion = "2.25.2"` and replaced the `"org.slf4j" % "slf4j-log4j12"` dependency with `org.apache.logging.log4j` artifacts (`log4j-api`, `log4j-core`, `log4j-slf4j-impl`, and `log4j-1.2-api`) in `project/Dependencies.scala`, while keeping `slf4j-api`.

### Testing
- Attempted to run `sbt core/compile`, but the command could not be executed because `sbt` is not installed in this environment, so compilation was not verified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15107775108330a25689e81bdf9f3e)