### PR TITLE
Add Iceberg v3 source connector

### DIFF
--- a/docs/contents/dev/dev-connectors.md
+++ b/docs/contents/dev/dev-connectors.md
@@ -16,6 +16,7 @@ Currently, we have following `DataSource` supported.
 Name | Description
 -----| ----------
 `CollectionDataSource` | Convert a collection to a recursive data source. E.g. `seq(1, 2, 3)` will output `1,2,3,1,2,3...`.
+`IcebergSource` | Read a pinned snapshot of an Iceberg format-version 3 table as a bounded source.
 `KafkaSource` | Read from Kafka.
 
 ### `DataSink` implemented
@@ -146,7 +147,7 @@ Attention, due to the issue discussed [here](http://stackoverflow.com/questions/
 	}
 	val sink = HBaseSink(UserConfig.empty, tableName, hadoopConfig)
 
-### Use of the Iceberg v3 sink connector
+### Use of Iceberg v3 connectors
 
 Add the `gearpump-external-iceberg` dependency to the application:
 
@@ -167,6 +168,10 @@ Add the `gearpump-external-iceberg` dependency to the application:
 The connector uses Iceberg Java 1.11.0 and requires table format version 3. Tables can be addressed
 directly by Hadoop location or through any Iceberg catalog implementation available on the
 application classpath.
+
+The source pins the table's current snapshot when it is constructed, before Gearpump serializes it
+to parallel tasks, and divides that snapshot's planned scan tasks between those tasks. An explicit
+snapshot ID can be supplied when repeatable reads must target an older snapshot.
 
 The sink supports partition fanout, target-sized file rolling, record/estimated-byte/time commit
 thresholds, field-name or custom record mapping, table metadata refresh between batches, commit
@@ -190,6 +195,7 @@ not provide exactly-once delivery or row-level deduplication.
 	:::scala
 	import io.gearpump.external.iceberg._
 	import io.gearpump.streaming.sink.DataSinkProcessor
+	import io.gearpump.streaming.source.DataSourceProcessor
 	import org.apache.iceberg.Schema
 	import org.apache.iceberg.types.Types
 
@@ -200,6 +206,10 @@ not provide exactly-once delivery or row-level deduplication.
 	)
 
 	val table = IcebergTableConfig.forNewV3Table("/tmp/gearpump-iceberg", schema)
+	val source = new IcebergSource(
+	  IcebergTableConfig.forV3Table("/tmp/gearpump-iceberg"),
+	  timestampExtractor = IcebergTimestampExtractor.field("event_millis")
+	)
 	val sink = new IcebergSink(
 	  table,
 	  options = IcebergSinkOptions(
@@ -210,6 +220,8 @@ not provide exactly-once delivery or row-level deduplication.
 	  )
 	)
 
+	val sourceProcessor = DataSourceProcessor(source, parallelism = 2,
+	  description = "IcebergSource")
 	val sinkProcessor = DataSinkProcessor(sink, parallelism = 2,
 	  description = "IcebergSink")
 

--- a/docs/contents/introduction/features.md
+++ b/docs/contents/introduction/features.md
@@ -64,4 +64,4 @@ Gearpump has a built-in dashboard UI to manage the cluster and visualize the app
 
 #### Data connectors for Kafka, HDFS, and Iceberg
 
-Gearpump has built-in data connectors for Kafka, HDFS, and Iceberg. For the Kafka connector, we support message replay from a specified timestamp. The Iceberg connector supports batched, partition-aware appends to format-version 3 tables addressed by location or catalog.
+Gearpump has built-in data connectors for Kafka, HDFS, and Iceberg. For the Kafka connector, we support message replay from a specified timestamp. The Iceberg connector supports parallel bounded reads and batched, partition-aware appends to format-version 3 tables addressed by location or catalog.

--- a/gearpump-external-iceberg/src/main/java/org/apache/iceberg/data/GearpumpIcebergData.java
+++ b/gearpump-external-iceberg/src/main/java/org/apache/iceberg/data/GearpumpIcebergData.java
@@ -16,21 +16,33 @@ package org.apache.iceberg.data;
 
 import java.io.IOException;
 import java.util.UUID;
