### PR TITLE
[codex] Fix local cluster startup

### DIFF
--- a/core/src/main/resources/geardefault.conf
+++ b/core/src/main/resources/geardefault.conf
@@ -603,6 +603,7 @@ pekko {
   log-dead-letters-during-shutdown = off
   actor {
     provider = "remote"
+    allow-java-serialization = on
 
     ## Doesn't warn on Java serializer usage
     ##
@@ -627,6 +628,7 @@ pekko {
     }
   }
   remote {
+    use-unsafe-remote-features-outside-cluster = on
     artery.enabled = off
     default-remote-dispatcher {
       throughput = 5

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -32,7 +32,7 @@ object Dependencies {
   val junitJupiterVersion = "5.14.4"
   val jupiterInterfaceVersion = "0.16.0"
   val jsonSimpleVersion = "1.1"
-  val slf4jVersion = "1.7.16"
+  val slf4jVersion = "2.0.17"
   val slf4jSimpleVersion = "2.0.18"
   val log4jVersion = "2.25.2"
   val guavaVersion = "33.6.0-jre"
@@ -70,7 +70,7 @@ object Dependencies {
       "org.slf4j" % "slf4j-api" % slf4jVersion,
       "org.apache.logging.log4j" % "log4j-api" % log4jVersion,
       "org.apache.logging.log4j" % "log4j-core" % log4jVersion,
-      "org.apache.logging.log4j" % "log4j-slf4j-impl" % log4jVersion,
+      "org.apache.logging.log4j" % "log4j-slf4j2-impl" % log4jVersion,
       "org.apache.logging.log4j" % "log4j-1.2-api" % log4jVersion,
       "commons-lang" % "commons-lang" % commonsLangVersion,
 
@@ -98,7 +98,8 @@ object Dependencies {
       "org.apache.pekko" %% "pekko-http" % pekkoHttpVersion,
       "org.apache.pekko" %% "pekko-http-spray-json" % pekkoHttpVersion,
       "org.scala-lang" % "scala-reflect" % scalaVersionNumber,
-      "io.altoo" %% "pekko-kryo-serialization" % pekkoKryoVersion,
+      "io.altoo" %% "pekko-kryo-serialization" % pekkoKryoVersion
+        exclude("org.slf4j", "log4j-over-slf4j"),
       "com.google.guava" % "guava" % guavaVersion,
       "com.codahale.metrics" % "metrics-graphite" % codahaleVersion
         exclude("org.slf4j", "slf4j-api"),


### PR DESCRIPTION
## Summary

- align Gearpump's SLF4J runtime dependency with the Log4j 2 SLF4J bridge
- exclude `log4j-over-slf4j` from `pekko-kryo-serialization` to avoid conflicting SLF4J bridge wiring
- enable the Pekko remote compatibility settings needed by the local cluster's existing control-message path

## Root Cause

After the Log4j 2 and Pekko upgrades, the local runtime still had a mixed SLF4J 1.x/2.x bridge setup and Pekko 1.6 blocked the legacy Java-serialization remote control path by default. That prevented workers from registering reliably in a local cluster launch.

## Validation

- `git diff --check`
- `sbt "gearpump-core / Test / compile"`