### PR TITLE
[codex] Tune Dependabot sbt updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,4 @@
 version: 2
-enable-beta-ecosystems: true
 updates:
   - package-ecosystem: github-actions
     directory: "/"
@@ -19,8 +18,39 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    open-pull-requests-limit: 15
     commit-message:
       prefix: build
     labels:
       - dependencies
       - sbt
+    groups:
+      apache-beam:
+        patterns:
+          - "org.apache.beam:*"
+      apache-hadoop:
+        patterns:
+          - "org.apache.hadoop:*"
+      apache-log4j:
+        patterns:
+          - "org.apache.logging.log4j:*"
+      netty-four:
+        patterns:
+          - "io.netty:netty-handler"
+          - "io.netty:netty-transport"
+      apache-pekko:
+        patterns:
+          - "org.apache.pekko:*"
+      sbt-plugins:
+        patterns:
+          - "com.eed3si9n:*"
+          - "com.github.gseitz:*"
+          - "com.github.sbt.junit:sbt-jupiter-interface"
+          - "com.jsuereth:*"
+          - "org.scalastyle:*"
+          - "org.scoverage:*"
+          - "org.xerial.sbt:*"
+    ignore:
+      - dependency-name: "org.webjars:*"
+      - dependency-name: "org.webjars.bower:*"
+      - dependency-name: "org.webjars.npm:*"


### PR DESCRIPTION
## Summary

This updates the sbt Dependabot configuration so Java and Scala dependency updates are less likely to be crowded out by low-signal dashboard dependency PRs.

Changes:
- raise the sbt `open-pull-requests-limit` to 15
- group high-signal JVM dependency families: Beam, Hadoop, Log4j, Netty 4, Pekko, and sbt plugins
- ignore WebJar dependency families in Dependabot
- remove the unused `enable-beta-ecosystems` option

## Why

The latest Dependabot sbt run was resolving meaningful updates such as Beam, Hadoop, Log4j, and Netty, but several of those ended with `No update possible` while the queue was filled by WebJar/plugin PRs. Grouping the JVM families and reducing WebJar noise should make Dependabot's output easier to review and keep the queue available for more important dependency work.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml"); puts "dependabot.yml YAML OK"'`
- `git diff --check -- .github/dependabot.yml`