+import org.apache.iceberg.CombinedScanTask;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.PartitionKey;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableScan;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
+import org.apache.iceberg.io.CloseableGroup;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.io.DataWriter;
 import org.apache.iceberg.io.FanoutDataWriter;
 import org.apache.iceberg.io.FileWriterFactory;
 import org.apache.iceberg.io.OutputFileFactory;
 import org.apache.iceberg.io.TaskWriter;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 
 /** Bridges Gearpump to Iceberg's generic record readers and writers. */
 public final class GearpumpIcebergData {
   private GearpumpIcebergData() {}
+
+  public static CloseableIterable<Record> read(
+      TableScan scan, int taskIndex, int parallelism) {
+    return new TaskPartitionedScan(scan, taskIndex, parallelism);
+  }
 
   public static DataWriter<Record> newDataWriter(
       Table table, FileFormat format, EncryptedOutputFile outputFile) {
@@ -144,4 +156,60 @@ public final class GearpumpIcebergData {
     }
   }
 
+  /** Reads one deterministic partition of the file tasks planned by an Iceberg table scan. */
+  private static final class TaskPartitionedScan extends CloseableGroup
+      implements CloseableIterable<Record> {
+    private final GenericReader reader;
+    private final CloseableIterable<CombinedScanTask> plannedTasks;
+    private final Iterable<FileScanTask> assignedFiles;
+    private boolean iterated = false;
+
+    private TaskPartitionedScan(TableScan scan, int taskIndex, int parallelism) {
+      if (parallelism <= 0) {
+        throw new IllegalArgumentException("Parallelism must be greater than zero");
+      }
+
+      if (taskIndex < 0 || taskIndex >= parallelism) {
+        throw new IllegalArgumentException(
+            String.format("Task index %s must be between 0 and %s", taskIndex, parallelism - 1));
+      }
+
+      this.reader = new GenericReader(scan, false);
+      this.plannedTasks = scan.planTasks();
+      Iterable<FileScanTask> files =
+          Iterables.concat(Iterables.transform(plannedTasks, CombinedScanTask::files));
+      this.assignedFiles =
+          Iterables.filter(files, file -> assignedTask(file, parallelism) == taskIndex);
+    }
+
+    @Override
+    public synchronized CloseableIterator<Record> iterator() {
+      if (iterated) {
+        throw new IllegalStateException("TaskPartitionedScan may only be iterated once");
+      }
+
+      iterated = true;
+      Iterable<CloseableIterable<Record>> readers =
+          Iterables.transform(assignedFiles, reader::open);
+      CloseableIterator<Record> iterator = CloseableIterable.concat(readers).iterator();
+      addCloseable(iterator);
+      return iterator;
+    }
+
+    private static int assignedTask(FileScanTask file, int parallelism) {
+      int hash = file.file().location().hashCode();
+      hash = 31 * hash + Long.hashCode(file.start());
+      hash = 31 * hash + Long.hashCode(file.length());
+      return Math.floorMod(hash, parallelism);
+    }
+
+    @Override
+    public void close() throws IOException {
+      try {
+        plannedTasks.close();
+      } finally {
+        super.close();
+      }
+    }
+  }
 }

--- a/gearpump-external-iceberg/src/main/scala/io/gearpump/external/iceberg/IcebergSource.scala
+++ b/gearpump-external-iceberg/src/main/scala/io/gearpump/external/iceberg/IcebergSource.scala
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gearpump.external.iceberg
+
+import io.gearpump.{DefaultMessage, Message}
+import io.gearpump.streaming.source.{DataSource, Watermark}
+import io.gearpump.streaming.task.TaskContext
+import java.time.Instant
+import org.apache.iceberg.Schema
+import org.apache.iceberg.data.{GearpumpIcebergData, Record}
+import org.apache.iceberg.io.CloseableIterable
+
+/**
+ * Bounded source that divides the current snapshot of an Iceberg v3 table across Gearpump source
+ * tasks.
+ *
+ * The watermark remains at `Watermark.MIN` while scanning because an Iceberg snapshot does not
+ * guarantee timestamp ordering. It advances to `Watermark.MAX` once this task's scan partition
+ * is exhausted.
+ */
+class IcebergSource(
+    tableConfig: IcebergTableConfig,
+    projection: Option[Schema] = None,
+    timestampExtractor: IcebergTimestampExtractor = IcebergTimestampExtractor.epoch,
+    snapshotId: Option[Long] = None)
+  extends DataSource {
+
+  private val pinnedSnapshotId = snapshotId.orElse {
+    Option(tableConfig.loadTable().currentSnapshot()).map(_.snapshotId())
+  }
+
+  private var records: CloseableIterable[Record] = _
+  private var iterator: java.util.Iterator[Record] = _
+  private var finished = false
+
+  override def open(context: TaskContext, startTime: Instant): Unit = {
+    val table = tableConfig.loadTable()
+    records = pinnedSnapshotId match {
+      case Some(id) =>
+        val scan = projection match {
+          case Some(schema) => table.newScan().useSnapshot(id).project(schema)
+          case None => table.newScan().useSnapshot(id)
+        }
+        GearpumpIcebergData.read(scan, context.taskId.index, context.parallelism)
+      case None => CloseableIterable.empty()
+    }
+    iterator = records.iterator()
+    finished = false
+  }
+
+  override def read(): Message = {
+    if (iterator != null && iterator.hasNext) {
+      val record = iterator.next()
+      new DefaultMessage(record, timestampExtractor.timestamp(record))
+    } else {
+      finished = true
+      null
+    }
+  }
+
+  override def close(): Unit = {
+    if (records != null) {
+      records.close()
+      records = null
+    }
+    iterator = null
+    finished = true
+  }
+
+  override def getWatermark: Instant = {
+    if (finished) Watermark.MAX else Watermark.MIN
+  }
+}

