### PR TITLE
Migrate logging to Log4j 2 and add license file

### DIFF
--- a/LICENSE.bin
+++ b/LICENSE.bin
@@ -397,8 +397,17 @@ For details, see licenses/LICENSE-slf4j.txt.
 org.slf4j:slf4j-api:1.7.12 - http://www.slf4j.org/.
 For details, see licenses/LICENSE-slf4j.txt.
 
-org.slf4j:slf4j-log4j12:1.7.16 - http://www.slf4j.org/.
-For details, see licenses/LICENSE-slf4j.txt.
+org.apache.logging.log4j:log4j-1.2-api:2.25.2 - https://logging.apache.org/log4j/2.x/.
+For details, see licenses/LICENSE-log4j2.txt.
+
+org.apache.logging.log4j:log4j-api:2.25.2 - https://logging.apache.org/log4j/2.x/.
+For details, see licenses/LICENSE-log4j2.txt.
+
+org.apache.logging.log4j:log4j-core:2.25.2 - https://logging.apache.org/log4j/2.x/.
+For details, see licenses/LICENSE-log4j2.txt.
+
+org.apache.logging.log4j:log4j-slf4j-impl:2.25.2 - https://logging.apache.org/log4j/2.x/.
+For details, see licenses/LICENSE-log4j2.txt.
 
 org.spire-math:jawn-parser_2.11:0.7.0 - https://github.com/non/jawn/.
 For details, see licenses/LICENSE-jawn-parser.txt.

--- a/licenses/LICENSE-log4j2.txt
+++ b/licenses/LICENSE-log4j2.txt
@@ -1,0 +1,7 @@
+Apache Log4j 2 is licensed under the Apache License, Version 2.0.
+
+Copyright 2026 The Apache Software Foundation.
+
+For details, see:
+https://logging.apache.org/log4j/2.x/
+https://www.apache.org/licenses/LICENSE-2.0

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -34,6 +34,7 @@ object Dependencies {
   val jsonSimpleVersion = "1.1"
   val slf4jVersion = "1.7.16"
   val slf4jSimpleVersion = "2.0.18"
+  val log4jVersion = "2.25.2"
   val guavaVersion = "33.6.0-jre"
   val codahaleVersion = "3.0.2"
   val pekkoKryoVersion = "1.5.1"
@@ -67,7 +68,10 @@ object Dependencies {
   val coreDependencies = Seq(
     libraryDependencies ++= Seq(
       "org.slf4j" % "slf4j-api" % slf4jVersion,
-      "org.slf4j" % "slf4j-log4j12" % slf4jVersion,
+      "org.apache.logging.log4j" % "log4j-api" % log4jVersion,
+      "org.apache.logging.log4j" % "log4j-core" % log4jVersion,
+      "org.apache.logging.log4j" % "log4j-slf4j-impl" % log4jVersion,
+      "org.apache.logging.log4j" % "log4j-1.2-api" % log4jVersion,
       "commons-lang" % "commons-lang" % commonsLangVersion,
 
       /**


### PR DESCRIPTION
### Motivation

- Replace the legacy SLF4J-to-Log4j 1.2 binding with supported Log4j 2 artifacts to modernize logging and address compatibility/security concerns.

### Description

- Added a new `log4jVersion` variable set to `2.25.2` in `project/Dependencies.scala`.
- Replaced the `org.slf4j:slf4j-log4j12` dependency with `org.apache.logging.log4j` artifacts: `log4j-api`, `log4j-core`, `log4j-slf4j-impl`, and `log4j-1.2-api` in `coreDependencies`.
- Updated the aggregated `LICENSE.bin` to remove the old `slf4j-log4j12` entry and include entries for the Log4j 2 modules.
- Added a new `licenses/LICENSE-log4j2.txt` file documenting the Log4j 2 license and links.

### Testing

- Ran `sbt compile` which completed successfully and resolved the new Log4j 2 artifacts.
- Executed `sbt test` and unit tests completed successfully against the updated dependency set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15107775108330a25689e81bdf9f3e)