### PR TITLE
Follow-up: upgrade async-http-client to org.asynchttpclient:3.0.10

### DIFF
--- a/project/BuildDashboard.scala
+++ b/project/BuildDashboard.scala
@@ -30,7 +30,7 @@ object BuildDashboard {
         "com.softwaremill.pekko-http-session" %% "core" % pekkoHttpSessionVersion,
         "org.apache.pekko" %% "pekko-http-spray-json" % pekkoHttpVersion,
         "com.github.scribejava" % "scribejava-apis" % "2.4.0",
-        "com.ning" % "async-http-client" % "1.9.40",
+        "org.asynchttpclient" % "async-http-client" % "3.0.10",
         "org.webjars" % "angularjs" % "1.4.9",
 
         // angular 1.5 breaks ui-select, but we need ng-touch 1.5

--- a/services/jvm/src/main/scala/io/gearpump/services/security/oauth2/impl/BaseOAuth2Authenticator.scala
+++ b/services/jvm/src/main/scala/io/gearpump/services/security/oauth2/impl/BaseOAuth2Authenticator.scala
@@ -19,7 +19,7 @@ import com.github.scribejava.core.builder.api.DefaultApi20
 import com.github.scribejava.core.model._
 import com.github.scribejava.core.oauth.OAuth20Service
 import com.github.scribejava.core.utils.OAuthEncoder
-import com.ning.http.client.AsyncHttpClientConfig
+import org.asynchttpclient.AsyncHttpClientConfig
 import com.typesafe.config.Config
 import io.gearpump.security.Authenticator
 import io.gearpump.services.SecurityService.UserSession

--- a/services/jvm/src/main/scala/io/gearpump/services/security/oauth2/impl/CloudFoundryUAAOAuth2Authenticator.scala
+++ b/services/jvm/src/main/scala/io/gearpump/services/security/oauth2/impl/CloudFoundryUAAOAuth2Authenticator.scala
@@ -18,8 +18,8 @@ import java.util.Base64
 import com.github.scribejava.core.builder.api.DefaultApi20
 import com.github.scribejava.core.model._
 import com.github.scribejava.core.oauth.OAuth20Service
-import com.ning.http.client
-import com.ning.http.client.{AsyncCompletionHandler, AsyncHttpClient}
+import org.asynchttpclient
+import org.asynchttpclient.{AsyncCompletionHandler, AsyncHttpClient}
 import com.typesafe.config.Config
 import io.gearpump.services.SecurityService.UserSession
 import io.gearpump.services.security.oauth2.impl.BaseOAuth2Authenticator.BaseApi20


### PR DESCRIPTION
### Motivation
- Address reviewer follow-up to move off the legacy unmaintained `com.ning:async-http-client` coordinates and align the dashboard OAuth client with a maintained `org.asynchttpclient` release.
- Reduce exposure to CVE/maintenance risk by upgrading the async HTTP client used by the dashboard and OAuth services.

### Description
- Replaced the dashboard dependency `com.ning:async-http-client:1.9.40` with `org.asynchttpclient:async-http-client:3.0.10` in `project/BuildDashboard.scala`.
- Updated imports in the OAuth2 service implementations to use `org.asynchttpclient` types by replacing `com.ning.http.client.*` imports with `org.asynchttpclient.*` in `services/jvm/src/main/scala/io/gearpump/services/security/oauth2/impl/BaseOAuth2Authenticator.scala` and `CloudFoundryUAAOAuth2Authenticator.scala` so source references match the new artifact.
- Created a follow-up PR metadata entry via the repo `make_pr` helper describing this delta on top of the original CVE PR.

### Testing
- Attempted to run `sbt 'servicesJVM/compile'` to validate the change, but the command failed in this environment because `sbt` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16ab2525c88330ba3faa7c53b56a68)