--- a/gearpump-external-iceberg/src/main/scala/io/gearpump/external/iceberg/IcebergTimestampExtractor.scala
+++ b/gearpump-external-iceberg/src/main/scala/io/gearpump/external/iceberg/IcebergTimestampExtractor.scala
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gearpump.external.iceberg
+
+import java.sql.Timestamp
+import java.time.{Instant, LocalDateTime, OffsetDateTime, ZoneOffset}
+import org.apache.iceberg.data.Record
+
+trait IcebergTimestampExtractor extends Serializable {
+  def timestamp(record: Record): Instant
+}
+
+object IcebergTimestampExtractor {
+
+  val epoch: IcebergTimestampExtractor = constant(Instant.EPOCH)
+
+  def constant(timestamp: Instant): IcebergTimestampExtractor = {
+    ConstantIcebergTimestampExtractor(timestamp)
+  }
+
+  def field(fieldName: String): IcebergTimestampExtractor = {
+    FieldIcebergTimestampExtractor(fieldName)
+  }
+
+  private final case class ConstantIcebergTimestampExtractor(timestampValue: Instant)
+    extends IcebergTimestampExtractor {
+
+    override def timestamp(record: Record): Instant = timestampValue
+  }
+
+  private final case class FieldIcebergTimestampExtractor(fieldName: String)
+    extends IcebergTimestampExtractor {
+
+    override def timestamp(record: Record): Instant = {
+      record.getField(fieldName) match {
+        case instant: Instant =>
+          instant
+        case offsetDateTime: OffsetDateTime =>
+          offsetDateTime.toInstant
+        case localDateTime: LocalDateTime =>
+          localDateTime.toInstant(ZoneOffset.UTC)
+        case timestamp: Timestamp =>
+          timestamp.toInstant
+        case millis: java.lang.Long =>
+          Instant.ofEpochMilli(millis.longValue())
+        case value =>
+          throw new IllegalArgumentException(
+            s"Unsupported Iceberg timestamp value for field '$fieldName': $value")
+      }
+    }
+  }
+}

