### PR TITLE
Follow-up: bump Netty 3 dependency to 3.10.6.Final

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -78,7 +78,7 @@ object Dependencies {
        * Gearpump's internal transport still uses the legacy Netty 3 API
        * (`org.jboss.netty.*`), so keep the original Netty 3 line on the classpath.
        */
-      "io.netty" % "netty" % "3.8.0.Final",
+      "io.netty" % "netty" % "3.10.6.Final",
       /**
        * Pekko classic remoting now expects Netty 4 (`io.netty.channel.Channel`) and publishes
        * those modules as optional dependencies, so add them explicitly for runtime/test startup.


### PR DESCRIPTION
### Motivation
- Reduce exposure flagged by CVE-2019-20444 findings and satisfy dependency hygiene by moving the legacy Netty 3 line to the latest available 3.x release.

### Description
- Update in `project/Dependencies.scala` replacing `"io.netty" % "netty" % "3.8.0.Final"` with `"io.netty" % "netty" % "3.10.6.Final"` to bump the legacy Netty 3 dependency.

### Testing
- Attempted `sbt 'core/compile'` to validate the change but the command failed in this environment because `sbt` is not installed (`/bin/bash: sbt: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16698bffa883309b59bc51cd3d4833)