### PR TITLE
[codex] Add Beam quick start example

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,7 @@ import BuildGearpump._
 import Dependencies._
 import Docs._
 import Pack.packSettings
+import sbtassembly.AssemblyPlugin.autoImport._
 import sbtunidoc.JavaUnidocPlugin
 import sbtunidoc.ScalaUnidocPlugin
 
@@ -26,6 +27,7 @@ lazy val aggregated: Seq[ProjectReference] = Seq[ProjectReference](
   streaming,
   services,
   beamRunner,
+  beamQuickStart,
   gearpumpHadoop,
   packProject,
   complexdag,
@@ -144,6 +146,29 @@ lazy val beamRunner = Project(
   base = file("experiments/beam"))
   .settings(commonSettings ++ javadocSettings ++ beamRunnerDependencies: _*)
   .dependsOn(core % "provided", streaming % "provided")
+
+lazy val beamQuickStart = Project(
+  id = "gearpump-examples-beam-quickstart",
+  base = file("examples/beam/quickstart"))
+  .settings(commonSettings ++ noPublish ++ myAssemblySettings ++ Seq(
+    Compile / mainClass :=
+      Some("io.gearpump.examples.beam.quickstart.BeamQuickStart"),
+    assembly / mainClass :=
+      Some("io.gearpump.examples.beam.quickstart.BeamQuickStart"),
+    assembly / assemblyMergeStrategy := {
+      case PathList("META-INF", "services", _*) =>
+        MergeStrategy.concat
+      case PathList("META-INF", _*) | "module-info.class" =>
+        MergeStrategy.discard
+      case "geardefault.conf" =>
+        MergeStrategy.last
+      case "reference.conf" =>
+        MergeStrategy.concat
+      case _ =>
+        MergeStrategy.first
+    }
+  ))
+  .dependsOn(core, streaming, beamRunner)
 
 /**
  * The follow examples can be run in IDE or with `sbt run`

--- a/examples/beam/quickstart/README.md
+++ b/examples/beam/quickstart/README.md
@@ -1,0 +1,83 @@
+# Gearpump Beam Quick Start
+
+This example submits a small Apache Beam pipeline to a Gearpump local cluster. By default, the
+bounded pipeline tokenizes two lines, counts words with `Sum.integersPerKey()`, and writes the
+result to `target/beam-quickstart/output.txt`.
+
+From a source checkout, use a stable runtime classpath for long-running local daemons:
+
+```bash
+mkdir -p target/beam-quickstart
+cp conf/gear.conf target/beam-quickstart/gear.conf
+perl -0pi -e \
+  's/masters = \["127\.0\.0\.1:3000"\]/masters = ["127.0.0.1:3010"]/g' \
+  target/beam-quickstart/gear.conf
+printf '\ngearpump.worker.executor-share-same-jvm-as-worker = true\n' \
+  >> target/beam-quickstart/gear.conf
+
+sbt "show gearpump-examples-beam-quickstart / Runtime / fullClasspath" \
+  > target/beam-quickstart/fullclasspath.raw
+sed -n 's/^\[info\] \* Attributed(\(.*\))$/\1/p' \
+  target/beam-quickstart/fullclasspath.raw \
+  > target/beam-quickstart/classpath.entries
+paste -sd: target/beam-quickstart/classpath.entries \
+  > target/beam-quickstart/classpath.txt
+```
+
+Start the local master and at least one worker in separate shells:
+
+```bash
+java -Djava.net.preferIPv4Stack=true \
+  -Dgearpump.home="$PWD" \
+  -Dgearpump.config.file=target/beam-quickstart/gear.conf \
+  -cp "conf:$(cat target/beam-quickstart/classpath.txt)" \
+  io.gearpump.cluster.main.Master -ip 127.0.0.1 -port 3010
+
+java -Djava.net.preferIPv4Stack=true \
+  -Dgearpump.home="$PWD" \
+  -Dgearpump.config.file=target/beam-quickstart/gear.conf \
+  -cp "conf:$(cat target/beam-quickstart/classpath.txt)" \
+  io.gearpump.cluster.main.Worker
+```
+
+Submit the Beam pipeline:
+
+```bash
+java -Djava.net.preferIPv4Stack=true \
+  -Dgearpump.home="$PWD" \
+  -Dgearpump.config.file=target/beam-quickstart/gear.conf \
+  -cp "conf:$(cat target/beam-quickstart/classpath.txt)" \
+  io.gearpump.examples.beam.quickstart.BeamQuickStart \
+  --remote=true \
+  --output=target/beam-quickstart/output.txt
+```
+
+The client waits for the bounded output, terminates the application, and prints the sorted counts:
+
+```text
+apache=1
+beam=2
+gearpump=2
+on=1
+pipelines=1
+runs=2
+```
+
+To keep the application visible as active in the Web UI after the bounded output is written, submit
+with `--keepRunning=true`:
+
+```bash
+java -Djava.net.preferIPv4Stack=true \
+  -Dgearpump.home="$PWD" \
+  -Dgearpump.config.file=target/beam-quickstart/gear.conf \
+  -cp "conf:$(cat target/beam-quickstart/classpath.txt)" \
+  io.gearpump.examples.beam.quickstart.BeamQuickStart \
+  --remote=true \
+  --output=target/beam-quickstart/output.txt \
+  --keepRunning=true
+```
+
+Use `--keepRunningMillis=<milliseconds>` with `--keepRunning=true` to stop after a fixed delay
+instead of waiting until the client is interrupted. Long-running mode adds a basic unbounded Beam
+source that writes a periodic heartbeat to `<output>.keep-running` while the application stays
+active.

--- a/examples/beam/quickstart/src/main/java/io/gearpump/examples/beam/quickstart/BeamQuickStart.java
+++ b/examples/beam/quickstart/src/main/java/io/gearpump/examples/beam/quickstart/BeamQuickStart.java
@@ -1,0 +1,332 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gearpump.examples.beam.quickstart;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.TreeSet;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+import org.apache.beam.runners.gearpump.GearpumpPipelineOptions;
+import org.apache.beam.runners.gearpump.GearpumpPipelineResult;
+import org.apache.beam.runners.gearpump.GearpumpRunner;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.SerializableCoder;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.io.Read;
+import org.apache.beam.sdk.io.UnboundedSource;
+import org.apache.beam.sdk.options.Default;
+import org.apache.beam.sdk.options.Description;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.Sum;
+import org.apache.beam.sdk.values.KV;
+
+/** Quick start Beam pipeline for the Gearpump runner. */
+public final class BeamQuickStart {
+
+  private static final int EXPECTED_OUTPUT_LINES = 6;
+
+  private BeamQuickStart() {}
+
+  public interface QuickStartOptions extends GearpumpPipelineOptions {
+
+    @Description("Local file written by the Beam workers")
+    @Default.String("target/beam-quick-start-output.txt")
+    String getOutput();
+
+    void setOutput(String output);
+
+    @Description("Milliseconds to wait for the bounded local output")
+    @Default.Long(30000)
+    Long getWaitMillis();
+
+    void setWaitMillis(Long waitMillis);
+
+    @Description("Keep the Gearpump application running after the bounded output is written")
+    @Default.Boolean(false)
+    Boolean getKeepRunning();
+
+    void setKeepRunning(Boolean keepRunning);
+
+    @Description("Milliseconds to keep running after output; 0 means until interrupted")
+    @Default.Long(0)
+    Long getKeepRunningMillis();
+
+    void setKeepRunningMillis(Long keepRunningMillis);
+  }
+
+  public static void main(String[] args) throws Exception {
+    QuickStartOptions options =
+        PipelineOptionsFactory.fromArgs(args).as(QuickStartOptions.class);
+    options.setRunner(GearpumpRunner.class);
+    if (options.getApplicationName() == null) {
+      options.setApplicationName("beamQuickStart");
+    }
+
+    Path output = Paths.get(options.getOutput()).toAbsolutePath();
+    prepareOutput(output);
+
+    Pipeline pipeline = Pipeline.create(options);
+    if (Boolean.TRUE.equals(options.getKeepRunning())) {
+      Path keepRunningOutput = Paths.get(options.getOutput() + ".keep-running").toAbsolutePath();
+      prepareOutput(keepRunningOutput);
+      pipeline
+          .apply(
+              "KeepRunningInput",
+              Read.from(new KeepRunningSource(options.getKeepRunningMillis())))
+          .apply(
+              "WriteKeepRunningOutput",
+              ParDo.of(new WriteOutputFn(keepRunningOutput.toString())));
+    }
+    pipeline
+        .apply(
+            "Input",
+            Create.of("Apache Beam runs on Gearpump", "Gearpump runs Beam pipelines"))
+        .apply("ExtractWords", ParDo.of(new ExtractWordsFn()))
+        .apply("CountWords", Sum.integersPerKey())
+        .apply("FormatCounts", ParDo.of(new FormatCountsFn()))
+        .apply("WriteOutput", ParDo.of(new WriteOutputFn(output.toString())));
+
+    GearpumpPipelineResult result = null;
+    try {
+      result = (GearpumpPipelineResult) pipeline.run();
+      List<String> lines =
+          waitForOutput(output, EXPECTED_OUTPUT_LINES, options.getWaitMillis());
+      System.out.println("Beam quick start output:");
+      for (String line : lines) {
+        System.out.println(line);
+      }
+      if (Boolean.TRUE.equals(options.getKeepRunning())) {
+        keepRunning(options.getKeepRunningMillis());
+      }
+    } finally {
+      if (result != null) {
+        try {
+          result.cancel();
+        } finally {
+          result.getClientContext().close();
+        }
+      }
+    }
+  }
+
+  private static void prepareOutput(Path output) throws IOException {
+    Path parent = output.getParent();
+    if (parent != null) {
+      Files.createDirectories(parent);
+    }
+    Files.deleteIfExists(output);
+  }
+
+  private static List<String> waitForOutput(Path output, int expectedLineCount, long waitMillis)
+      throws IOException, InterruptedException {
+    long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(waitMillis);
+    while (System.nanoTime() < deadline) {
+      if (Files.exists(output)) {
+        TreeSet<String> lines =
+            new TreeSet<>(Files.readAllLines(output, StandardCharsets.UTF_8));
+        if (lines.size() >= expectedLineCount) {
+          return new ArrayList<>(lines);
+        }
+      }
+      Thread.sleep(250);
+    }
+    throw new IllegalStateException(
+        "Timed out waiting for Beam quick start output in " + output);
+  }
+
+  private static void keepRunning(long keepRunningMillis) throws InterruptedException {
+    if (keepRunningMillis > 0) {
+      System.out.println(
+          "Keeping Beam quick start application running for " + keepRunningMillis + " ms.");
+      Thread.sleep(keepRunningMillis);
+    } else {
+      System.out.println("Keeping Beam quick start application running until interrupted.");
+      new CountDownLatch(1).await();
+    }
+  }
+
+  private static final class KeepRunningSource
+      extends UnboundedSource<String, KeepRunningCheckpoint> {
+    private static final long serialVersionUID = 1L;
+    private static final long INTERVAL_MILLIS = 1000L;
+
+    private final long keepRunningMillis;
+
+    private KeepRunningSource(long keepRunningMillis) {
+      this.keepRunningMillis = keepRunningMillis;
+    }
+
+    @Override
+    public List<? extends UnboundedSource<String, KeepRunningCheckpoint>> split(
+        int desiredNumSplits, PipelineOptions options) {
+      return Collections.singletonList(this);
+    }
+
+    @Override
+    public UnboundedReader<String> createReader(
+        PipelineOptions options, KeepRunningCheckpoint checkpointMark) {
+      return new KeepRunningReader(this);
+    }
+
+    @Override
+    public void validate() {}
+
+    @Override
+    public Coder<String> getOutputCoder() {
+      return StringUtf8Coder.of();
+    }
+
+    @Override
+    public Coder<KeepRunningCheckpoint> getCheckpointMarkCoder() {
+      return SerializableCoder.of(KeepRunningCheckpoint.class);
+    }
+  }
+
+  private static final class KeepRunningReader extends UnboundedSource.UnboundedReader<String> {
+    private final KeepRunningSource source;
+    private long startNanos;
+    private long sequence;
+    private String current;
+
+    private KeepRunningReader(KeepRunningSource source) {
+      this.source = source;
+    }
+
+    @Override
+    public boolean start() {
+      startNanos = System.nanoTime();
+      current = keepRunningMessage();
+      return true;
+    }
+
+    @Override
+    public boolean advance() throws IOException {
+      if (source.keepRunningMillis > 0
+          && elapsedMillis() >= source.keepRunningMillis) {
+        return false;
+      }
+      try {
+        Thread.sleep(KeepRunningSource.INTERVAL_MILLIS);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new IOException("Interrupted while emitting keep-running records", e);
+      }
+      sequence++;
+      current = keepRunningMessage();
+      return true;
+    }
+
+    @Override
+    public String getCurrent() {
+      return current;
+    }
+
+    @Override
+    public org.joda.time.Instant getCurrentTimestamp() {
+      return org.joda.time.Instant.now();
+    }
+
+    @Override
+    public void close() {}
+
+    @Override
+    public UnboundedSource<String, ?> getCurrentSource() {
+      return source;
+    }
+
+    @Override
+    public org.joda.time.Instant getWatermark() {
+      return org.joda.time.Instant.now();
+    }
+
+    @Override
+    public UnboundedSource.CheckpointMark getCheckpointMark() {
+      return new KeepRunningCheckpoint();
+    }
+
+    private long elapsedMillis() {
+      return TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+    }
+
+    private String keepRunningMessage() {
+      return "keep-running=" + sequence;
+    }
+  }
+
+  private static final class KeepRunningCheckpoint
+      implements UnboundedSource.CheckpointMark, Serializable {
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void finalizeCheckpoint() {}
+  }
+
+  private static final class ExtractWordsFn extends DoFn<String, KV<String, Integer>> {
+    private static final Pattern WORD_SEPARATOR = Pattern.compile("[^A-Za-z]+");
+
+    @ProcessElement
+    public void processElement(ProcessContext context) {
+      for (String word :
+          WORD_SEPARATOR.split(context.element().toLowerCase(Locale.ROOT))) {
+        if (!word.isEmpty()) {
+          context.output(KV.of(word, 1));
+        }
+      }
+    }
+  }
+
+  private static final class FormatCountsFn extends DoFn<KV<String, Integer>, String> {
+    @ProcessElement
+    public void processElement(ProcessContext context) {
+      KV<String, Integer> element = context.element();
+      context.output(element.getKey() + "=" + element.getValue());
+    }
+  }
+
+  private static final class WriteOutputFn extends DoFn<String, String> {
+    private final String output;
+
+    private WriteOutputFn(String output) {
+      this.output = output;
+    }
+
+    @ProcessElement
+    public void processElement(ProcessContext context) throws IOException {
+      String line = context.element();
+      Files.write(
+          Paths.get(output),
+          Collections.singletonList(line),
+          StandardCharsets.UTF_8,
+          StandardOpenOption.CREATE,
+          StandardOpenOption.APPEND);
+      context.output(line);
+    }
+  }
+}

--- a/experiments/beam/README.md
+++ b/experiments/beam/README.md
@@ -5,7 +5,7 @@ graph API.
 
 Current scope:
 
-- `Create`, `Impulse`, and other `Read.Bounded` sources
+- `Create`, `Impulse`, `Read.Bounded`, and basic `Read.Unbounded` sources
 - `ParDo`, including multi-output `ParDo` without side inputs
 - `Flatten.pCollections()`
 - `Window.into(...)` for non-merging windows
@@ -16,9 +16,12 @@ Current limitations:
 
 - No side inputs
 - No merging windows
-- No unbounded sources
+- No checkpoint restoration for unbounded sources
 - No Beam state/timers support
 - No custom trigger/pane semantics beyond one final emission at watermark max
 
 The implementation intentionally keeps the first supported transform set small and routes Beam
 execution through Gearpump's low-level runtime instead of the older DSL-based runner design.
+
+See `examples/beam/quickstart` for a runnable Beam quick start that submits to a Gearpump local
+cluster.

--- a/experiments/beam/src/main/java/org/apache/beam/runners/gearpump/translators/GearpumpPipelineTranslator.java
+++ b/experiments/beam/src/main/java/org/apache/beam/runners/gearpump/translators/GearpumpPipelineTranslator.java
@@ -44,6 +44,7 @@ public class GearpumpPipelineTranslator extends Pipeline.PipelineVisitor.Default
     registerTransformTranslator(Create.Values.class, new CreateValuesTranslator());
     registerTransformTranslator(Impulse.class, new ImpulseTranslator());
     registerTransformTranslator(Read.Bounded.class, new ReadBoundedTranslator());
+    registerTransformTranslator(Read.Unbounded.class, new ReadUnboundedTranslator());
     registerTransformTranslator(Flatten.PCollections.class, new FlattenPCollectionsTranslator());
     registerTransformTranslator(Window.Assign.class, new WindowAssignTranslator());
     registerTransformTranslator(GroupByKey.class, new GroupByKeyTranslator());
@@ -62,7 +63,9 @@ public class GearpumpPipelineTranslator extends Pipeline.PipelineVisitor.Default
   @Override
   public CompositeBehavior enterCompositeTransform(TransformHierarchy.Node node) {
     PTransform transform = node.getTransform();
-    if (transform instanceof Create.Values || transform instanceof Read.Bounded) {
+    if (transform instanceof Create.Values
+        || transform instanceof Read.Bounded
+        || transform instanceof Read.Unbounded) {
       TransformTranslator translator = getTransformTranslator(transform.getClass());
       if (translator == null) {
         throw new UnsupportedOperationException(
@@ -84,7 +87,7 @@ public class GearpumpPipelineTranslator extends Pipeline.PipelineVisitor.Default
           "Unsupported Beam transform "
               + transform.getClass().getName()
               + ". The low-level Gearpump runner currently supports only "
-              + "Read.Bounded/Create, Impulse, ParDo, Flatten, Window.Assign, "
+              + "Read.Bounded/Read.Unbounded/Create, Impulse, ParDo, Flatten, Window.Assign, "
               + "GroupByKey in non-merging windows, and Combine.GroupedValues.");
     }
     translationContext.setCurrentTransform(node, getPipeline());

--- a/experiments/beam/src/main/java/org/apache/beam/runners/gearpump/translators/ReadUnboundedTranslator.java
+++ b/experiments/beam/src/main/java/org/apache/beam/runners/gearpump/translators/ReadUnboundedTranslator.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.gearpump.translators;
+
+import io.gearpump.cluster.UserConfig;
+import io.gearpump.streaming.javaapi.Processor;
+import io.gearpump.streaming.source.DataSourceTask;
+import org.apache.beam.runners.gearpump.translators.io.UnboundedSourceWrapper;
+import org.apache.beam.sdk.io.Read;
+
+/** Translates a Beam {@link Read.Unbounded} into a Gearpump source processor. */
+public class ReadUnboundedTranslator<T> implements TransformTranslator<Read.Unbounded<T>> {
+
+  @Override
+  public void translate(Read.Unbounded<T> transform, TranslationContext context) {
+    UnboundedSourceWrapper<T> sourceWrapper =
+        new UnboundedSourceWrapper<>(transform.getSource(), context.getPipelineOptions());
+    Processor<DataSourceTask> source =
+        Processor.source(
+            sourceWrapper,
+            context.getParallelism(),
+            transform.getName(),
+            UserConfig.empty(),
+            context.getActorSystem());
+    context.getGraph().addVertex(source);
+    context.setOutputProcessor(context.getOutput(), source);
+  }
+}

--- a/experiments/beam/src/main/java/org/apache/beam/runners/gearpump/translators/io/UnboundedSourceWrapper.java
+++ b/experiments/beam/src/main/java/org/apache/beam/runners/gearpump/translators/io/UnboundedSourceWrapper.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.gearpump.translators.io;
+
+import io.gearpump.DefaultMessage;
+import io.gearpump.Message;
+import io.gearpump.streaming.source.DataSource;
+import io.gearpump.streaming.source.Watermark;
+import io.gearpump.streaming.task.TaskContext;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import org.apache.beam.runners.core.construction.SerializablePipelineOptions;
+import org.apache.beam.runners.gearpump.translators.utils.TranslatorUtils;
+import org.apache.beam.sdk.io.UnboundedSource;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.values.WindowedValues;
+
+/** Wraps a Beam {@link UnboundedSource} as a Gearpump {@link DataSource}. */
+public class UnboundedSourceWrapper<T> implements DataSource {
+
+  private final SerializablePipelineOptions serializedOptions;
+  private final UnboundedSource<T, ?> source;
+
+  private transient UnboundedSource.UnboundedReader<T> reader;
+  private transient boolean available;
+
+  public UnboundedSourceWrapper(UnboundedSource<T, ?> source, PipelineOptions options) {
+    this.source = source;
+    this.serializedOptions = new SerializablePipelineOptions(options);
+  }
+
+  @Override
+  public void open(TaskContext context, Instant startTime) {
+    try {
+      PipelineOptions options = serializedOptions.get();
+      UnboundedSource<T, ?> assigned = assignSource(source, options, context);
+      if (assigned != null) {
+        reader = assigned.createReader(options, null);
+        available = reader.start();
+      }
+    } catch (Exception e) {
+      close();
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public Message read() {
+    if (reader == null) {
+      return null;
+    }
+    try {
+      if (!available) {
+        available = reader.advance();
+        if (!available) {
+          return null;
+        }
+      }
+
+      T current = reader.getCurrent();
+      org.joda.time.Instant timestamp = reader.getCurrentTimestamp();
+      available = false;
+      return new DefaultMessage(
+          WindowedValues.timestampedValueInGlobalWindow(current, timestamp),
+          TranslatorUtils.jodaTimeToJava8Time(timestamp));
+    } catch (Exception e) {
+      close();
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public void close() {
+    try {
+      if (reader != null) {
+        reader.close();
+      }
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    } finally {
+      reader = null;
+      available = false;
+    }
+  }
+
+  @Override
+  public Instant getWatermark() {
+    if (reader == null) {
+      return Watermark.MAX();
+    }
+    return TranslatorUtils.jodaTimeToJava8Time(reader.getWatermark());
+  }
+
+  private UnboundedSource<T, ?> assignSource(
+      UnboundedSource<T, ?> source, PipelineOptions options, TaskContext context) throws Exception {
+    int parallelism = Math.max(1, context.parallelism());
+    List<? extends UnboundedSource<T, ?>> splits = source.split(parallelism, options);
+    if (splits == null || splits.isEmpty()) {
+      splits = Collections.singletonList(source);
+    }
+
+    int taskIndex = context.taskId().index();
+    for (int i = 0; i < splits.size(); i++) {
+      if (i % parallelism == taskIndex) {
+        return splits.get(i);
+      }
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

- Add `gearpump-examples-beam-quickstart`, an unpublished example project that packages a runnable Beam quick start with sbt-assembly.
- Add a Java Beam word-count pipeline for the Gearpump runner, including output waiting and an optional `--keepRunning=true` heartbeat mode for Web UI demos.
- Add basic `Read.Unbounded` translation support and use an unbounded Beam source for the keep-running heartbeat.
- Document local-cluster setup/submission commands and link the quick start from the Beam runner README.

## Validation

- `sbt "gearpump-examples-beam-quickstart / Compile / compile"`
- `sbt "gearpump-examples-beam-quickstart / assembly"`
- Submitted the quick start to the local Gearpump cluster and verified the bounded output counts.
- Submitted `--keepRunning=true` as `beamQuickStartUnbounded`; Gearpump REST reported app `1` as `active`, and the unbounded heartbeat output advanced through `keep-running=35`.