--- a/gearpump-external-iceberg/src/test/scala/io/gearpump/external/iceberg/IcebergSourceSpec.scala
+++ b/gearpump-external-iceberg/src/test/scala/io/gearpump/external/iceberg/IcebergSourceSpec.scala
@@ -1,0 +1,116 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gearpump.external.iceberg
+
+import io.gearpump.Message
+import io.gearpump.streaming.source.Watermark
+import java.time.Instant
+import org.apache.iceberg.{Schema, TableProperties}
+import org.apache.iceberg.data.{GenericRecord, Record}
+import org.apache.iceberg.types.Types
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
+
+class IcebergSourceSpec extends AnyPropSpec with Matchers {
+
+  private val schema = new Schema(
+    Types.NestedField.required(1, "id", Types.LongType.get()),
+    Types.NestedField.required(2, "data", Types.StringType.get()),
+    Types.NestedField.required(3, "event_millis", Types.LongType.get()))
+
+  property("IcebergSource should scan a v3 snapshot as a bounded source") {
+    IcebergTestSupport.withTempDirectory("gearpump-iceberg-v3-source") { tableDirectory =>
+      val createConfig = IcebergTableConfig.forNewV3Table(tableDirectory.toString, schema)
+      appendRecord(createConfig, newRecord(1L, "alpha", 1000L))
+      appendRecord(createConfig, newRecord(2L, "beta", 2500L))
+
+      val source = new IcebergSource(
+        IcebergTableConfig.forV3Table(tableDirectory.toString),
+        timestampExtractor = IcebergTimestampExtractor.field("event_millis"))
+
+      source.open(IcebergTestSupport.mockTaskContext(), Instant.EPOCH)
+      source.getWatermark shouldBe Watermark.MIN
+
+      val actual = drain(source)
+      val actualById = actual.map { message =>
+        val record = message.value.asInstanceOf[Record]
+        record.getField("id").asInstanceOf[Long] ->
+          (record.getField("data").toString, message.timestamp)
+      }.toMap
+      actualById shouldBe Map(
+        1L -> ("alpha", Instant.ofEpochMilli(1000L)),
+        2L -> ("beta", Instant.ofEpochMilli(2500L)))
+      source.getWatermark shouldBe Watermark.MAX
+      source.close()
+    }
+  }
+
+  property("parallel IcebergSource tasks should pin and divide one snapshot") {
+    IcebergTestSupport.withTempDirectory("gearpump-iceberg-v3-parallel-source") {
+      tableDirectory =>
+        val createConfig = IcebergTableConfig.forNewV3Table(
+          tableDirectory.toString,
+          schema,
+          tableProperties = Map(
+            TableProperties.SPLIT_SIZE -> "1",
+            TableProperties.SPLIT_LOOKBACK -> "1",
+            TableProperties.SPLIT_OPEN_FILE_COST -> "0"))
+        (0L until 6L).foreach { id =>
+          appendRecord(createConfig, newRecord(id, s"value-$id", id * 1000L))
+        }
+
+        val tableConfig = IcebergTableConfig.forV3Table(tableDirectory.toString)
+        val sources = (0 until 2).map(_ => new IcebergSource(tableConfig))
+        appendRecord(tableConfig, newRecord(6L, "appended-after-source-construction", 6000L))
+
+        val recordsByTask = sources.zipWithIndex.map { case (source, taskIndex) =>
+          source.open(IcebergTestSupport.mockTaskContext(taskIndex, 2), Instant.EPOCH)
+          try {
+            drain(source).map(_.value.asInstanceOf[Record].getField("id").asInstanceOf[Long])
+          } finally {
+            source.close()
+          }
+        }
+
+        recordsByTask.flatten.sorted shouldBe (0L until 6L)
+        recordsByTask(0).intersect(recordsByTask(1)) shouldBe empty
+    }
+  }
+
+  private def appendRecord(tableConfig: IcebergTableConfig, record: Record): Unit = {
+    val sink = new IcebergSink(tableConfig)
+    sink.open(IcebergTestSupport.mockTaskContext())
+    sink.write(Message(record))
+    sink.close()
+  }
+
+  private def drain(source: IcebergSource): Seq[Message] = {
+    val builder = Seq.newBuilder[Message]
+    var message = source.read()
+    while (message != null) {
+      builder += message
+      message = source.read()
+    }
+    builder.result()
+  }
+
+  private def newRecord(id: Long, data: String, eventMillis: Long): Record = {
+    val record = GenericRecord.create(schema)
+    record.setField("id", id)
+    record.setField("data", data)
+    record.setField("event_millis", eventMillis)
+    record
+  }
+}


### PR DESCRIPTION
### Description

Add a bounded Apache Iceberg source connector for Gearpump format-version 3 tables.

This is stacked on the sink and shared table configuration in #2375. The source:

- pins the current snapshot when the source is constructed, before Gearpump serializes it to tasks
- optionally accepts an explicit snapshot ID for repeatable reads of an older snapshot
- deterministically divides planned file tasks across parallel Gearpump source tasks
- emits `Watermark.MIN` while scanning and `Watermark.MAX` after the bounded snapshot is exhausted
- supports constant, field-based, or custom timestamp extraction

Pinning happens once for the processor so an append while parallel tasks are starting cannot make
different tasks plan different file sets.

### Validation

- `sbt 'project gearpump-external-iceberg' 'testOnly io.gearpump.external.iceberg.IcebergSourceSpec'`
  - 2 source tests passed
- `sbt 'project gearpump-external-iceberg' 'scalastyle' 'Test/scalastyle' 'Compile/doc' 'package'`
- `git diff --check codex/iceberg-v3-connector...HEAD`

### Stack

- Base PR: #2375

### Checklist

 - [x] Make sure the commit message is meaningful.
 - [ ] Make sure tests pass via `sbt clean test` (focused source tests pass).
 - [x] Make sure documentation is up-to-date.
